### PR TITLE
Switch to guardian/setup-scala in GHA workflows

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -11,15 +11,8 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install Java
-        id: java
-        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
-        with: 
-          distribution: 'corretto'
-          java-version: '17'
-      - name: Install SBT
-        id: install
-        uses: sbt/setup-sbt@96cf3f09dc501acdad7807fffe97dba9fa0709be # v1.1.5
+      - name: Install Scala
+        uses: guardian/setup-scala@v1
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -23,13 +23,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
-        with:
-          distribution: 'corretto'
-          java-version: '11'
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@96cf3f09dc501acdad7807fffe97dba9fa0709be # v1.1.5
+      - name: Install Scala
+        uses: guardian/setup-scala@v1
 
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-21.0.3.9.1
+java corretto-21


### PR DESCRIPTION
This workflow installs Java and sbt, and is managed by us. Also updates the .tool-versions file, which was pointing at an out-of-date version of Java. We now only specify the major Java version, which is supported locally by `mise` (but not `asdf`).

