### PR TITLE
Migrate AWS Java SDK from v1 to v2 in config-tools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / organization := "com.gu"
 ThisBuild / licenses := Seq(License.Apache2)
 
 val awsSdkVersion = "1.12.780"
+val awsSdkV2Version = "2.30.10"
 val awscalaVersion = "0.9.2"
 val circeVersion = "0.14.10"
 val commonDependencies = Seq(
@@ -140,7 +141,7 @@ lazy val configTools = (project in file("configTools"))
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-config" % "0.10.1",
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
+      "software.amazon.awssdk" % "iam-policy-builder" % awsSdkV2Version
     ) ++ jacksonDatabindOverrides,
     name := "janus-config-tools",
     description := "Library for reading and writing Janus configuration files"

--- a/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
@@ -1,12 +1,18 @@
 package com.gu.janus.policy
 
-import awscala._
-import com.amazonaws.auth.policy.Statement.Effect
+import software.amazon.awssdk.policybuilder.iam.IamEffect.ALLOW
+import software.amazon.awssdk.policybuilder.iam.{
+  IamEffect,
+  IamPolicy,
+  IamStatement
+}
+
+import scala.jdk.CollectionConverters._
 
 object Statements {
 
-  def policy(statements: Seq[Statement]*): Policy = {
-    Policy(statements.flatten.distinct)
+  def policy(statements: Seq[IamStatement]*): IamPolicy = {
+    IamPolicy.builder().statements(statements.flatten.distinct.asJava).build()
   }
 
   private[policy] def enforceCorrectPath(path: String): Boolean = {
@@ -26,41 +32,40 @@ object Statements {
   def s3ReadAccess(
       bucketName: String,
       path: String,
-      effect: Effect = Effect.Allow
-  ): Seq[Statement] = {
+      effect: IamEffect = ALLOW
+  ): Seq[IamStatement] = {
     assert(
       enforceCorrectPath(path),
       s"Provided path should include leading slash and omit trailing slash ($bucketName :: $path)"
     )
     s3ConsoleEssentials(bucketName) :+
-      Statement(
-        effect,
-        Seq(Action("s3:Get*"), Action("s3:List*")),
-        Seq(
-          Resource(s"arn:aws:s3:::$bucketName$path"),
-          Resource(s"arn:aws:s3:::$bucketName${hierarchyPath(path)}")
-        )
-      )
+      IamStatement
+        .builder()
+        .effect(effect)
+        .addAction("s3:Get*")
+        .addAction("s3:List*")
+        .addResource(s"arn:aws:s3:::$bucketName$path")
+        .addResource(s"arn:aws:s3:::$bucketName${hierarchyPath(path)}")
+        .build()
   }
 
   /** Grants full access to a given path in an s3 bucket.
     *
     * Provided path should include leading slash and omit trailing slash.
     */
-  def s3FullAccess(bucketName: String, path: String): Seq[Statement] = {
+  def s3FullAccess(bucketName: String, path: String): Seq[IamStatement] = {
     assert(
       enforceCorrectPath(path),
       s"Provided path should include leading slash and omit trailing slash ($bucketName :: $path)"
     )
     s3ConsoleEssentials(bucketName) :+
-      Statement(
-        Effect.Allow,
-        Seq(Action("s3:*")),
-        Seq(
-          Resource(s"arn:aws:s3:::$bucketName$path"),
-          Resource(s"arn:aws:s3:::$bucketName${hierarchyPath(path)}")
-        )
-      )
+      IamStatement
+        .builder()
+        .effect(ALLOW)
+        .addAction("s3:*")
+        .addResource(s"arn:aws:s3:::$bucketName$path")
+        .addResource(s"arn:aws:s3:::$bucketName${hierarchyPath(path)}")
+        .build()
   }
 
   /** Grants permissions for basic s3 console access (list buckets and
@@ -68,42 +73,42 @@ object Statements {
     *
     * Typically bundled as part of other S3 permissions.
     */
-  def s3ConsoleEssentials(bucketName: String): Seq[Statement] = {
+  def s3ConsoleEssentials(bucketName: String): Seq[IamStatement] = {
     Seq(
-      Statement(
-        Effect.Allow,
-        Seq(
-          Action("s3:ListAllMyBuckets"),
-          Action("s3:GetBucketLocation")
-        ),
-        Seq(Resource("arn:aws:s3:::*"))
-      ),
-      Statement(
-        Effect.Allow,
-        Seq(Action("s3:ListBucket")),
-        Seq(Resource(s"arn:aws:s3:::$bucketName"))
-      )
+      IamStatement
+        .builder()
+        .effect(ALLOW)
+        .addAction("s3:ListAllMyBuckets")
+        .addAction("s3:GetBucketLocation")
+        .addResource("arn:aws:s3:::*")
+        .build(),
+      IamStatement
+        .builder()
+        .effect(ALLOW)
+        .addAction("s3:ListBucket")
+        .addResource(s"arn:aws:s3:::$bucketName")
+        .build()
     )
   }
 
   /** Policy statements that allow basic access to s3 bucket (console view and
     * object list)
     */
-  def s3BucketBasicAccessStatements(bucketName: String): Seq[Statement] = {
+  def s3BucketBasicAccessStatements(bucketName: String): Seq[IamStatement] = {
     Seq(
-      Statement(
-        Effect.Allow,
-        Seq(
-          Action("s3:ListAllMyBuckets"),
-          Action("s3:GetBucketLocation")
-        ),
-        Seq(Resource("arn:aws:s3:::*"))
-      ),
-      Statement(
-        Effect.Allow,
-        Seq(Action("s3:ListBucket")),
-        Seq(Resource(s"arn:aws:s3:::$bucketName"))
-      )
+      IamStatement
+        .builder()
+        .effect(ALLOW)
+        .addAction("s3:ListAllMyBuckets")
+        .addAction("s3:GetBucketLocation")
+        .addResource("arn:aws:s3:::*")
+        .build(),
+      IamStatement
+        .builder()
+        .effect(ALLOW)
+        .addAction("s3:ListBucket")
+        .addResource(s"arn:aws:s3:::$bucketName")
+        .build()
     )
   }
 }

--- a/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
@@ -1,8 +1,10 @@
 package com.gu.janus.policy
 
-import Statements._
+import com.gu.janus.policy.Statements._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
 
 class StatementsTest extends AnyFreeSpec with Matchers {
   "policy helper" - {
@@ -14,7 +16,7 @@ class StatementsTest extends AnyFreeSpec with Matchers {
 
     "deduplicates statements" in {
       val p = policy(statements: _*)
-      p.statements.distinct shouldBe p.statements
+      p.statements.asScala.distinct.asJava shouldBe p.statements
     }
   }
 


### PR DESCRIPTION
In the configTools subproject.
This project is built as a jar
and imported into the Janus config project
and the example project in this repo.

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?


## What is the value of this change and how do we measure success?


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->


## Any additional notes?

