### PR TITLE
Add console logging

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -15,6 +15,15 @@
         </encoder>
     </appender>
 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT" />
+    </appender>
 
     <logger name="play" level="INFO" />
     <logger name="application" level="DEBUG" />
@@ -32,6 +41,7 @@
 
     <root level="INFO">
         <appender-ref ref="LOGFILE"/>
+        <appender-ref ref="ASYNCSTDOUT"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
## What is the purpose of this change?

* This change allows us to send logs to `stdout` as well as a log file. This allows us to collect logs via [Fluent Bit's systemd plugin](https://docs.fluentbit.io/manual/pipeline/inputs/systemd), which is an approach we're exploring for shipping logs at the OS level (rather than via changes to the application code).

## What is the value of this change and how do we measure success?

* Application logs should be available via `journalctl -u janus.service`
* When combined with the [config added here](https://github.com/guardian/janus/pull/2774), we should be able to ship logs to Central ELK