### PR TITLE
chore: Upgrade to Java 11

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
-          java-version: '8'
+          java-version: '11'
           cache: 'sbt'
 
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,6 @@ lazy val root = (project in file("."))
     Compile / packageDoc / publishArtifact := false,
     Debian / topLevelDirectory := Some(normalizedName.value),
     Debian / serverLoading := Some(Systemd),
-    debianPackageDependencies := Seq("java8-runtime-headless"),
     Debian / maintainer := "Developer Experience <dig.dev.tooling@theguardian.com>",
     Debian / packageSummary := "Janus webapp",
     Debian / packageDescription := "Janus: Google-based federated AWS login"

--- a/build.sbt
+++ b/build.sbt
@@ -88,8 +88,8 @@ lazy val root = (project in file("."))
     Universal / javaOptions ++= Seq(
       "-Dconfig.file=/etc/gu/janus.conf", // for PROD, overridden by local sbt file
       "-Dpidfile.path=/dev/null",
-      "-J-Xms2048m",
-      "-J-Xmx2048m"
+      "-J-Xms1g",
+      "-J-Xmx1g"
     ),
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,

--- a/build.sbt
+++ b/build.sbt
@@ -88,15 +88,8 @@ lazy val root = (project in file("."))
     Universal / javaOptions ++= Seq(
       "-Dconfig.file=/etc/gu/janus.conf", // for PROD, overridden by local sbt file
       "-Dpidfile.path=/dev/null",
-      "-J-XX:MaxRAMFraction=2",
-      "-J-XX:InitialRAMFraction=2",
-      "-J-XX:+UseG1GC",
-      "-J-XX:G1HeapRegionSize=32m",
-      "-J-XX:+PrintGCDetails",
-      "-J-XX:+PrintGCDateStamps",
-      "-J-Xloggc:/var/log/${packageName.value}/gc.log",
-      "-J-XX:+UseCompressedOops",
-      "-J-XX:+UseStringDeduplication"
+      "-J-Xms2048m",
+      "-J-Xmx2048m"
     ),
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,


### PR DESCRIPTION
This is a re-attempt to upgrade Java to v11. This was attempted in #379 and reverted in #381.

Requires: https://github.com/guardian/janus/pull/3947 which should be merged first, as Java 11 is backwards compatible with Java 8.