### PR TITLE
Ignore failures in the test-reporter build step

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Test Report for Janus-App
         uses: dorny/test-reporter@31a54ee7ebcacc03a09ea97a7e5465a47b84aea5 # v1.9.1
         if: success() || failure() # run this step even if previous step failed
+        continue-on-error: true # this step fails when PRs are raised from forks, we don't mind!
         with:
           name: Janus-App Tests
           path: logs/test-reports/TEST-*.xml


### PR DESCRIPTION
## What is the purpose of this change?
The test reporter step does not work for PRs raised from forks. We don't mind about this, it's a nice-to-have!

Let's ignore those failures.
## What is the value of this change and how do we measure success?

This means contributions from outside DevX won't have their builds fail at the test-reporter step.

