### PR TITLE
feat: add sbt dependency submission action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,12 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: scalacenter/sbt-dependency-submission@v2
+    permissions:
+        contents: write # this permission is needed to submit the dependency graph


### PR DESCRIPTION
## What is the purpose of this change?

Adds a workflow that updates the dependency graph with SBT dependencies, using the third party (from Scalacenter) [SBT Dependency Submission workflow](https://github.com/marketplace/actions/sbt-dependency-submission).

## What is the value of this change and how do we measure success?

This wil allow Dependabot to report on vulnerabilites in Scala dependencies. 

This has been tested on push to this branch and [created a snapshot of the dependencies](https://api.github.com/repos/guardian/janus-app/dependency-graph/snapshots/10509078). (See them under `snapshots > manifests > com.gu:janus... > resolved`).

When it is run on `main` after this PR is merged, the Scala dependencies should appear in [the dependency graph in this repo](https://github.com/guardian/janus-app/network/dependencies).