### PR TITLE
Update versions of Scala and library dependencies

### DIFF
--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -10,6 +10,7 @@ import models._
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 
@@ -49,12 +50,16 @@ object Config {
     val clientSecret = requiredString(config, "auth.google.clientSecret")
     val domain = requiredString(config, "auth.domain")
     val redirectUrl = s"${requiredString(config, "host")}/oauthCallback"
+
+    @nowarn
+    val legacyAntiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+
     GoogleAuthConfig(
       clientId = clientId,
       clientSecret = clientSecret,
       redirectUrl = redirectUrl,
-      domain = domain,
-      antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+      domains = List(domain),
+      antiForgeryChecker = legacyAntiForgeryChecker,
     )
   }
 
@@ -62,6 +67,7 @@ object Config {
     val twoFAUser = requiredString(config, "auth.google.2faUser")
     val serviceAccountCertPath = requiredString(config, "auth.google.serviceAccountCertPath")
 
+    @nowarn
     val credentials: GoogleCredential = {
       val jsonCertStream =
         Try(new FileInputStream(serviceAccountCertPath))

--- a/app/logic/AuditTrail.scala
+++ b/app/logic/AuditTrail.scala
@@ -63,27 +63,27 @@ object AuditTrail extends Logging {
   def auditLogFromAttrs(attrs: Seq[Attribute]): Either[(String, Seq[Attribute]), AuditLog] = {
     for {
       account <- attrs.find("j_account" == _.name).flatMap(_.value.s)
-        .toRight("Could not extract account" -> attrs).right
+        .toRight("Could not extract account" -> attrs)
       username <- attrs.find("j_username" == _.name).flatMap(_.value.s)
-        .toRight("Could not extract username" -> attrs).right
+        .toRight("Could not extract username" -> attrs)
       dateTime <- attrs.find("j_timestamp" == _.name).flatMap(_.value.n)
         .map(ts => new DateTime(ts.toLong, DateTimeZone.UTC))
-        .toRight("Could not extract dateTime" -> attrs).right
+        .toRight("Could not extract dateTime" -> attrs)
       duration <- attrs.find("j_duration" == _.name).flatMap(_.value.n)
         .map(d => new Duration(d.toLong * 1000))
-        .toRight("Could not extract duration" -> attrs).right
+        .toRight("Could not extract duration" -> attrs)
       accessLevel <- attrs.find("j_accessLevel" == _.name).flatMap(_.value.s)
-        .toRight("Could not extract accessLevel" -> attrs).right
+        .toRight("Could not extract accessLevel" -> attrs)
       accessType <- attrs.find("j_accessType" == _.name).flatMap(_.value.s)
         .flatMap(JanusAccessType.fromString)
-        .toRight("Could not extract accessType" -> attrs).right
+        .toRight("Could not extract accessType" -> attrs)
       external <- attrs.find("j_external" == _.name).flatMap(attr => attr.value.n)
         .flatMap {
           case "0" => Some(false)
           case "1" => Some(true)
           case _ => None
         }
-        .toRight("Could not extract external" -> attrs).right
+        .toRight("Could not extract external" -> attrs)
     } yield AuditLog(account, username, dateTime, duration, accessLevel, accessType, external)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -13,21 +13,22 @@ ThisBuild / scmInfo := Some(ScmInfo(url("https://github.com/guardian/janus-app")
 ThisBuild / homepage := scmInfo.value.map(_.browseUrl)
 ThisBuild / developers := List(Developer(id = "guardian", name = "Guardian", email = null, url = url("https://github.com/guardian")))
 
-val awsSdkVersion = "1.11.663"
-val awscalaVersion = "0.8.1"
-val circeVersion = "0.12.3"
+val awsSdkVersion = "1.11.848"
+val awscalaVersion = "0.8.4"
+val circeVersion = "0.13.0"
 val commonDependencies = Seq(
   "org.typelevel" %% "cats-core" % "2.0.0",
-  "joda-time" % "joda-time" % "2.10.5",
+  "joda-time" % "joda-time" % "2.10.6",
   "org.joda" % "joda-convert" % "2.2.1",
   "com.github.seratch" %% "awscala-iam" % awscalaVersion,
   "com.github.seratch" %% "awscala-sts" % awscalaVersion,
   "com.github.seratch" %% "awscala-dynamodb" % awscalaVersion,
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
+  "org.scalatest" %% "scalatest" % "3.2.2" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
+  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test,
 )
 lazy val commonSettings = Seq(
-  scalaVersion := "2.12.11",
+  scalaVersion := "2.13.3",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings"),
   testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports"))
 )
@@ -57,7 +58,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,
       filters,
-      "com.gu" %% "play-googleauth" % "0.7.4",
+      "com.gu.play-googleauth" %% "play-v27" % "1.0.7",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
@@ -89,14 +90,14 @@ lazy val root = (project in file("."))
 lazy val configTools = (project in file("configTools"))
   .enablePlugins(SbtTwirl)
   .settings(
-    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.8"),
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
     commonSettings,
     libraryDependencies ++= commonDependencies ++ Seq(
       "com.typesafe" % "config" % "1.4.0",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "io.circe" %% "circe-config" % "0.7.0"
+      "io.circe" %% "circe-config" % "0.8.0"
     ),
     name := "janus-config-tools",
     description := "Library for reading and writing Janus configuration files",

--- a/configTools/src/test/scala/com/gu/janus/JanusConfigTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/JanusConfigTest.scala
@@ -1,10 +1,11 @@
 package com.gu.janus
 
 import com.gu.janus.JanusConfig.JanusConfigurationException
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class JanusConfigTest extends FreeSpec with Matchers {
+class JanusConfigTest extends AnyFreeSpec with Matchers {
   "Can load a config file" in {
     noException should be thrownBy {
       JanusConfig.load("example.conf")

--- a/configTools/src/test/scala/com/gu/janus/ValidationTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/ValidationTest.scala
@@ -3,10 +3,11 @@ package com.gu.janus
 import com.gu.janus.Validation.{isClean, noErrors}
 import com.gu.janus.model._
 import org.joda.time.{DateTime, Period}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class ValidationTest extends FreeSpec with Matchers {
+class ValidationTest extends AnyFreeSpec with Matchers {
   val account1 = AwsAccount("Test 1", "test1")
   val account2 = AwsAccount("Test 2", "test2")
   val emptyAcl = ACL(Map.empty, Set.empty)

--- a/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
@@ -1,18 +1,20 @@
 package com.gu.janus.config
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import java.io.{File, PrintWriter}
 
 import com.gu.janus.JanusConfig
+import com.gu.janus.testutils.RightValues
 
 
-class ConfigIntegrationTests extends FreeSpec with Matchers with EitherValues {
+class ConfigIntegrationTests extends AnyFreeSpec with Matchers with RightValues {
   "round trips" - {
     "the example janus data can be read, written and re-read" in {
       val testConfig = ConfigFactory.load("example.conf")
       val result = Loader.fromConfig(testConfig)
-      val janusData = result.right.value
+      val janusData = result.value
       val content = Writer.toConfig(janusData)
       val file = File.createTempFile("janus-config-integration-round-trip-test", ".conf")
       file.deleteOnExit()
@@ -37,7 +39,7 @@ class ConfigIntegrationTests extends FreeSpec with Matchers with EitherValues {
     "the example janus data that omits a permissions repo can be read, written and re-read" in {
       val testConfig = ConfigFactory.load("example-without-permissions-repo.conf")
       val result = Loader.fromConfig(testConfig)
-      val janusData = result.right.value
+      val janusData = result.value
       val content = Writer.toConfig(janusData)
       val file = File.createTempFile("janus-config-integration-round-trip-test-no-perm-repo", ".conf")
       file.deleteOnExit()
@@ -64,7 +66,7 @@ class ConfigIntegrationTests extends FreeSpec with Matchers with EitherValues {
     "print the generated config file to the console for manual inspection" ignore {
       val testConfig = ConfigFactory.load("example.conf")
       val result = Loader.fromConfig(testConfig)
-      val janusData = result.right.value
+      val janusData = result.value
       println(Writer.toConfig(janusData))
     }
   }

--- a/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
@@ -2,10 +2,11 @@ package com.gu.janus.config
 
 import com.gu.janus.model._
 import org.joda.time.Period
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class WriterTest extends FreeSpec with Matchers {
+class WriterTest extends AnyFreeSpec with Matchers {
   val account1 = AwsAccount("Test 1", "test1")
   val account2 = AwsAccount("Test 2", "test2")
 

--- a/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
@@ -1,10 +1,11 @@
 package com.gu.janus.policy
 
 import Statements._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class StatementsTest extends FreeSpec with Matchers {
+class StatementsTest extends AnyFreeSpec with Matchers {
   "policy helper" - {
     val statements = Seq(
       s3FullAccess("my-bucket", "/"),

--- a/configTools/src/test/scala/com/gu/janus/testutils/HaveMatchers.scala
+++ b/configTools/src/test/scala/com/gu/janus/testutils/HaveMatchers.scala
@@ -1,0 +1,18 @@
+package com.gu.janus.testutils
+
+import org.scalatest.matchers.HavePropertyMatcher
+import org.scalatest.matchers.should.Matchers
+
+
+trait HaveMatchers extends Matchers {
+  def having[A](propertyName: String, propertyValue: A): HavePropertyMatcher[AnyRef, Any] = {
+    Symbol(propertyName) (propertyValue)
+  }
+
+  implicit class HavingTestHelperString(propertyName: String) {
+    def as[A](propertyValue: A): HavePropertyMatcher[AnyRef, Any] = {
+      Symbol(propertyName) (propertyValue)
+    }
+  }
+}
+object HaveMatchers extends HaveMatchers

--- a/configTools/src/test/scala/com/gu/janus/testutils/RightValues.scala
+++ b/configTools/src/test/scala/com/gu/janus/testutils/RightValues.scala
@@ -1,0 +1,24 @@
+package com.gu.janus.testutils
+
+import org.scalactic.source.Position
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+
+trait RightValues {
+  implicit class RichEither[L, R](e: Either[L, R]) {
+    def value(implicit pos: Position): R = {
+      e.fold(
+        { l =>
+          throw new TestFailedException(
+            (_: StackDepthException) => Some {
+              s"The Either on which value was invoked was not a Right, got Left($l)"
+            },
+            None,
+            pos
+          )
+        },
+        identity
+      )
+    }
+  }
+}
+object RightValues extends RightValues

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
@@ -15,3 +15,5 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,5 +15,3 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -3,10 +3,11 @@ package aws
 import awscala.dynamodbv2._
 import com.gu.janus.model.{AuditLog, JConsole}
 import org.joda.time.{DateTime, DateTimeZone, Duration}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class AuditTrailDBTest extends FreeSpec with Matchers {
+class AuditTrailDBTest extends AnyFreeSpec with Matchers {
 
   "test db stuff - use this to test DynamoDB stuff locally during development" - {
     implicit val dynamoDB = DynamoDB.local()

--- a/test/aws/FederationTest.scala
+++ b/test/aws/FederationTest.scala
@@ -3,11 +3,12 @@ package aws
 import awscala.Policy
 import com.gu.janus.model.{AwsAccount, Permission}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import testutils.JodaTimeUtils
 
 
-class FederationTest extends FreeSpec with Matchers with JodaTimeUtils {
+class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
   import Federation._
 
   "duration" - {

--- a/test/conf/ConfigTest.scala
+++ b/test/conf/ConfigTest.scala
@@ -5,13 +5,13 @@ import com.typesafe.config.{ConfigException, ConfigFactory}
 import fixtures.Fixtures._
 import models.{ConfigError, ConfigSuccess, ConfigWarn, FederationConfigError}
 import org.joda.time.Period
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 
-class ConfigTest extends FreeSpec with Matchers {
 
+class ConfigTest extends AnyFreeSpec with Matchers {
   "validateAccountConfig" - {
-
     val testJanusData = JanusData(
       accounts = Set.empty,
       ACL(Map.empty),

--- a/test/instances/ACLMergeTest.scala
+++ b/test/instances/ACLMergeTest.scala
@@ -3,10 +3,11 @@ package instances
 import cats.syntax.semigroup._
 import cats.instances.set._
 import cats.instances.map._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class ACLMergeTest extends FreeSpec with Matchers {
+class ACLMergeTest extends AnyFreeSpec with Matchers {
   "Monoid instance for ACL entries" - {
     "should correctly combine overlapping entries" in {
       val a = Map(

--- a/test/logic/AccountOrderingTest.scala
+++ b/test/logic/AccountOrderingTest.scala
@@ -1,12 +1,14 @@
 package logic
 
 import fixtures.Fixtures._
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random.shuffle
 
 
-class AccountOrderingTest extends FreeSpec with Matchers with OptionValues {
+class AccountOrderingTest extends AnyFreeSpec with Matchers with OptionValues {
   import AccountOrdering._
 
   "userAccountAccess" - {

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -3,11 +3,14 @@ package logic
 
 import awscala.dynamodbv2.{Attribute, AttributeValue}
 import com.gu.janus.model.{AuditLog, JConsole, JCredentials}
+import com.gu.janus.testutils.{HaveMatchers, RightValues}
 import org.joda.time.{DateTime, DateTimeZone, Duration}
-import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{EitherValues, OptionValues}
 
 
-class AuditTrailTest extends FreeSpec with Matchers with EitherValues with OptionValues {
+class AuditTrailTest extends AnyFreeSpec with Matchers with RightValues with EitherValues with OptionValues with HaveMatchers {
   "auditLogAttrs" - {
     val al = AuditLog("account", "username", new DateTime(2015, 11, 4, 15, 22), new Duration(3600 * 1000), "accessLevel", JCredentials, external = true)
 
@@ -63,19 +66,19 @@ class AuditTrailTest extends FreeSpec with Matchers with EitherValues with Optio
       )
 
       "extracts an audit log from valid attritbutes" in {
-        AuditTrail.auditLogFromAttrs(attrs).right.value should have(
-          'account ("account"),
-          'username ("username"),
-          'dateTime (new DateTime(2015, 11, 4, 15, 22, DateTimeZone.UTC)),
-          'duration (new Duration(3600000)),
-          'accessLevel ("dev"),
-          'accessType (JConsole),
-          'external (true)
+        AuditTrail.auditLogFromAttrs(attrs).value should have(
+          "account" as "account",
+          "username" as "username",
+          "dateTime" as new DateTime(2015, 11, 4, 15, 22, DateTimeZone.UTC),
+          "duration" as new Duration(3600000),
+          "accessLevel" as "dev",
+          "accessType" as JConsole,
+          "external" as true
         )
       }
 
       "extracts a correct (ms) duration from the DB's seconds field" in {
-        AuditTrail.auditLogFromAttrs(attrs).right.value.duration shouldEqual new Duration(3600 * 1000)
+        AuditTrail.auditLogFromAttrs(attrs).value.duration shouldEqual new Duration(3600 * 1000)
       }
     }
 

--- a/test/logic/CustomisationTest.scala
+++ b/test/logic/CustomisationTest.scala
@@ -1,11 +1,13 @@
 package logic
 
 import org.joda.time.{DateTimeZone, Duration}
-import org.scalatest.{OptionValues, Matchers, FreeSpec}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.test.FakeRequest
 
 
-class CustomisationTest extends FreeSpec with Matchers with OptionValues {
+class CustomisationTest extends AnyFreeSpec with Matchers with OptionValues {
   import Customisation._
 
   "durationParams" - {

--- a/test/logic/DateTest.scala
+++ b/test/logic/DateTest.scala
@@ -1,10 +1,12 @@
 package logic
 
 import org.joda.time._
-import org.scalatest.{OptionValues, Matchers, FreeSpec}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class DateTest extends FreeSpec with Matchers with OptionValues {
+class DateTest extends AnyFreeSpec with Matchers with OptionValues {
   "formatPeriod" - {
     "prints a nice message for a complex period" in {
       Date.formatPeriod(new Period(8, 10, 14, 0)) shouldEqual "8 hours, 10 minutes, 14 seconds"
@@ -75,12 +77,12 @@ class DateTest extends FreeSpec with Matchers with OptionValues {
 
       "excludes previous week" in {
         val (before, _) = Date.prevNextAuditWeeks(date)
-        before should be ('empty)
+        before shouldBe empty
       }
 
       "still includes the next week" in {
         val (_, after) = Date.prevNextAuditWeeks(date)
-        after should be ('defined)
+        after should not be empty
       }
     }
 
@@ -88,12 +90,12 @@ class DateTest extends FreeSpec with Matchers with OptionValues {
       val date = DateTime.now(DateTimeZone.UTC)
       "excludes the next week" in {
         val (_, after) = Date.prevNextAuditWeeks(date)
-        after should be ('empty)
+        after shouldBe empty
       }
 
       "still includes previous week" in {
         val (before, _) = Date.prevNextAuditWeeks(date)
-        before should be ('defined)
+        before should not be empty
       }
     }
   }

--- a/test/logic/FavouritesTest.scala
+++ b/test/logic/FavouritesTest.scala
@@ -2,11 +2,12 @@ package logic
 
 import java.util.Base64
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.mvc.Cookie
 
 
-class FavouritesTest extends FreeSpec with Matchers {
+class FavouritesTest extends AnyFreeSpec with Matchers {
   import Favourites._
 
   "fromCookie" - {

--- a/test/logic/OwnersTest.scala
+++ b/test/logic/OwnersTest.scala
@@ -2,10 +2,11 @@ package logic
 
 import com.gu.janus.model.{ACL, AccountOwners}
 import fixtures.Fixtures._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class OwnersTest extends FreeSpec with Matchers {
+class OwnersTest extends AnyFreeSpec with Matchers {
   import Owners._
 
   val acl = ACL(Map(

--- a/test/logic/PlayHelpersTest.scala
+++ b/test/logic/PlayHelpersTest.scala
@@ -1,9 +1,10 @@
 package logic
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class PlayHelpersTest extends FreeSpec with Matchers {
+class PlayHelpersTest extends AnyFreeSpec with Matchers {
   import PlayHelpers._
 
   "splitQuerystringParam" - {

--- a/test/logic/RevocationTest.scala
+++ b/test/logic/RevocationTest.scala
@@ -1,12 +1,13 @@
 package logic
 
 import com.gu.janus.model.AwsAccount
-import org.scalacheck.Prop.{BooleanOperators, forAll}
-import org.scalatest.prop.Checkers
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalacheck.Prop.{propBoolean, forAll}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
 
 
-class RevocationTest extends FreeSpec with Matchers with Checkers {
+class RevocationTest extends AnyFreeSpec with Matchers with Checkers {
   import Revocation._
 
   "checkConfirmation" - {

--- a/test/logic/UserAccessTest.scala
+++ b/test/logic/UserAccessTest.scala
@@ -5,11 +5,13 @@ import com.gu.googleauth.UserIdentity
 import fixtures.Fixtures._
 import com.gu.janus.model.{ACL, SupportACL}
 import org.joda.time.{DateTimeZone, Period}
-import org.scalatest.{FreeSpec, Inspectors, Matchers, OptionValues}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Inspectors, OptionValues}
 import testutils.JodaTimeUtils
 
 
-class UserAccessTest extends FreeSpec with Matchers with OptionValues with Inspectors with JodaTimeUtils {
+class UserAccessTest extends AnyFreeSpec with Matchers with OptionValues with Inspectors with JodaTimeUtils {
   import UserAccess._
 
   "userAccess" - {
@@ -20,7 +22,8 @@ class UserAccessTest extends FreeSpec with Matchers with OptionValues with Inspe
     }
 
     "returns the user's permissions if they exist" in {
-      userAccess("test.user", testAccess).value should contain allOf (fooDev, barDev)
+      val permissions = userAccess("test.user", testAccess).value
+      permissions should (contain (fooDev) and contain (barDev))
     }
 
     "include default permissions in all users' available permissions" in {

--- a/test/logic/ViewHelpersTest.scala
+++ b/test/logic/ViewHelpersTest.scala
@@ -3,11 +3,12 @@ package logic
 import fixtures.Fixtures._
 import awscala.sts.TemporaryCredentials
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
 import ViewHelpers.shellCredentials
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class ViewHelpersTest extends FreeSpec with Matchers {
+class ViewHelpersTest extends AnyFreeSpec with Matchers {
 
   "shellCredentials" - {
     "for a single account" - {


### PR DESCRIPTION
## What is the purpose of this change?

Update library dependencies, particularly the Play Googleauth dependency so that we take advantage of [an important security fix from the Google Auth library](https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276).

## What is the value of this change and how do we measure success?

Up-to date software without security problems, with the application still working as expected.

## Any additional notes?

A separate PR will follow to update the way Play-Googleauth is used, for now the deprecated constructors are still being called. To prevent this causing compile errors, the PR also bumps the project to Scala 2.13.x so we get the `@nowarn` annotation. This change meant quite a few dependencies needed updating and it spiralled from there.

Of note, is that `scalatest` moved a few things around with v3.2 so the test changes are quite verbose. For the most part it is just renaming, but we've also had to introduce a few helpers to patch things that aren't working in scalatest on Scala 2.13. The `RightValues` and `HaveMatchers` utilities patch old behaviour back into the test suite to keep the test changes small.

## Deployment

I have tested this locally, and it looks to be fine. I'll deploy this to a real AWS environment as well to check it works fine in a production setting prior to merging. Let's do a code review first though!
