### PR TITLE
fix: explicitly install java/sbt in build and dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ts/fix-dependency-submission
   workflow_dispatch:
 jobs:
   dependency-graph:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,14 +1,25 @@
-name: Update Dependency Graph
+name: Update Dependency Graph for SBT
 on:
   push:
     branches:
-      - main # default branch of the project
+      - main
+      - ts/fix-dependency-submission
+  workflow_dispatch:
 jobs:
   dependency-graph:
-    name: Update Dependency Graph
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      - name: Checkout branch
+        id: checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install SBT
+        id: install
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - name: Submit dependencies
+        id: submit
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      - name: Log snapshot for user validation
+        id: validate
+        run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq
     permissions:
-        contents: write # this permission is needed to submit the dependency graph
+      contents: write

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,6 +11,12 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with: 
+          distribution: 'corretto'
+          java-version: '17'
       - name: Install SBT
         id: install
         uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -29,6 +29,8 @@ jobs:
           java-version: '11'
           cache: 'sbt'
 
+      - uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
 
       - name: Test Report for Janus-App


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

- installs sbt in the build workflow
- installs java and sbt in the dependency submission workflow and updates it to reflect how the dependency graph integrator-raised PRs look.

## What is the value of this change and how do we measure success?

Ubuntu latest no longer includes sbt, so it needs to be installed explicitly.

Tested the dependency submission action [before](https://github.com/guardian/janus-app/actions/runs/11210047264) and [after](https://github.com/guardian/janus-app/actions/runs/11347263637). The build action [failed on this pr](https://github.com/guardian/janus-app/actions/runs/11347333410) until the [commit to add sbt](https://github.com/guardian/janus-app/actions/runs/11347406629) was made.

- [x] TODO: remove this branch from the workflow
