### PR TITLE
Auto logout support for console URLs

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -104,24 +104,28 @@ object Federation {
     autoLogoutUrl(url, autoLogout)
   }
 
-  /**
-   * Janus supports logging users out before redirecting them to the Console.
-   *
-   * If this setting is enabled we send the user to the console logout page, with their login URL as the
-   * post-logout redirect URL. This means AWS logs the user out of the console before sending them to log in
-   * with their temporary session.
-   *
-   * NOTE: us-east-1 is required in these URLs, as per https://serverfault.com/questions/985255/1097528#comment1469112_1097528
-   */
-  private[aws] def autoLogoutUrl(loginUrl: String, autoLogout: Boolean): String = {
+  /** Janus supports logging users out before redirecting them to the Console.
+    *
+    * If this setting is enabled we send the user to the console logout page,
+    * with their login URL as the post-logout redirect URL. This means AWS logs
+    * the user out of the console before sending them to log in with their
+    * temporary session.
+    *
+    * NOTE: us-east-1 is required in these URLs, as per
+    * https://serverfault.com/questions/985255/1097528#comment1469112_1097528
+    */
+  private[aws] def autoLogoutUrl(
+      loginUrl: String,
+      autoLogout: Boolean
+  ): String = {
     if (autoLogout) {
       s"https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=${URLEncoder.encode(
-        loginUrl.replace(
-          "https://signin.aws.amazon.com/",
-          "https://us-east-1.signin.aws.amazon.com/"
-        ),
-        "UTF-8"
-      )}"
+          loginUrl.replace(
+            "https://signin.aws.amazon.com/",
+            "https://us-east-1.signin.aws.amazon.com/"
+          ),
+          "UTF-8"
+        )}"
     } else {
       loginUrl
     }

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -11,6 +11,8 @@ import data.Policies
 import logic.Date
 import org.joda.time.{DateTime, DateTimeZone, Duration, Period}
 
+import java.net.URLEncoder
+
 object Federation {
 
   /** Credential/Console lease times. Defaults are used when user doesn't
@@ -88,16 +90,41 @@ object Federation {
     TemporaryCredentials(response.getCredentials)
   }
 
-  def loginUrl(
+  def generateLoginUrl(
       temporaryCredentials: TemporaryCredentials,
       host: String,
+      autoLogout: Boolean,
       sts: STS
   ): String = {
-    sts.loginUrl(
+    val url = sts.loginUrl(
       credentials = temporaryCredentials,
       consoleUrl = "https://console.aws.amazon.com/",
       issuerUrl = host
     )
+    autoLogoutUrl(url, autoLogout)
+  }
+
+  /**
+   * Janus supports logging users out before redirecting them to the Console.
+   *
+   * If this setting is enabled we send the user to the console logout page, with their login URL as the
+   * post-logout redirect URL. This means AWS logs the user out of the console before sending them to log in
+   * with their temporary session.
+   *
+   * NOTE: us-east-1 is required in these URLs, as per https://serverfault.com/questions/985255/1097528#comment1469112_1097528
+   */
+  private[aws] def autoLogoutUrl(loginUrl: String, autoLogout: Boolean): String = {
+    if (autoLogout) {
+      s"https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=${URLEncoder.encode(
+        loginUrl.replace(
+          "https://signin.aws.amazon.com/",
+          "https://us-east-1.signin.aws.amazon.com/"
+        ),
+        "UTF-8"
+      )}"
+    } else {
+      loginUrl
+    }
   }
 
   def credentials(federationToken: FederationToken): TemporaryCredentials = {

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -99,7 +99,12 @@ class Janus(
         Customisation.durationParams(request)
       )
       autoLogout = Customisation.autoLogoutPreference(request.cookies)
-      loginUrl = Federation.generateLoginUrl(credentials, host, autoLogout, stsClient)
+      loginUrl = Federation.generateLoginUrl(
+        credentials,
+        host,
+        autoLogout,
+        stsClient
+      )
     } yield {
       SeeOther(loginUrl)
         .withHeaders(CACHE_CONTROL -> "no-cache")
@@ -120,7 +125,12 @@ class Janus(
         Customisation.durationParams(request)
       )
       autoLogout = Customisation.autoLogoutPreference(request.cookies)
-      loginUrl = Federation.generateLoginUrl(credentials, host, autoLogout, stsClient)
+      loginUrl = Federation.generateLoginUrl(
+        credentials,
+        host,
+        autoLogout,
+        stsClient
+      )
     } yield {
       Ok(
         views.html.consoleUrl(

--- a/app/logic/Customisation.scala
+++ b/app/logic/Customisation.scala
@@ -2,7 +2,7 @@ package logic
 
 import models.{DisplayMode, Festive, Normal, Spooky}
 import org.joda.time.{DateTimeZone, Duration}
-import play.api.mvc.RequestHeader
+import play.api.mvc.{Cookies, RequestHeader}
 
 import scala.util.Try
 
@@ -30,5 +30,14 @@ object Customisation {
       case Spooky  => "purple"
       case Festive => "red"
     }
+  }
+
+  /**
+   * The auto-logout functionality is controlled by a UI toggle that sets a Cookie.
+   *
+   * This function extracts the preference from the cookie for use on the server.
+   */
+  def autoLogoutPreference(cookies: Cookies): Boolean = {
+    cookies.get("janus_auto_logout").exists(_.value == "1")
   }
 }

--- a/app/logic/Customisation.scala
+++ b/app/logic/Customisation.scala
@@ -32,11 +32,12 @@ object Customisation {
     }
   }
 
