### PR TITLE
Upload Fluent Bit configuration to Riff-Raff's S3 buckets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,8 @@ lazy val root = (project in file("."))
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffArtifactResources += (file("cloudformation/janus.template.yaml"), s"${name.value}-cfn/cfn.yaml"),
+    riffRaffArtifactResources += (file("conf/fluentbit/td-agent-bit.conf"), s"${name.value}-fluentbit-conf/td-agent-bit.conf"),
+    riffRaffArtifactResources += (file("conf/fluentbit/parsers.conf"), s"${name.value}-fluentbit-conf/parsers.conf"),
 
     // packaging / running package
     pipelineStages in Assets := Seq(digest),


### PR DESCRIPTION
## What is the purpose of this change?

This PR uploads Janus's Fluent Bit configuration to Riff-Raff's S3 buckets, following the convention that we are already using for CloudFormation. 

Strictly speaking, all of this Riff-Raff configuration should be moved out of the public repo, but after discussing this with @adamnfish we believe that there is currently no easy way to achieve this using the [`sbt-riffraff-artifact-plugin`](https://github.com/guardian/sbt-riffraff-artifact). Consequently I have opted to stick with the existing convention for now.


