### PR TITLE
Update play-googleauth to support Play 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,12 +172,13 @@ the missing values and includes the `application.config`.
 Instructions on configuring the Google Authentication for Janus are
 available in the
 [guardian/play-googleauth](https://github.com/guardian/play-googleauth)
-library.
+library. Please note that application secret rotation is not yet supported.
 
 The configuration properties that come from the above steps should be
 included in the application's configuration file, and the service
 account certificate file will need to be available to the Janus
 application.
+
 
 ## Non-Guardian use
 

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val root = (project in file("."))
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,
       filters,
-      "com.gu.play-googleauth" %% "play-v27" % "1.0.7",
+      "com.gu.play-googleauth" %% "play-v28" % "2.2.6",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,


### PR DESCRIPTION
## What is the purpose of this change?
There's currently an incompatibility between our Play version (2.8) and the version of `play-googleauth` we're using (a Play 2.7 compatible one). This PR updates `play-googleauth` to the latest version that works with Play 2.8.

One note is that we've explicitly chosen not to support application secret rotation _yet_. This incompatibility should be fixed quickly, and we will put more thought into the best way to support secret rotation in a relatively environment-independent way (probably mostly via good documentation).

## What is the value of this change and how do we measure success?
It should avoid some runtime errors that have been observed in our deployment of Janus.

## Any additional notes?
This has been tested briefly in our production environment.