-  /**
-   * The auto-logout functionality is controlled by a UI toggle that sets a Cookie.
-   *
-   * This function extracts the preference from the cookie for use on the server.
-   */
+  /** The auto-logout functionality is controlled by a UI toggle that sets a
+    * Cookie.
+    *
+    * This function extracts the preference from the cookie for use on the
+    * server.
+    */
   def autoLogoutPreference(cookies: Cookies): Boolean = {
     cookies.get("janus_auto_logout").exists(_.value == "1")
   }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -13,12 +13,15 @@
 
         <div class="row">
             <div class="logout-button">
-            <a href="https://signin.aws.amazon.com/oauth?Action=logout"
-               target="_blank"
-               class="waves-effect waves-light btn">
-                <i class="material-icons">exit_to_app</i>
-                logout
-            </a>
+                <span class="switch" title="Automatically logout before entering a new account's console">
+                    <label><span>Auto-logout</span><input id="auto_logout_switch" type="checkbox"><span class="lever"></span></label>
+                </span>
+                <a href="https://signin.aws.amazon.com/oauth?Action=logout"
+                   target="_blank"
+                   class="waves-effect waves-light btn">
+                    <i class="material-icons">exit_to_app</i>
+                    logout
+                </a>
             </div>
         </div>
 

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -279,4 +279,16 @@ jQuery(function($){
         }
     });
 
+    // auto-logout (preference persisted via cookie, so server-side can see it when redirecting to federation endpoint)
+    $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
+        const COOKIE__AUTO_LOGOUT = "autoLogout"
+        autoLogoutSwitchElement.checked =
+          !!decodeURIComponent(document.cookie)
+          .split(";")
+          .find(_ => _.trim().startsWith(`${COOKIE__AUTO_LOGOUT}=true`));
+        autoLogoutSwitchElement.onchange = (event) => {
+            document.cookie = `${COOKIE__AUTO_LOGOUT}=${event.target.checked}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/`
+        };
+    });
+
 });

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -280,14 +280,16 @@ jQuery(function($){
     });
 
     // auto-logout (preference persisted via cookie, so server-side can see it when redirecting to federation endpoint)
+    // see also `Customisation.scala` for the function that extracts this cookie value
     $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
-        const COOKIE__AUTO_LOGOUT = "autoLogout"
+        const COOKIE__AUTO_LOGOUT = "janus_auto_logout"
         autoLogoutSwitchElement.checked =
           !!decodeURIComponent(document.cookie)
-          .split(";")
-          .find(_ => _.trim().startsWith(`${COOKIE__AUTO_LOGOUT}=true`));
+              .split(";")
+              .find(_ => $.trim(_) === `${COOKIE__AUTO_LOGOUT}=1`);
         autoLogoutSwitchElement.onchange = (event) => {
-            document.cookie = `${COOKIE__AUTO_LOGOUT}=${event.target.checked}; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/`
+            const isEnabled = event.target.checked ? "1" : "0";
+            document.cookie = `${COOKIE__AUTO_LOGOUT}=${isEnabled}; expires=Fri, 1 Jan 2038 23:59:59 GMT; path=/`
         };
     });
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -17,7 +17,20 @@ main {
     vertical-align: -3px;
 }
 
