### PR TITLE
Revert "chore: Move to Java 11"

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '8'
           cache: 'sbt'
 
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test

--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val root = (project in file("."))
     Compile / packageDoc / publishArtifact := false,
     Debian / topLevelDirectory := Some(normalizedName.value),
     Debian / serverLoading := Some(Systemd),
+    debianPackageDependencies := Seq("java8-runtime-headless"),
     Debian / maintainer := "Developer Experience <dig.dev.tooling@theguardian.com>",
     Debian / packageSummary := "Janus webapp",
     Debian / packageDescription := "Janus: Google-based federated AWS login"


### PR DESCRIPTION
Reverts guardian/janus-app#379

The upgrade to Java 11 has not worked and I don't have time to fix forwards at the moment, so reverting for now.

https://github.com/guardian/janus/pull/3896 should also be merged to revert this upgrade.