### PR TITLE
use later jackson-databind version in configTools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val configTools = (project in file("configTools"))
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-config" % "0.8.0"
-    ),
+    ) ++ jacksonDatabindOverrides,
     name := "janus-config-tools",
     description := "Library for reading and writing Janus configuration files",
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Makes the configTools project use the same version of `jackson-databind` as the main app. 

## What is the value of this change and how do we measure success?

This is an attempt to mitigate the critical issues discovered by Dependabot, whereby configTools' reliance on [aws-scala](https://github.com/seratch/AWScala) which has been deprecated, and which in turn relies on an old version of `jackson-databind` (v2.6). Once this is merged, if successful we should see the critical issues disappear.

I have tested this locally and the dependency tree for configTools shows that the vulnerable v2.6 is now evicted by the safe version:

![image](https://github.com/guardian/janus-app/assets/15648334/60346a9c-9240-48b2-85d5-9743fa57cd93)
