### PR TITLE
chore(deps): Rollback update to `logstash-logback-encoder`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val root = (project in file("."))
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
-      "net.logstash.logback" % "logstash-logback-encoder" % "7.4"
+      "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
     ) ++ jacksonDatabindOverrides
       ++ jacksonOverrides
       ++ akkaSerializationJacksonOverrides,


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
Fix an issue where logs are not appearing in Central ELK.

Running Janus locally, we're getting the following error:

```log
Exception in thread "AsyncAppender-Worker-ASYNCSTDOUT" java.lang.NoSuchMethodError: 'java.time.Instant ch.qos.logback.classic.spi.ILoggingEvent.getInstant()'
```

Rolling back fixes this.

## What is the value of this change and how do we measure success?
Logs will start appearing in Central ELK again.
