### PR TITLE
Add Java version - see guardian/gha-scala-library-release-workflow#36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,3 @@ crashlytics-build.properties
 .bsp/
 .metals/
 .vscode/
-
-# asdf
-.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java corretto-21.0.3.9.1

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val commonSettings = Seq(
     "-deprecation",
     "-feature",
     "-unchecked",
-    "-release:8",
+    "-release:11",
     "-Xfatal-warnings"
   ),
   Test / testOptions ++= Seq(


### PR DESCRIPTION
See https://github.com/guardian/gha-scala-library-release-workflow/pull/36 - [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) has moved to _requiring_ projects to specify what version of Java they want to use to build, and this is expressed through an [`asdf`](https://asdf-vm.com/)-formatted `.tool-versions` file.

This allows individual projects to experiment with later (or even _earlier_) versions of Java if they wish, without requiring all other projects using `gha-scala-library-release-workflow` to upgrade their version of Java at the same time.

#### "But maybe we need to support older versions of Java!"

Note that, although this PR specifies Java 21 (the latest LTS release of Java, which apparently has several performance benefits) for the library _build_, the artifacts released by the project do not need to _require_ Java 21 - so long as the `scalacOptions` defined in the project's `build.sbt` includes a `-release` flag, we can specify that we want the artifacts to support some older version of Java (eg `-release:11` for Java 11).