-.btn, .btn-large {
+.switch label:has(> #auto_logout_switch) span {
+    margin-top: -2px;
+    font-size: 1rem;
+}
+
+.switch label:has(> #auto_logout_switch) .lever{
+    margin-left: 10px;
+}
+
+.switch label input[type=checkbox]:checked+.lever {
+    background-color: #efb57c;
+}
+
+.btn, .btn-large, .switch label input[type=checkbox]:checked+.lever:after{
     background-color: #f57c00;
 }
 

--- a/test/aws/FederationTest.scala
+++ b/test/aws/FederationTest.scala
@@ -6,12 +6,14 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.scalactic.source
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.routing.sird.{QueryStringParameterExtractor, RequiredQueryStringParameter}
+import play.api.routing.sird.{
+  QueryStringParameterExtractor,
+  RequiredQueryStringParameter
+}
 import testutils.JodaTimeUtils
 
 import java.net.URLDecoder
 import java.nio.charset.Charset
-
 
 class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
   import Federation._
@@ -153,7 +155,9 @@ class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
     "if autoLogout is enabled" - {
       "the returned URL is for the console logout endpoint" in {
         val url = autoLogoutUrl(signinUrl, autoLogout = true)
-        url should startWith("https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&")
+        url should startWith(
+          "https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&"
+        )
       }
 
       "the provided URL is included (URL-encoded) in the redirect_uri GET parameter" - {
@@ -162,7 +166,9 @@ class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
           // https://serverfault.com/questions/985255/1097528#comment1469112_1097528
           val url = autoLogoutUrl(signinUrl, autoLogout = true)
           val redirectUri = extractRedirectUri(url)
-          redirectUri should startWith("https://us-east-1.signin.aws.amazon.com/")
+          redirectUri should startWith(
+            "https://us-east-1.signin.aws.amazon.com/"
+          )
         }
 
         "and the rest of the URL unchanged" in {
@@ -193,12 +199,15 @@ class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
   }
 
   // helper for testing the autoLogoutUrl functionality
-  private val RedirectUri = QueryStringParameterExtractor.required("redirect_uri")
-  private def extractRedirectUri(url: String)(implicit pos: source.Position): String = {
+  private val RedirectUri =
+    QueryStringParameterExtractor.required("redirect_uri")
+  private def extractRedirectUri(
+      url: String
+  )(implicit pos: source.Position): String = {
     new java.net.URL(url) match {
       case RedirectUri(redirectUri) => URLDecoder.decode(redirectUri, "UTF-8")
-      case result => fail(s"redirect_uri parameter not present on resulting URL $result")
+      case result =>
+        fail(s"redirect_uri parameter not present on resulting URL $result")
     }
   }
 }
-


### PR DESCRIPTION
This PR is an augmentation of the following. Unfortunately, this one is in a fork I do not have access to, so I've had to raise a duplicate PR and close that one.
https://github.com/guardian/janus-app/pull/448

Copying the information from that PR, with thanks to @twrichards:

------------------

Looking to achieve the same as #439 and #447 were trying to do, but achieving it server-side, if toggle is active (persisted via cookie now, so server can see the preference on the request) [for AWS Console buttons] the server redirects to `https://us-east-1.signin.aws.amazon.com/oauth?Action=logout` with a `redirect_uri` query param containing the federated login link Janus would normally redirect to directly (see https://serverfault.com/a/1097528).

<img width="307" alt="image" src="https://github.com/guardian/janus-app/assets/19289579/684f6372-a294-43c5-bc90-7f211baea378">

**✅ TESTED the logout with `redirect_uri` approach manually** in the browser console... 
```javascript
location.href=`https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=${encodeURIComponent("https://us-east-1.signin.aws.amazon.com/federation?Action=login&SigninToken=REDACTED&Issuer=https%3A%2F%2Fjanus.gutools.co.uk&Destination=https%3A%2F%2Fconsole.aws.amazon.com%2F")}`
```
... obviously with `REDACTED` being a real token (which I got by observing/copying from the `federation` link via the Network tab of browser developer tools)
