### PR TITLE
Configure project to publish to Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,12 @@ import sbt.Keys._
 import sbt.{addCompilerPlugin, _}
 
 
+ThisBuild / organization := "com.gu"
+ThisBuild / licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/guardian/guardian-janus"), "scm:git@github.com:guardian/guardian-janus"))
+ThisBuild / homepage := scmInfo.value.map(_.browseUrl)
+ThisBuild / developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
+
 val awsSdkVersion = "1.11.663"
 val awscalaVersion = "0.8.1"
 val circeVersion = "0.12.3"
@@ -91,5 +97,8 @@ lazy val configTools = (project in file("configTools"))
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-config" % "0.7.0"
-    )
+    ),
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
+    publishTo := sonatypePublishTo.value,
+    releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,8 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
+
+// These are for releasing to Sonatype
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "0.0.1-SNAPSHOT"


### PR DESCRIPTION
This has been tested by using `publishLocal` to create an artifact.

Due to running into a `java.lang.RuntimeException` when attempting to compile the project, this PR is also giving a minor bump to the Scala version, moving from `2.12.8` to `2.12.11`.

⛈🌈