### PR TITLE
fix: Write logs to console in JSON format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,29 @@ lazy val commonSettings = Seq(
   Test / testOptions ++= Seq(Tests.Argument(TestFrameworks.ScalaTest, "-o"), Tests.Argument(TestFrameworks.ScalaTest, "-u", "logs/test-reports"))
 )
 
+/*
+Workaround for CVE-2020-36518 in Jackson
+@see https://github.com/orgs/playframework/discussions/11222
+ */
+val jacksonVersion         = "2.13.2"
+val jacksonDatabindVersion = "2.13.3"
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core"     % "jackson-core",
+  "com.fasterxml.jackson.core"     % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module"     % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module"     %% "jackson-module-scala",
+).map(_ % jacksonVersion)
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
@@ -61,8 +84,11 @@ lazy val root = (project in file("."))
       "com.gu.play-googleauth" %% "play-v27" % "1.0.7",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
-    ),
+      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1"
+    ) ++ jacksonDatabindOverrides
+      ++ jacksonOverrides
+      ++ akkaSerializationJacksonOverrides,
 
     dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2", // Avoid binary incompatibility error.
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -16,9 +16,7 @@
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
     <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
Following #21 (and as [commented upon](https://github.com/guardian/janus-app/pull/21#discussion_r693978977)), this change uses the Logstash Encoder to output logs in JSON format. These are easier to consume by machines, in this case Fluentbit via [devx-logs](https://github.com/guardian/devx-logs).

Regarding the jackson overrides, this is to address compatibility issues with the version of the logstash encoder and Play and also addresses a vulnerability. See https://github.com/orgs/playframework/discussions/11222. See https://github.com/guardian/amiable/pull/133 for similar.

## What is the value of this change and how do we measure success?
In conjunction with https://github.com/guardian/janus/pull/3050, this change means our infrastructure becomes simpler as we've fewer configuration files.

## Any additional notes?
This will close #22.