### PR TITLE
Move statements into configTools

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
@@ -1,4 +1,5 @@
-package com.example
+package com.gu.janus.policy
+
 
 import awscala._
 import com.amazonaws.auth.policy.Statement.Effect
@@ -10,14 +11,14 @@ object Statements {
     Policy(statements.flatten.distinct)
   }
 
-  def enforceCorrectPath(path: String): Boolean = {
+  private[policy] def enforceCorrectPath(path: String): Boolean = {
     if (path == "/") true
     else {
       path.headOption.contains('/') && !path.lastOption.contains('/')
     }
   }
 
-  def hierarchyPath(path: String) = s"${path.stripSuffix("/")}/*"
+  private[policy] def hierarchyPath(path: String) = s"${path.stripSuffix("/")}/*"
 
   /**
     * Grants read-only access to a given path in an s3 bucket.
@@ -61,6 +62,25 @@ object Statements {
     * Typically bundled as part of other S3 permissions.
     */
   def s3ConsoleEssentials(bucketName: String): Seq[Statement] = {
+    Seq(
+      Statement(Effect.Allow,
+        Seq(
+          Action("s3:ListAllMyBuckets"),
+          Action("s3:GetBucketLocation")
+        ),
+        Seq(Resource("arn:aws:s3:::*"))
+      ),
+      Statement(Effect.Allow,
+        Seq(Action("s3:ListBucket")),
+        Seq(Resource(s"arn:aws:s3:::$bucketName"))
+      )
+    )
+  }
+
+  /**
+    * Policy statements that allow basic access to s3 bucket (console view and object list)
+    */
+  def s3BucketBasicAccessStatements(bucketName: String): Seq[Statement] = {
     Seq(
       Statement(Effect.Allow,
         Seq(

--- a/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
@@ -1,24 +1,21 @@
-package com.example
+package com.gu.janus.policy
 
-import com.example.Statements._
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import Statements._
+import org.scalatest.{FreeSpec, Matchers}
 
 
-class StatementsTest extends AnyFreeSpec with Matchers {
-
+class StatementsTest extends FreeSpec with Matchers {
   "policy helper" - {
     val statements = Seq(
       s3FullAccess("my-bucket", "/"),
       s3ReadAccess("your-bucket", "/"),
-      s3ReadAccess("your-bucket", "/")
+      s3ReadAccess("your-bucket", "/"),
     )
 
     "deduplicates statements" in {
       val p = policy(statements :_*)
       p.statements.distinct shouldBe p.statements
     }
-
   }
 
   "enforceCorrectPath" - {

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "example",
     libraryDependencies ++= Seq(
-      "com.gu" %% "janus-config-tools" % "0.0.3",
+      "com.gu" %% "janus-config-tools" % "0.0.4",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
     )
   )

--- a/example/src/main/scala/com/example/Data.scala
+++ b/example/src/main/scala/com/example/Data.scala
@@ -8,6 +8,7 @@ object Data {
     accounts = Accounts.allAccounts,
     access = Access.acl,
     admin = Admin.acl,
-    support = Support.acl
+    support = Support.acl,
+    permissionsRepo = None,
   )
 }


### PR DESCRIPTION
## What is the purpose of this change?

Move Statements out of example and into configTools, and bump the version of configTools depended upon.
The Statements are a useful shared functionality that can be used for creating bespoke policies.

This also adds the required `permissionsRepo` to the JanusData used in the example app.

## What is the value of this change and how do we measure success?

We can release a new version of configTools
