### PR TITLE
Chore: bump config tools after releasing to Maven

### DIFF
--- a/configTools/version.sbt
+++ b/configTools/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.6-SNAPSHOT"
+ThisBuild / version := "0.0.6"

--- a/configTools/version.sbt
+++ b/configTools/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.0.6"
+ThisBuild / version := "0.0.7-SNAPSHOT"


### PR DESCRIPTION
## What is the purpose of this change?

This bumps the version of `janus-config-tools` to v0.0.6. This reflects the version of the latest Maven release.  

## What is the value of this change and how do we measure success?

The published version has its dependency updates and the versions are in line between Maven and this repo.

Co-authored-by: @adamnfish 
