### PR TITLE
docs: update readme with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,7 @@ your own version under a different organisation by updating the
 metadata in [the build.sbt file](build.sbt).
 
 Updates can be published by running the `release` workflow in GitHub Actions.
+
+This repo uses [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow)
+to automate publishing the Scala client (both full and preview releases) - see
+[**Making a Release**](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md) for more details.


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Updates the README with more information about publishing the Janus ConfigTools.
