### PR TITLE
Fix to allow Scala Steward to monitor dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,3 +150,11 @@ lazy val configTools = (project in file("configTools"))
     ),
     releaseProcess += releaseStepCommandAndRemaining("sonatypeRelease")
   )
+
+/*
+ * This is required for Scala Steward to run until SBT plugins all migrated to scala-xml 2.
+ * See https://github.com/scala-steward-org/scala-steward/blob/13d63e8ae98a714efcdac2c7af18f004130512fa/project/plugins.sbt#L16-L19
+ */
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)


### PR DESCRIPTION
Recent Scala Steward runs have been failing because of incompatibilities between versions of scala-xml.

Eg. https://github.com/guardian/scala-steward-public-repos/actions/runs/3378212621/jobs/5608120855#step:5:244
![image](https://user-images.githubusercontent.com/1722550/199520655-7897558b-a8f1-4769-b418-805338939f74.png)
