### PR TITLE
chore(deps): Remove `sbt-riffraff-artifact`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.gu.riffraff.artifact.RiffRaffArtifact
-import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import play.sbt.PlayImport.PlayKeys._
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 import sbt.Keys._
@@ -80,7 +78,7 @@ val akkaSerializationJacksonOverrides = Seq(
 ).map(_ % jacksonVersion)
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
+  .enablePlugins(PlayScala, JDebPackaging, SystemdPlugin)
   .dependsOn(configTools % "compile->compile;test->test")
   .settings(
     commonSettings,
@@ -115,14 +113,6 @@ lazy val root = (project in file("."))
     // local development
     playDefaultPort := 9100,
     Test / fork := false,
-
-    // deployment
-    riffRaffPackageType := (Debian / packageBin).value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-    riffRaffArtifactResources += (file(
-      "cloudformation/janus.template.yaml"
-    ), s"${name.value}-cfn/cfn.yaml"),
 
     // packaging / running package
     Assets / pipelineStages := Seq(digest),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 // sbt-native-packager cannot be updated to >1.9.9 until Play supports scala-xml 2
 addSbtPlugin(
   "com.github.sbt" % "sbt-native-packager" % "1.9.16"


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
https://github.com/guardian/sbt-riffraff-artifact is deprecated, and also unused as https://github.com/guardian/janus has adopted https://github.com/guardian/actions-riff-raff.

## What is the value of this change and how do we measure success?
Fewer dependencies.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->
N/A.

## Any additional notes?
N/A.