### PR TITLE
Bump dependencies on example project

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion     := "2.12.12"
+ThisBuild / scalaVersion     := "2.13.10"
 ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "com.example"
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "example",
     libraryDependencies ++= Seq(
-      "com.gu" %% "janus-config-tools" % "0.0.4",
-      "org.scalatest" %% "scalatest" % "3.1.1" % Test,
+      "com.gu" %% "janus-config-tools" % "0.0.5",
+      "org.scalatest" %% "scalatest" % "3.2.14" % Test,
     )
   )

--- a/example/src/main/scala/com/example/Access.scala
+++ b/example/src/main/scala/com/example/Access.scala
@@ -16,7 +16,7 @@ object Access {
     "sherlock.holmes" -> (Root.dev ++ securityAccess),
     "john.watson" -> (Production.dev ++ Staging.dev ++ Root.billing),
     "irene.adler" -> (Production.dev ++ Staging.dev ++ DataLake.dev),
-    "mycroft.holmes" -> (productionAccessLogs ++ securityCloudtrailLogs ++ serviceControlPolicyAccess)
+    "mycroft.holmes" -> (productionAccessLogs ++ securityCloudtrailLogs)
   )
 
   // Default permissions are granted to every developer that is named below

--- a/example/src/main/scala/com/example/Access.scala
+++ b/example/src/main/scala/com/example/Access.scala
@@ -16,7 +16,7 @@ object Access {
     "sherlock.holmes" -> (Root.dev ++ securityAccess),
     "john.watson" -> (Production.dev ++ Staging.dev ++ Root.billing),
     "irene.adler" -> (Production.dev ++ Staging.dev ++ DataLake.dev),
-    "mycroft.holmes" -> (productionAccessLogs ++ securityCloudtrailLogs)
+    "mycroft.holmes" -> (productionAccessLogs ++ securityCloudtrailLogs ++ serviceControlPolicyManagement)
   )
 
   // Default permissions are granted to every developer that is named below


### PR DESCRIPTION
## What is the purpose of this change?

The example project here was being flagged by vulnerability monitoring, also upon inspection it did not appear to compile / test successfully.

This change bumps some dependencies in the example project to provide better defaults for someone using the project and removes some code that was preventing the project compiling.