### PR TITLE
Update version number of configTools

### DIFF
--- a/configTools/version.sbt
+++ b/configTools/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.5-SNAPSHOT"
+version in ThisBuild := "0.0.5"

--- a/configTools/version.sbt
+++ b/configTools/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.5"
+version in ThisBuild := "0.0.6-SNAPSHOT"


### PR DESCRIPTION
## What is the purpose of this change?

Version 0.0.5 of configTools is [now available](https://mvnrepository.com/artifact/com.gu/janus-config-tools_2.13/0.0.5) on mvnrepository. This updates the version of configTools to reflect the current release.

## What is the value of this change and how do we measure success?

It not possible possible for the sbt release plugin to push updates to master because this Git repository is locked-down. After performing the release, it is necessary to raise a PR to share the updated version number. 🚀 🌕 


