### PR TITLE
Add a pointer to the docs for Guardian engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Wherever you run Janus, you need to provide three configuration files:
 
 The configuration section (below) shows what is required.
 
+**Note:** If you're a Guardian engineer looking to test changes on the internal
+instance of this service, see these [specific instructions](https://github.com/guardian/janus/blob/main/docs/running-janus.md) 
+
 ### In AWS
 
 This repository provides an [example CloudFormation template](docs/cloudformation/example.template.yaml).


### PR DESCRIPTION
## What is the purpose of this change?

This is a small documentation update to point at the docs for guardian engineers to get started quickly.

Follows https://github.com/guardian/janus/pull/3273