### PR TITLE
add an 'auto-logout toggle' (take 3 - proper way)

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -13,12 +13,15 @@
 
         <div class="row">
             <div class="logout-button">
-            <a href="https://signin.aws.amazon.com/oauth?Action=logout"
-               target="_blank"
-               class="waves-effect waves-light btn">
-                <i class="material-icons">exit_to_app</i>
-                logout
-            </a>
+                <span class="switch" title="Automatically logout before entering a new account's console">
+                    <label><span>Auto-logout</span><input id="auto_logout_switch" type="checkbox"><span class="lever"></span></label>
+                </span>
+                <a href="https://signin.aws.amazon.com/oauth?Action=logout"
+                   target="_blank"
+                   class="waves-effect waves-light btn">
+                    <i class="material-icons">exit_to_app</i>
+                    logout
+                </a>
             </div>
         </div>
 

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -279,4 +279,16 @@ jQuery(function($){
         }
     });
 
+    // auto-logout (preference persisted via cookie, so server-side can see it when redirecting to federation endpoint)
+    $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
+        const COOKIE__AUTO_LOGOUT = "autoLogout"
+        autoLogoutSwitchElement.checked =
+          !!decodeURIComponent(document.cookie)
+          .split(";")
+          .find(_ => _.trim().startsWith(`${COOKIE__AUTO_LOGOUT}=true`));
+        autoLogoutSwitchElement.onchange = (event) => {
+            document.cookie = `${COOKIE__AUTO_LOGOUT}=${event.target.checked}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/`
+        };
+    });
+
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -17,7 +17,20 @@ main {
     vertical-align: -3px;
 }
 
-.btn, .btn-large {
+.switch label:has(> #auto_logout_switch) span {
+    margin-top: -2px;
+    font-size: 1rem;
+}
+
+.switch label:has(> #auto_logout_switch) .lever{
+    margin-left: 10px;
+}
+
+.switch label input[type=checkbox]:checked+.lever {
+    background-color: #efb57c;
+}
+
+.btn, .btn-large, .switch label input[type=checkbox]:checked+.lever:after{
     background-color: #f57c00;
 }
 


### PR DESCRIPTION
Looking to achieve the same as #439 and #447 were trying to do, but achieving it server-side, if toggle is active (persisted via cookie now, so server can see the preference on the request) [for AWS Console buttons] the server redirects to `https://us-east-1.signin.aws.amazon.com/oauth?Action=logout` with a `redirect_uri` query param containing the federated login link Janus would normally redirect to directly (see https://serverfault.com/a/1097528).

<img width="307" alt="image" src="https://github.com/guardian/janus-app/assets/19289579/684f6372-a294-43c5-bc90-7f211baea378">

**✅ TESTED the logout with `redirect_uri` approach manually** in the browser console... 
```javascript
location.href=`https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=${encodeURIComponent("https://us-east-1.signin.aws.amazon.com/federation?Action=login&SigninToken=REDACTED&Issuer=https%3A%2F%2Fjanus.gutools.co.uk&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F")}`
```
... obviously with `REDACTED` being a real token (which I got by observing/copying from the `federation` link via the Network tab of browser developer tools)