### PR TITLE
exclude test project from snyk scan

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -13,5 +13,6 @@ jobs:
       DEBUG: true
       ORG: guardian-security
       SKIP_NODE: true
+      EXCLUDE: example
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What is the purpose of this change?

This repo includes an example project that is not used for anything in production. This change excludes that directory from the scan

## What is the value of this change and how do we measure success?

These vulnerabilities are not ones we are concerned about, excluding them makes our count go down

## Images

### Before

<img width="480" alt="Screenshot 2023-05-25 at 13 16 40" src="https://github.com/guardian/janus-app/assets/67543397/5076ff69-02de-452f-a16b-fef2988dd80c">

### After

<img width="484" alt="Screenshot 2023-05-25 at 13 25 08" src="https://github.com/guardian/janus-app/assets/67543397/1d6bc1f6-e0cf-419b-a967-f9e40f0a2a08">


## Any additional notes?

Dependency patches will still be applied by scala steward, but are less critical as the example project is not used.
