### PR TITLE
Add method to verify the janusData can be found and loaded

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/VerifyJanusData.scala
+++ b/configTools/src/main/scala/com/gu/janus/VerifyJanusData.scala
@@ -12,9 +12,9 @@ object VerifyJanusData {
   def main(args: Array[String]): Unit = {
     args.headOption.fold {
       Console.err.println(
-        s"""${RED}Error: Missing argument <output file>
+        s"""${RED}Error: Missing argument <input file>
            |
-           |Usage: example <output file>$RESET""".stripMargin)
+           |Usage: run <input file>$RESET""".stripMargin)
       System.exit(1)
     } { fileName =>
       try {
@@ -35,7 +35,7 @@ object VerifyJanusData {
           System.exit(1)
         case NonFatal(e) =>
           Console.err.println(
-            s"""${RED}Error loading JanusData: ${e.getMessage}>$RESET""".stripMargin)
+            s"""${RED}Error loading JanusData: ${e.getMessage}$RESET""".stripMargin)
           System.exit(1)
       }
     }

--- a/configTools/src/main/scala/com/gu/janus/VerifyJanusData.scala
+++ b/configTools/src/main/scala/com/gu/janus/VerifyJanusData.scala
@@ -1,0 +1,43 @@
+package com.gu.janus
+
+import java.io.File
+
+import com.gu.janus.JanusConfig.JanusConfigurationException
+
+import scala.Console.{GREEN, RED, RESET}
+import scala.util.control.NonFatal
+
+
+object VerifyJanusData {
+  def main(args: Array[String]): Unit = {
+    args.headOption.fold {
+      Console.err.println(
+        s"""${RED}Error: Missing argument <output file>
+           |
+           |Usage: example <output file>$RESET""".stripMargin)
+      System.exit(1)
+    } { fileName =>
+      try {
+        val file = new File(fileName)
+        if (file.exists()) {
+          JanusConfig.load(file)
+          println(
+            s"""${GREEN}JanusData was loaded$RESET""".stripMargin)
+        } else {
+          Console.err.println(
+            s"""$RED$fileName does not exist$RESET""".stripMargin)
+          System.exit(1)
+        }
+      } catch {
+        case e: JanusConfigurationException =>
+          Console.err.println(
+            s"""$RED${e.getMessage}$RESET""".stripMargin)
+          System.exit(1)
+        case NonFatal(e) =>
+          Console.err.println(
+            s"""${RED}Error loading JanusData: ${e.getMessage}>$RESET""".stripMargin)
+          System.exit(1)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Add support for verification that the JanusData can be found and loaded.

## What is the value of this change and how do we measure success?

This can be ran as part of a build script and will provide helpful information if an error is encountered and prevent the build from continuing.

Janus will only be deployed if the janusData is present and valid. 

## Images

Example of error printed before a non-zero exit:

<img width="841" alt="Screenshot 2020-09-04 at 11 50 58" src="https://user-images.githubusercontent.com/8607683/92231729-3423d700-eea5-11ea-9151-35a49967bcc0.png">
