### PR TITLE
Document the AWS Account model fields

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -42,7 +42,24 @@ object SupportACL {
 }
 
 case class AwsAccount(
+    /** The display name for the AWS account - will appear on the Janus UI
+      */
     name: String,
+
+    /** This value is used for three purposes:
+      *
+      *   - the configuration key used to look up the role to assume, to
+      *     authenticate into this account
+      *   - forms part of the permission key used to uniquely identify a
+      *     permission (you'll see this in the URL of Janus console and
+      *     credentials requests)
+      *
+      * and most obviously to end users...
+      *
+      *   - the profile name for created Janus CLI sessions in that account
+      *     (assuming you use the standard mechanism of populating an AWS
+      *     profile with the provided name)
+      */
     authConfigKey: String
 )
 case class AwsAccountAccess(


### PR DESCRIPTION
When people set up a new AWS account in Janus it helps if people clearly understand what these fields are for. Because the `authConfigKey` field has multiple purposes, it helps to make this clear to the reader.

## What is the value of this change and how do we measure success?

It should be easier for people to onboard new AWS accounts in the future.

## Any additional notes?

Replaces https://github.com/guardian/janus-app/pull/479 in a fork that the current DevX/Security team members control.