### PR TITLE
Increase the time we wait for the private build to complete

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -99,7 +99,9 @@ jobs:
           console.log(result);
           return result["data"]["workflow_runs"][0].id
 
-    - run: sleep 240 # wait 4 minutes for job to run
+    # wait 6 minutes for job to run
+    # This is the observed upper limit for builds that invalidate the sbt cache
+    - run: sleep 360
 
   # Reflect the build status from the workflow in the guardian/janus repository here
   check-status:


### PR DESCRIPTION

## What is the purpose of this change?

Make sure that the build for this repository correctly reports success or failure.

## What is the value of this change and how do we measure success?

The real build gets kicked off in another repository, and then we have a step that waits for a while before checking if it succeeded. In practice, with a cold cache we observe that a 6 minute wait covers all cases, so we've upped the wait time.

Note: Better would be to poll until the build completes, but since this doesn't actually delay anything, no harm in having it be long enough that it reliably gives the correct answer.

