### PR TITLE
document AwsAccount case class

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -42,7 +42,11 @@ object SupportACL {
 }
 
 case class AwsAccount(
+    /* The name of the account as you would like it to appear on Janus */
     name: String,
+    /** The name of the AWS profile to pass in via CLI. Should be relatively
+      * short, with no spaces
+      */
     authConfigKey: String
 )
 case class AwsAccountAccess(


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

When [trying to add a new account to janus](https://github.com/guardian/janus/pull/4447), I clicked through to the definition of AwsAccount to work out what the parameters were. Looking at the definition of this case class from there, it wasn't immediately obvious what they were supposed to mean/represent, so I've added a bit of documentation to clarify this for future users.

I'm not sure why it's called `authConfigKey`, but if there's no specific reason, we could maybe eliminate the second comment by renaming that param to `profileName`? Interested to hear people's thoughts.


## What is the value of this change and how do we measure success?

It's now more immediately clear what the parameters represent.

