### PR TITLE
Fix: downgrade play to make sbt work again

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 )
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
Downgrades the Play plugin from 2.9.0 (it was upgraded in #372) to 2.8.19, to fix issues:
1. SBT was no longer working locally
2. The `Trigger Private Janus build` action did not run successfully

## What is the value of this change and how do we measure success?
SBT can be run without error locally (and subsequently `snyk test`)
