### PR TITLE
Upgrade SBT to 1.5.6 (edit to 1.5.7 and Play from 2.7 to 2.8)

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.5.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Users/nicolas_long/.sdkman/candidates/java/8.0.292.j9-adpt/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/Users/nicolas_long/.sdkman/candidates/sbt/1.5.1/bin/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/Users/nicolas_long/.sdkman/candidates/sbt/1.5.1/bin/sbt-launch.jar"]}

--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.5.6","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Users/nicolas_long/.sdkman/candidates/java/8.0.292.j9-adpt/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/Users/nicolas_long/.sdkman/candidates/sbt/1.5.1/bin/sbt-launch.jar","xsbt.boot.Boot","-bsp","--sbt-launch-jar=/Users/nicolas_long/.sdkman/candidates/sbt/1.5.1/bin/sbt-launch.jar"]}

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -45,7 +45,7 @@ class AppComponents(context: ApplicationLoader.Context)
     case ConfigSuccess =>
   }
 
-  val authAction = new AuthAction[AnyContent](googleAuthConfig, routes.AuthController.login(), controllerComponents.parsers.default)(executionContext)
+  val authAction = new AuthAction[AnyContent](googleAuthConfig, routes.AuthController.login, controllerComponents.parsers.default)(executionContext)
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -13,7 +13,6 @@ import play.api.http.HttpConfiguration
 import scala.annotation.nowarn
 import scala.util.Try
 
-
 object Config {
   def roleArn(awsAccountAuthConfigKey: String, config: Configuration): String =
     requiredString(config, s"federation.$awsAccountAuthConfigKey.aws.roleArn")
@@ -80,6 +79,7 @@ object Config {
       credentials.getServiceAccountPrivateKey,
       twoFAUser
     )
+
     new GoogleGroupChecker(serviceAccount)
   }
 

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -12,8 +12,8 @@ class AuthController(janusData: JanusData, controllerComponents: ControllerCompo
                     (implicit val wsClient: WSClient, ec: ExecutionContext, assetsFinder: AssetsFinder)
   extends AbstractController(controllerComponents) with LoginSupport {
 
-  override val failureRedirectTarget: Call = routes.AuthController.loginError()
-  override val defaultRedirectTarget: Call = routes.Janus.index()
+  override val failureRedirectTarget: Call = routes.AuthController.loginError
+  override val defaultRedirectTarget: Call = routes.Janus.index
 
   def login = Action.async { implicit request =>
     startGoogleLogin()
@@ -25,7 +25,7 @@ class AuthController(janusData: JanusData, controllerComponents: ControllerCompo
   }
 
   def logout = Action { implicit request =>
-    Redirect(routes.Janus.index()).withNewSession
+    Redirect(routes.Janus.index).withNewSession
   }
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -113,7 +113,7 @@ class Janus(janusData: JanusData, controllerComponents: ControllerComponents, au
       favourites = Favourites.fromCookie(request.cookies.get("favourites"))
       newFavourites = Favourites.toggleFavourite(account, favourites)
     } yield {
-      Redirect(routes.Janus.index())
+      Redirect(routes.Janus.index)
         .withCookies(Favourites.toCookie(newFavourites))
     }) getOrElse Ok(views.html.error("Invalid favourite submission", Some(request.user), janusData))
   }

--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,8 @@ lazy val root = (project in file("."))
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
     ),
 
+    dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2", // Avoid binary incompatibility error.
+
     // local development
     playDefaultPort := 9100,
     Test / fork := false,

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val commonDependencies = Seq(
 lazy val commonSettings = Seq(
   scalaVersion := "2.13.3",
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings"),
-  testOptions in Test ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports"))
+  Test / testOptions ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports"))
 )
 
 
@@ -41,7 +41,7 @@ lazy val root = (project in file("."))
     commonSettings,
     name := """janus""",
     version := "1.0-SNAPSHOT", // must match URL in cloudformation userdata
-    javaOptions in Universal ++= Seq(
+    Universal / javaOptions ++= Seq(
       "-Dconfig.file=/etc/gu/janus.conf", // for PROD, overridden by local sbt file
       "-Dpidfile.path=/dev/null",
       "-J-XX:MaxRAMFraction=2",
@@ -66,25 +66,25 @@ lazy val root = (project in file("."))
 
     // local development
     playDefaultPort := 9100,
-    fork in Test := false,
+    Test / fork := false,
 
     // deployment
-    riffRaffPackageType := (packageBin in Debian).value,
+    riffRaffPackageType := (Debian / packageBin).value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),
     riffRaffArtifactResources += (file("cloudformation/janus.template.yaml"), s"${name.value}-cfn/cfn.yaml"),
 
     // packaging / running package
-    pipelineStages in Assets := Seq(digest),
-    sources in (Compile,doc) := Seq.empty,
-    publishArtifact in (Compile, packageDoc) := false,
+    Assets / pipelineStages := Seq(digest),
+    Compile / doc / sources := Seq.empty,
+    Compile / packageDoc / publishArtifact := false,
 
-    topLevelDirectory in Debian := Some(normalizedName.value),
-    serverLoading in Debian := Some(Systemd),
+    Debian / topLevelDirectory  := Some(normalizedName.value),
+    Debian / serverLoading  := Some(Systemd),
     debianPackageDependencies := Seq("java8-runtime-headless"),
-    maintainer in Debian := "Developer Experience <dig.dev.tooling@theguardian.com>",
-    packageSummary in Debian := "Janus webapp",
-    packageDescription in Debian := "Janus: Google-based federated AWS login",
+    Debian/ maintainer := "Developer Experience <dig.dev.tooling@theguardian.com>",
+    Debian / packageSummary := "Janus webapp",
+    Debian / packageDescription := "Janus: Google-based federated AWS login",
   )
 
 lazy val configTools = (project in file("configTools"))

--- a/configTools/version.sbt
+++ b/configTools/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.6-SNAPSHOT"
+ThisBuild / version := "0.0.6-SNAPSHOT"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.6
+sbt.version=1.5.7

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.6")
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 


### PR DESCRIPTION
Immediate motivation was to use the dependencyTree command to check for Log4j usage (re recent security vulnerability). But this is generally useful in any case.

See also: https://github.com/guardian/janus/pull/2904.

(Not really tested beyond CI - any suggestions on best way to test this appreciated.)

**Note: the Play upgrade would ideally be in a separate PR, but is forced by https://github.com/guardian/ophan/commit/bf8576e5c3a3c813de8b64271d3db260c7befbdf.**