### PR TITLE
add auto-logout toggle

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Test Report for Janus-App
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
-        if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork }} # run this step even if previous step failed
+        if: (success() || failure()) && !github.event.pull_request.head.repo.fork # run this step even if previous step failed
         with:
           name: Janus-App Tests
           path: logs/test-reports/TEST-*.xml

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -13,12 +13,15 @@
 
         <div class="row">
             <div class="logout-button">
-            <a href="https://signin.aws.amazon.com/oauth?Action=logout"
-               target="_blank"
-               class="waves-effect waves-light btn">
-                <i class="material-icons">exit_to_app</i>
-                logout
-            </a>
+                <span class="switch" title="Automatically logout before entering a new account's console">
+                    <label><span>Auto-logout</span><input id="auto_logout_switch" type="checkbox"><span class="lever"></span></label>
+                </span>
+                <a href="https://signin.aws.amazon.com/oauth?Action=logout"
+                   target="_blank"
+                   class="waves-effect waves-light btn">
+                    <i class="material-icons">exit_to_app</i>
+                    logout
+                </a>
             </div>
         </div>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,7 +67,7 @@ play {
 
   filters {
     hosts.allowed = [ "." ]  # allow all hosts because we're behind an ELB with a dynamic hostname
-    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' https://fonts.gstatic.com/; style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline'"
+    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' https://fonts.gstatic.com/; style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline'; connect-src 'self' https://signin.aws.amazon.com https://aws.amazon.com"
   }
 
   # Trust all proxies (the internet can't reach us directly so this is safe)

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -279,4 +279,30 @@ jQuery(function($){
         }
     });
 
+    // auto-logout (preference persisted with local storage)
+    $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
+        const LOCAL_STORAGE_KEY__AUTO_LOGOUT = "autoLogout"
+        autoLogoutSwitchElement.checked = localStorage.getItem(LOCAL_STORAGE_KEY__AUTO_LOGOUT) === "true";
+        autoLogoutSwitchElement.onchange = (event) => {
+            autoLogoutSwitchElement.checked = event.target.checked;
+            localStorage.setItem(LOCAL_STORAGE_KEY__AUTO_LOGOUT, event.target.checked.toString());
+        };
+
+        $("a[href*='/console?permissionId=']").each(function(_, el){
+            el.onclick = (clickEvent) => {
+                if(autoLogoutSwitchElement.checked) {
+                    clickEvent.preventDefault();
+                    const targetHref = el.href;
+                    console.log("Silently attempting logout before navigating to", targetHref)
+                    fetch("https://signin.aws.amazon.com/logout", {
+                        mode: "no-cors", // we avoid CORS issues here and really only care if the request succeeds,
+                        credentials: "include", // we need AWS cookies to be sent in this log out call
+                    }).finally(() => {
+                        location.href = targetHref;
+                    });
+                }
+            }
+        });
+    });
+
 });

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -295,8 +295,12 @@ jQuery(function($){
                     const targetHref = el.href;
                     console.log("Silently attempting logout before navigating to", targetHref)
                     fetch("https://signin.aws.amazon.com/logout", {
-                        mode: "no-cors", // we avoid CORS issues here and really only care if the request succeeds,
-                        credentials: "include", // we need AWS cookies to be sent in this log out call
+                        // we avoid CORS issues here and really only care if the request succeeds
+                        mode: "no-cors",
+                        // we need AWS cookies to be sent in this log out call
+                        credentials: "include",
+                        // give up after short delay to ensure user intent is followed promptly of log out is slow
+                        signal: AbortSignal.timeout(1500),
                     }).finally(() => {
                         location.href = targetHref;
                     });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -17,7 +17,20 @@ main {
     vertical-align: -3px;
 }
 
-.btn, .btn-large {
+.switch label:has(> #auto_logout_switch) span {
+    margin-top: -2px;
+    font-size: 1rem;
+}
+
+.switch label:has(> #auto_logout_switch) .lever{
+    margin-left: 10px;
+}
+
+.switch label input[type=checkbox]:checked+.lever {
+    background-color: #efb57c;
+}
+
+.btn, .btn-large, .switch label input[type=checkbox]:checked+.lever:after{
     background-color: #f57c00;
 }
 


### PR DESCRIPTION
When working with multiple AWS accounts throughout the day, it would be useful to have an (optional) auto-logout feature when clicking through to the console of the next/desired AWS account.

Turns out there's already an issue for this from 2017: https://github.com/guardian/janus/issues/868

## Changes

- allow `signin.aws.amazon.com` and `aws.amazon.com` as `connect-src`s in the CSP in anticipation of calling it client-side to perform auto-logout
- add an 'Auto-logout' toggle (persisted to local storage) and if active silently hit `https://signin.aws.amazon.com/logout` for AWS Console links before redirecting to the AWS console for desired/clicked account (gives up after 1.5s and redirects regardless)


## Images
#### Toggle
<img width="425" alt="image" src="https://github.com/guardian/janus-app/assets/19289579/19516267-4e6f-47a5-9f73-2d1cd8557a78">


#### Example console output (from local)
<img width="411" alt="image" src="https://github.com/guardian/janus-app/assets/19289579/5fd2b9e5-d3bd-4fb8-ab8d-a7ec8da475f9">

#### Local Storage value (from local)
<img width="313" alt="image" src="https://github.com/guardian/janus-app/assets/19289579/1c4fac84-607b-4333-80f1-67f66654143d">
