### PR TITLE
fix: use later aws sdk version in configTools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val configTools = (project in file("configTools"))
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "io.circe" %% "circe-config" % "0.8.0"
+      "io.circe" %% "circe-config" % "0.8.0",
+      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
     ) ++ jacksonDatabindOverrides,
     name := "janus-config-tools",
     description := "Library for reading and writing Janus configuration files",


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Makes the configTools project use the same version of `aws-sdk` as the main app. 

## What is the value of this change and how do we measure success?

This is an attempt to mitigate a high severity vulnerability discovered by Dependabot, whereby configTools' reliance on [aws-scala](https://github.com/seratch/AWScala) which has been deprecated, and which in turn relies on an old version of `aws-java-sdk-s3`. Once this is merged, if successful we should see the issue disappear.

I have tested this locally and the dependency tree for configTools shows that the vulnerable version has been replaced a safe version:

Before: 
![image](https://github.com/guardian/janus-app/assets/15648334/bd724267-59c6-47e0-82ce-9bcb42f5de8d)


After: 
![image](https://github.com/guardian/janus-app/assets/15648334/4c26c80b-3884-444d-83af-74ac821b20ef)

