### PR TITLE
Add more details on how to publish configTools

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,13 @@ metadata in [the build.sbt file](build.sbt).
 
 Updates can be published using `sbt`.
 
-    sbt release
+    sbt "project configTools" release
 
 **NOTE:** It isn't possible for the sbt release plugin to push updates
 to master because this app's Git repository is locked-down. After
 performing the release you should raise a PR to share the updated
-version number. The commits for this change will exist locally.
+version number. The commits for this change will exist locally;
+checkout a new branch, then push both the branch and relevant tags:
+
+    git checkout -b <BRANCH NAME>
+    git push origin <BRANCH NAME> --follow-tags


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Expand the README how to update the version number of configTools in the main branch after publishing a release.

## What is the value of this change and how do we measure success?

Ensure someone following the readme switches the the correct project before attempting to release configTools.
Encourage pushing git tags along with branch to the remote so that releases of configTools are tagged.
