### PR TITLE
ci: Tighten the build

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -1,24 +1,53 @@
-# This triggers a build in a separate github action
-
-## See documentation here: https://docs.google.com/document/d/1Xz-gzptICIza0oio0Kza3LWg2a6n_015o0MPu0LGfuU/edit#heading=h.k45jb8zdijoi
-## (Only available for select Guardian Staff)
-## This also relies on a personal access token, due to expire on or before 15th June 2024 ( 2024-06-15 ).
-## Details of how to renew this token in the docs.
-
-### This task is broken into 2 jobs
-### in case for whatever reason the internal build takes a long time to complete, 
-### we can just re-run the second job to check the status
-
 name: Trigger Private Janus build
 
 on:
+  # When a PR is merged
   push:
     branches: ["main"]
+
+  # When a PR is raised (for example, dependency updates from Dependabot or Scala Steward)
   pull_request:
+
+  # When a workflow is manually triggered
   workflow_dispatch:
 
 jobs:
+  # Compile and run tests
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      checks: write # Required by dorny/test-reporter
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '8'
+          cache: 'sbt'
+
+      - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
+
+      - name: Test Report for Janus-App
+        uses: dorny/test-reporter@v1
+        if: success() || failure() # run this step even if previous step failed
+        with:
+          name: Janus-App Tests
+          path: logs/test-reports/TEST-*.xml
+          reporter: java-junit
+          only-summary: 'false'
+          fail-on-error: 'true'
+
+  # Trigger a workflow in the guardian/janus repository, if and only if:
+  #   - The Scala build is successful
+  #   - We're on the 'main' branch
   trigger-workflow:
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+
     runs-on: ubuntu-latest
 
     outputs:
@@ -37,10 +66,7 @@ jobs:
             owner: 'guardian',
             repo: 'janus',
             workflow_id: 'build.yml',
-            ref: 'main',
-            inputs: {
-              "janus-app-branch": "${{ github.ref }}"
-            }
+            ref: 'main'
           })
 
     - run: sleep 5 # wait for event to register within github system
@@ -64,6 +90,7 @@ jobs:
 
     - run: sleep 240 # wait 4 minutes for job to run
 
+  # Reflect the build status from the workflow in the guardian/janus repository here
   check-status:
     runs-on: ubuntu-latest
     needs: trigger-workflow


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
This change removes the `janus-app-branch` input to the Workflow being triggered in `guardian/janus`, removing an edge case where feature branches were being deployed to PROD.

The build is now:
  1. Compile the Scala app, and run the tests
  2. If compilation is successful, and we're on the `main` branch, trigger the Workflow in `guardian/janus`
  3. The Workflow in `guardian/janus` will clone always clone the main branch of this repository

With these changes we lose the ability to deploy feature branches (as their build will not appear in Riff-Raff), however looking at the deployment history, this isn't a thing we've ever done.

## What is the value of this change and how do we measure success?
These changes removes an edge case from the build where feature branches in this repository were being deployed to PROD.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

Here's a diagram of the build steps:

![image](https://github.com/guardian/janus-app/assets/836140/fde0752e-c00f-4509-a02c-d22ae8af7fe7)

---

See also https://github.com/guardian/janus/pull/3769.