### PR TITLE
Fix the GHA workflow version comment

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Java
         id: java
-        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.2.0
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with: 
           distribution: 'corretto'
           java-version: '17'


### PR DESCRIPTION
For some reason the GHA workflow version comment did not get properly updated in https://github.com/guardian/janus-app/pull/484.
