### PR TITLE
Remove some whitespace to improve templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,6 @@ assignees: ''
 ---
 
 ## Summary of issue
-
 <!-- add a concise description of what the bug is -->
 
 
@@ -17,18 +16,15 @@ assignees: ''
 
 
 ## Actual Results
-
 <!-- Remember to redact any secret or private information! -->
 <!-- Screenshots will help explain your problem -->
 
 
 ## Expected Results
-
 <!-- Remember to redact any secret or private information! -->
 <!-- Screenshots will help explain your problem -->
 
 
 ## Additional context
-
 <!-- Please add any other context about the problem here -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,25 +8,20 @@ assignees: ''
 ---
 
 <!--
-
 Please note that it may not be possible for us to incorporate all feature requests. 
 Janus has been developed to meet the security and workflow requirements of Guardian Digital, 
 therefore we may be hesitant to significantly expand or alter the remit of this application.
-
 -->
 
 ## What problem would this feature solve?
-
 <!-- Please describe the problem this feature would solve and the requirements you have -->
 
 
 ## Alternative options or solutions
-
 <!-- Please describe any alternatives you have considered -->
 
 
 ## Additional context
-
 <!--
 Please add any other context or screenshots about the feature request here. This could include
  the source of the inspiration for the feature (such as a different service) or examples of how

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,6 @@
 <!-- 
-
 Hello and thank you for contributing! 
-
 Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-
 -->
 
 ## What is the purpose of this change?


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Removing whitespace that does not contribute to visual clarity of the templates.

This should reduce pointless scrolling when creating PRs and opening issues.

## What is the value of this change and how do we measure success?

More of the headings can fit into the default text editor window on GitHub.

PR and issue templates are still clear with visually distinct sections and guidance.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

#### 👇 👇  BEFORE 👇 👇 

<img width="600" alt="Screenshot 2020-07-24 at 19 17 16" src="https://user-images.githubusercontent.com/8607683/88422566-5cb6ac80-cde2-11ea-919d-889455270507.png">

#### 👇 👇  AFTER 👇 👇 

<img width="600" alt="Screenshot 2020-07-24 at 19 18 17" src="https://user-images.githubusercontent.com/8607683/88422720-9687b300-cde2-11ea-8d36-a151798e6e81.png">

