### PR TITLE
add an 'auto-logout toggle' (take 2)

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -13,12 +13,15 @@
 
         <div class="row">
             <div class="logout-button">
-            <a href="https://signin.aws.amazon.com/oauth?Action=logout"
-               target="_blank"
-               class="waves-effect waves-light btn">
-                <i class="material-icons">exit_to_app</i>
-                logout
-            </a>
+                <span class="switch" title="Automatically logout before entering a new account's console">
+                    <label><span>Auto-logout</span><input id="auto_logout_switch" type="checkbox"><span class="lever"></span></label>
+                </span>
+                <a href="https://signin.aws.amazon.com/oauth?Action=logout"
+                   target="_blank"
+                   class="waves-effect waves-light btn">
+                    <i class="material-icons">exit_to_app</i>
+                    logout
+                </a>
             </div>
         </div>
 

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -279,4 +279,33 @@ jQuery(function($){
         }
     });
 
+    // auto-logout (preference persisted with local storage)
+    $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
+        const LOCAL_STORAGE_KEY__AUTO_LOGOUT = "autoLogout"
+        autoLogoutSwitchElement.checked = localStorage.getItem(LOCAL_STORAGE_KEY__AUTO_LOGOUT) === "true";
+        autoLogoutSwitchElement.onchange = (event) => {
+            autoLogoutSwitchElement.checked = event.target.checked;
+            localStorage.setItem(LOCAL_STORAGE_KEY__AUTO_LOGOUT, event.target.checked.toString());
+        };
+
+        $("a[href*='/console?permissionId=']").each(function(_, el){
+            el.onclick = (clickEvent) => {
+                if(autoLogoutSwitchElement.checked) {
+                    clickEvent.preventDefault();
+                    const targetHref = el.href;
+                    console.log("Attempting logout before navigating to", targetHref)
+                    const popup = window.open(
+                      "https://signin.aws.amazon.com/logout",
+                      "AWSLogoutPopup",
+                      "width=500, height=500, top=100, left=100, popup=true"
+                    );
+                    setTimeout(() => {
+                        popup.close();
+                        location.href = targetHref;
+                    }, 750);
+                }
+            }
+        });
+    });
+
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -17,7 +17,20 @@ main {
     vertical-align: -3px;
 }
 
-.btn, .btn-large {
+.switch label:has(> #auto_logout_switch) span {
+    margin-top: -2px;
+    font-size: 1rem;
+}
+
+.switch label:has(> #auto_logout_switch) .lever{
+    margin-left: 10px;
+}
+
+.switch label input[type=checkbox]:checked+.lever {
+    background-color: #efb57c;
+}
+
+.btn, .btn-large, .switch label input[type=checkbox]:checked+.lever:after{
     background-color: #f57c00;
 }
 


### PR DESCRIPTION
This **reattempts #439**, which was reverted in #445 because it doesn't work in FireFox [and Chrome in a few months] owing to [stricter policy w.r.t. SameSite attribute of cookies](https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/) and AWS cookies need to be present when hitting logout. This time we achieve the same end result with [`window.open(   )`](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) which is displayed for 0.75s before being closed and redirected (which should allow enough time for the logout to complete)...
![janus_auto_logout_popup](https://github.com/guardian/janus-app/assets/19289579/cf466b66-2e75-4d85-aa7e-a18a5d1264b9)

