### PR TITLE
Allow janusData to be pulled from a file outside resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This will likely involve DNS or a hosts entry as well as a webserver
 Use sbt to run Janus in development mode. The server will
 automatically recompile and reload when changes are made.
 
-    sbt -Dconfig.file=<PATH>/janus.local.conf run
+    sbt -Dconfig.file=<PATH>/janusData.conf run
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This will likely involve DNS or a hosts entry as well as a webserver
 Use sbt to run Janus in development mode. The server will
 automatically recompile and reload when changes are made.
 
-    sbt -Dconfig.file=<PATH>/janusData.conf run
+    sbt -Dconfig.file=<PATH>/janus.local.conf run
 
 ## Configuration
 

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -33,7 +33,7 @@ class AppComponents(context: ApplicationLoader.Context)
     if (context.environment.mode == play.api.Mode.Prod) DynamoDB.at(Regions.getCurrentRegion)
     else DynamoDB.local()
 
-  val janusData = JanusConfig.load("janusData.conf")
+  val janusData = Config.janusData(configuration)
 
   Config.validateAccountConfig(janusData, configuration) match {
     case FederationConfigError(causedBy) =>

--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -1,8 +1,9 @@
 package conf
 
-import java.io.FileInputStream
+import java.io.{File, FileInputStream}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
+import com.gu.janus.JanusConfig
 import com.gu.janus.model._
 import models._
 import play.api.Configuration
@@ -40,6 +41,11 @@ object Config {
 
   def host(config: Configuration): String = {
     requiredString(config, "host")
+  }
+  def janusData(config: Configuration): JanusData = {
+    config.getOptional[String]("data.fileLocation")
+      .map(filePath => JanusConfig.load(new File(filePath)))
+      .getOrElse(JanusConfig.load("janusData.conf"))
   }
 
   def googleSettings(config: Configuration, httpConfiguration: HttpConfiguration): GoogleAuthConfig = {


### PR DESCRIPTION
## What is the purpose of this change?

This enables a better setup experience for users trying to run Janus locally, by allowing the Janus data file generated by a separate project to be referred to outside of the resources folder when doing local development.

See https://github.com/guardian/janus/pull/3273 for how this change is used.

**Next steps:** Following merging the above referenced PR, we should update the documentation in this repository to point Guardian engineers trying to run the Guardian version of Janus to the private Janus repo.