### PR TITLE
Fix the DB for local development

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -2,7 +2,6 @@ import aws.Clients
 import awscala.dynamodbv2.DynamoDB
 import com.amazonaws.regions.Regions
 import com.gu.googleauth.AuthAction
-import com.gu.janus.JanusConfig
 import com.typesafe.config.ConfigException
 import conf.Config
 import controllers._
@@ -32,7 +31,7 @@ class AppComponents(context: ApplicationLoader.Context)
   val dynamodDB =
     if (context.environment.mode == play.api.Mode.Prod)
       DynamoDB.at(Regions.getCurrentRegion)
-    else DynamoDB.local()
+    else Clients.localDb
 
   val janusData = Config.janusData(configuration)
 

--- a/app/aws/Clients.scala
+++ b/app/aws/Clients.scala
@@ -1,11 +1,15 @@
 package aws
 
+import awscala.Region
+import awscala.dynamodbv2.DynamoDB
 import awscala.sts.STS
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{
   AWSCredentialsProviderChain,
   InstanceProfileCredentialsProvider
 }
+
+import scala.annotation.nowarn
 
 object Clients {
   // local dev is in a separate profile name so it isn't overwritten when you obtain credentials using Janus
@@ -22,5 +26,15 @@ object Clients {
 
   lazy val stsClient: STS = {
     STS(credentialsProviderChain)
+  }
+
+  @nowarn("cat=deprecation")
+  def localDb: DynamoDB = {
+    val client =
+      DynamoDB("fakeMyKeyId", "fakeSecretAccessKey")(Region.default())
+    // this deprecated approach is required by the awscala helpers currently in use
+    // we suppress this warning, above
+    client.setEndpoint("http://localhost:8000")
+    client
   }
 }

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class AuditTrailDBTest extends AnyFreeSpec with Matchers {
 
   "test db stuff - use this to test DynamoDB stuff locally during development" - {
-    implicit val dynamoDB = DynamoDB.local()
+    implicit val dynamoDB: DynamoDB = Clients.localDb
 
     "insertion and querying" ignore {
       val table = AuditTrailDB.getTable()


### PR DESCRIPTION

## What is the purpose of this change?

Fixes the database when running the application locally.

## More detail

The helper library being used for DB access is not compatible with recent versions of DynamoDB loal. DynamoDB now verifies that access credentials have the right format, even for local development where they are not actually used. The library was using empty strings for the access key and secret, which did not pass validation.

This PR adds a utility for creating a valid DynamoDB client for local use, which is consumed from the server itself (in DEV mode) and the database integration tests.

## Deprecation suppression

Unfortunately, the code that sets up the local DB client also uses a deprecated method, so we suppress this deprecation warning for now. Fixing this properly will mean moving off AWScala, a job that we already know about.

