### PR TITLE
docs: update README to reflect new release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,4 @@ would like to use a modified version of the library, you can publish
 your own version under a different organisation by updating the
 metadata in [the build.sbt file](build.sbt).
 
-Updates can be published using `sbt`.
-
-    sbt "project configTools" release
-
-**NOTE:** It isn't possible for the sbt release plugin to push updates
-to master because this app's Git repository is locked-down. After
-performing the release you should raise a PR to share the updated
-version number. The commits for this change will exist locally;
-checkout a new branch, then push both the branch and relevant tags:
-
-    git checkout -b <BRANCH NAME>
-    git push origin <BRANCH NAME> --follow-tags
+Updates can be published by running the `release` workflow in GitHub Actions.


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Updates the README to reflect the new process for publishing Janus ConfigTools. We now publish using a GitHub Action rather than from SBT.