### PR TITLE
chore: add dependency tree plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 // Formatting
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+
+addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,7 +21,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
+addDependencyTreePlugin
+
 // Formatting
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-
-addDependencyTreePlugin


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Adds the SBT dependency tree plugin.

## What is the value of this change and how do we measure success?

This will allow us to generate the dependency tree locally, including using the useful `dependencyBrowseTree` command to display a searchable tree in the browser.
