### PR TITLE
Change `/admin` to `/superuser` to avoid the WAF

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -32,7 +32,7 @@
                         <ul class="right hide-on-med-and-down">
                             <li><a href="/accounts">Accounts</a></li>
                             <li><a href="/support">Support</a></li>
-                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/admin">Admin</a></li> }
+                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/logout">@user.firstName @user.lastName</a></li>
                         </ul>
@@ -41,7 +41,7 @@
                             <li><a href="/">Home</a></li>
                             <li><a href="/accounts">Accounts</a></li>
                             @if(isSupportUser(username(user), DateTime.now(), janusData.support)) { <li><a href="/support">Support</a></li> }
-                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/admin">Admin</a></li> }
+                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/logout">@user.firstName @user.lastName <i class="material-icons right">power_settings_new</i></a></li>
                         </ul>

--- a/conf/routes
+++ b/conf/routes
@@ -4,7 +4,7 @@
 
 # Home page
 GET     /                           controllers.Janus.index
-GET     /admin                      controllers.Janus.admin
+GET     /superuser                  controllers.Janus.admin
 GET     /support                    controllers.Janus.support
 GET     /console                    controllers.Janus.consoleLogin(permissionId: String)
 GET     /consoleUrl                 controllers.Janus.consoleUrl(permissionId: String)


### PR DESCRIPTION
The default WAF rules block URLs that look like important endpoints (e.g. /admin).

## What is the purpose of this change?

Allow access to the superuser endpoints for InfoSec.

## What is the value of this change and how do we measure success?

We should be able to access this endpoint, behind the WAF.