### PR TITLE
Remove v1 AWS dynamodb client and awscala dynamo lib

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,6 +1,4 @@
 import aws.Clients
-import awscala.dynamodbv2.DynamoDB
-import com.amazonaws.regions.Regions
 import com.gu.googleauth.AuthAction
 import com.typesafe.config.ConfigException
 import conf.Config
@@ -13,6 +11,7 @@ import play.api.routing.Router
 import play.api.{ApplicationLoader, BuiltInComponentsFromContext, Logging}
 import play.filters.HttpFiltersComponents
 import router.Routes
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class AppComponents(context: ApplicationLoader.Context)
     extends BuiltInComponentsFromContext(context)
@@ -30,7 +29,7 @@ class AppComponents(context: ApplicationLoader.Context)
   val requiredGoogleGroups = Set(Config.twoFAGroup(configuration))
   val dynamodDB =
     if (context.environment.mode == play.api.Mode.Prod)
-      DynamoDB.at(Regions.getCurrentRegion)
+      DynamoDbClient.create()
     else Clients.localDb
 
   val janusData = Config.janusData(configuration)

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -11,6 +11,7 @@ import play.api.routing.Router
 import play.api.{ApplicationLoader, BuiltInComponentsFromContext, Logging}
 import play.filters.HttpFiltersComponents
 import router.Routes
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class AppComponents(context: ApplicationLoader.Context)
@@ -29,7 +30,7 @@ class AppComponents(context: ApplicationLoader.Context)
   val requiredGoogleGroups = Set(Config.twoFAGroup(configuration))
   val dynamodDB =
     if (context.environment.mode == play.api.Mode.Prod)
-      DynamoDbClient.create()
+      DynamoDbClient.builder().region(EU_WEST_1).build()
     else Clients.localDb
 
   val janusData = Config.janusData(configuration)

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -1,64 +1,131 @@
 package aws
 
-import awscala.dynamodbv2.{DynamoDBCondition, _}
 import com.gu.janus.model.AuditLog
 import logic.AuditTrail
 import org.joda.time.DateTime
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator.{
+  BETWEEN,
+  EQ
+}
+import software.amazon.awssdk.services.dynamodb.model._
+
+import scala.jdk.CollectionConverters._
 
 object AuditTrailDB {
   import AuditTrail._
 
   val tableName = "AuditTrail"
-  val secondaryIndexName = "AuditTrailByUser"
+  private val secondaryIndexName = "AuditTrailByUser"
 
-  def getTable()(implicit dynamoDB: DynamoDB): Table =
-    dynamoDB.table(tableName).get
+  def getTable()(implicit dynamoDB: DynamoDbClient): TableDescription = {
+    val request = DescribeTableRequest.builder().tableName(tableName).build()
+    dynamoDB.describeTable(request).table()
+  }
 
-  def insert(table: Table, auditLog: AuditLog)(implicit dynamoDB: DynamoDB) = {
+  def insert(table: TableDescription, auditLog: AuditLog)(implicit
+      dynamoDB: DynamoDbClient
+  ): Unit = {
+    val keySchema = table.keySchema().asScala
+    val partitionKeyName =
+      keySchema.find(_.keyType() == "HASH").get.attributeName()
+    val sortKeyName = keySchema.find(_.keyType() == "RANGE").get.attributeName()
     val (hash_project, range_date, attrs) = auditLogAttrs(auditLog)
-    table.put(hash_project, range_date, attrs: _*)
+    val partitionKey = partitionKeyName -> AttributeValue.fromS(hash_project)
+    val sortKey = sortKeyName -> AttributeValue.fromN(range_date.toString)
+    val item = (attrs.toMap.view
+      .mapValues(toAttribValue)
+      .toMap + partitionKey + sortKey).asJava
+    val request = PutItemRequest
+      .builder()
+      .tableName(tableName)
+      .item(item)
+      .build()
+    dynamoDB.putItem(request)
+  }
+
+  private def toAttribValue(value: Any): AttributeValue = {
+    value match {
+      case s: String  => AttributeValue.fromS(s)
+      case i: Int     => AttributeValue.fromN(i.toString)
+      case l: Long    => AttributeValue.fromN(l.toString)
+      case d: Double  => AttributeValue.fromN(d.toString)
+      case b: Boolean => AttributeValue.fromBool(b)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported type: ${value.getClass}"
+        )
+    }
   }
 
   def getAccountLogs(
-      table: Table,
+      table: TableDescription,
       account: String,
       startDate: DateTime,
       endDate: DateTime
-  )(implicit dynamoDB: DynamoDB): Seq[Either[String, AuditLog]] = {
-    dynamoDB
-      .query(
-        table,
-        keyConditions = Seq(
-          "j_account" -> DynamoDBCondition.eq(account),
-          "j_timestamp" -> DynamoDBCondition
-            .between(startDate.getMillis, endDate.getMillis)
-        ),
-        scanIndexForward = false
+  )(implicit dynamoDB: DynamoDbClient): Seq[Either[String, AuditLog]] = {
+    val request = QueryRequest
+      .builder()
+      .tableName(table.tableName())
+      .keyConditions(
+        Map(
+          "j_account" -> Condition
+            .builder()
+            .comparisonOperator(EQ)
+            .attributeValueList(AttributeValue.fromS(account))
+            .build(),
+          dateRangeCondition(startDate, endDate)
+        ).asJava
       )
-      .map(
-        _.attributes
-      ) map auditLogFromAttrs map logDbResultErrs map errorStrings
+      .scanIndexForward(false)
+      .build()
+    queryResult(dynamoDB, request)
   }
 
   def getUserLogs(
-      table: Table,
+      table: TableDescription,
       username: String,
       startDate: DateTime,
       endDate: DateTime
-  )(implicit dynamoDB: DynamoDB): Seq[Either[String, AuditLog]] = {
-    dynamoDB
-      .queryWithIndex(
-        table,
-        index = IndexName(secondaryIndexName),
-        keyConditions = Seq(
-          "j_username" -> DynamoDBCondition.eq(username),
-          "j_timestamp" -> DynamoDBCondition
-            .between(startDate.getMillis, endDate.getMillis)
-        ),
-        scanIndexForward = false
+  )(implicit dynamoDB: DynamoDbClient): Seq[Either[String, AuditLog]] = {
+    val request = QueryRequest
+      .builder()
+      .tableName(table.tableName())
+        .indexName(secondaryIndexName)
+      .keyConditions(
+        Map(
+          "j_username" -> Condition
+            .builder()
+            .comparisonOperator(EQ)
+            .attributeValueList(AttributeValue.fromS(username))
+            .build(),
+          dateRangeCondition(startDate, endDate)
+        ).asJava
       )
-      .map(
-        _.attributes
-      ) map auditLogFromAttrs map logDbResultErrs map errorStrings
+      .scanIndexForward(false)
+      .build()
+    queryResult(dynamoDB, request)
+  }
+
+  private def dateRangeCondition(startDate: DateTime, endDate: DateTime): (String, Condition) = {
+    "j_timestamp" -> Condition
+      .builder()
+      .comparisonOperator(BETWEEN)
+      .attributeValueList(
+        AttributeValue.fromN(startDate.getMillis.toString),
+        AttributeValue.fromN(endDate.getMillis.toString)
+      )
+      .build()
+  }
+
+  private def queryResult(dynamoDB: DynamoDbClient, request: QueryRequest): Seq[Either[String, AuditLog]] = {
+    val result = dynamoDB.query(request)
+    result
+      .items()
+      .asScala
+      .map(attrs => auditLogFromAttrs(attrs.asScala.toMap))
+      .map(logDbResultErrs)
+      .map(errorStrings)
+      .toSeq
   }
 }

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator.{
   BETWEEN,
   EQ
 }
+import software.amazon.awssdk.services.dynamodb.model.KeyType.{HASH, RANGE}
 import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.jdk.CollectionConverters._
@@ -28,8 +29,8 @@ object AuditTrailDB {
   ): Unit = {
     val keySchema = table.keySchema().asScala
     val partitionKeyName =
-      keySchema.find(_.keyType() == "HASH").get.attributeName()
-    val sortKeyName = keySchema.find(_.keyType() == "RANGE").get.attributeName()
+      keySchema.find(_.keyType() == HASH).get.attributeName()
+    val sortKeyName = keySchema.find(_.keyType() == RANGE).get.attributeName()
     val (hash_project, range_date, attrs) = auditLogAttrs(auditLog)
     val partitionKey = partitionKeyName -> AttributeValue.fromS(hash_project)
     val sortKey = sortKeyName -> AttributeValue.fromN(range_date.toString)

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -91,7 +91,7 @@ object AuditTrailDB {
     val request = QueryRequest
       .builder()
       .tableName(table.tableName())
-        .indexName(secondaryIndexName)
+      .indexName(secondaryIndexName)
       .keyConditions(
         Map(
           "j_username" -> Condition
@@ -107,7 +107,10 @@ object AuditTrailDB {
     queryResult(dynamoDB, request)
   }
 
-  private def dateRangeCondition(startDate: DateTime, endDate: DateTime): (String, Condition) = {
+  private def dateRangeCondition(
+      startDate: DateTime,
+      endDate: DateTime
+  ): (String, Condition) = {
     "j_timestamp" -> Condition
       .builder()
       .comparisonOperator(BETWEEN)
@@ -118,7 +121,10 @@ object AuditTrailDB {
       .build()
   }
 
-  private def queryResult(dynamoDB: DynamoDbClient, request: QueryRequest): Seq[Either[String, AuditLog]] = {
+  private def queryResult(
+      dynamoDB: DynamoDbClient,
+      request: QueryRequest
+  ): Seq[Either[String, AuditLog]] = {
     val result = dynamoDB.query(request)
     result
       .items()

--- a/app/aws/Clients.scala
+++ b/app/aws/Clients.scala
@@ -10,6 +10,7 @@ import software.amazon.awssdk.auth.credentials.{
   AwsBasicCredentials,
   StaticCredentialsProvider
 }
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import java.net.URI
@@ -39,6 +40,7 @@ object Clients {
           AwsBasicCredentials.create("fakeMyKeyId", "fakeSecretAccessKey")
         )
       )
+      .region(EU_WEST_1)
       .endpointOverride(URI.create("http://localhost:8000"))
       .build()
 }

--- a/app/aws/DynamoDB.scala
+++ b/app/aws/DynamoDB.scala
@@ -1,5 +1,0 @@
-package aws
-
-import awscala.dynamodbv2.SecondaryIndex
-
-case class IndexName(name: String) extends SecondaryIndex

--- a/app/controllers/Audit.scala
+++ b/app/controllers/Audit.scala
@@ -1,18 +1,18 @@
 package controllers
 
 import aws.AuditTrailDB
-import awscala.dynamodbv2._
 import com.gu.googleauth.AuthAction
 import com.gu.janus.model.JanusData
 import logic.Date
 import play.api.Logging
 import play.api.mvc.{AbstractController, AnyContent, ControllerComponents}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class Audit(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
     authAction: AuthAction[AnyContent]
-)(implicit dynamodDB: DynamoDB, assetsFinder: AssetsFinder)
+)(implicit dynamodDB: DynamoDbClient, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
 

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import aws.{AuditTrailDB, Federation}
-import awscala.dynamodbv2.DynamoDB
 import awscala.sts.{STS, TemporaryCredentials}
 import cats.syntax.all._
 import com.gu.googleauth.{AuthAction, UserIdentity}
@@ -10,10 +9,9 @@ import conf.Config
 import logic.PlayHelpers.splitQuerystringParam
 import logic.{AuditTrail, Customisation, Date, Favourites}
 import org.joda.time.{DateTime, DateTimeZone, Duration}
-import play.api.{Configuration, Logging}
 import play.api.mvc._
-
-import java.net.URLEncoder
+import play.api.{Configuration, Logging}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 class Janus(
     janusData: JanusData,
@@ -22,7 +20,7 @@ class Janus(
     host: String,
     stsClient: STS,
     configuration: Configuration
-)(implicit dynamodDB: DynamoDB, assetsFinder: AssetsFinder)
+)(implicit dynamodDB: DynamoDbClient, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
 

--- a/app/logic/AuditTrail.scala
+++ b/app/logic/AuditTrail.scala
@@ -1,11 +1,11 @@
 package logic
 
-import awscala.dynamodbv2.Attribute
 import com.gu.googleauth.UserIdentity
 import com.gu.janus.model.{ACL, AuditLog, JanusAccessType, Permission}
-import org.joda.time.{DateTime, DateTimeZone, Duration}
 import logic.UserAccess.{hasExplicitAccess, username}
+import org.joda.time.{DateTime, DateTimeZone, Duration}
 import play.api.Logging
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 object AuditTrail extends Logging {
   def createLog(
@@ -44,7 +44,7 @@ object AuditTrail extends Logging {
   /** Extract nice error message from db conversion.
     */
   def errorStrings(
-      error: Either[(String, Seq[Attribute]), AuditLog]
+      error: Either[(String, Map[String, AttributeValue]), AuditLog]
   ): Either[String, AuditLog] = {
     error.left.map(_._1)
   }
@@ -52,11 +52,11 @@ object AuditTrail extends Logging {
   /** Log detailed info for any DB result extraction errors.
     */
   def logDbResultErrs(
-      attempt: Either[(String, Seq[Attribute]), AuditLog]
-  ): Either[(String, Seq[Attribute]), AuditLog] = {
-    attempt.left.foreach { case (message, attrs) =>
-      val formattedAttrs = attrs.map { attr =>
-        s"${attr.name}: ${attr.value.toString}"
+      attempt: Either[(String, Map[String, AttributeValue]), AuditLog]
+  ): Either[(String, Map[String, AttributeValue]), AuditLog] = {
+    attempt.left.foreach { case (_, attrs) =>
+      val formattedAttrs = attrs.map { case (name, value) =>
+        s"$name: ${value.toString}"
       } mkString ", "
       logger.error(s"Failed to extract auditLog data $formattedAttrs")
     }
@@ -66,39 +66,39 @@ object AuditTrail extends Logging {
   /** (Attempt to) convert a database result into an audit log.
     */
   def auditLogFromAttrs(
-      attrs: Seq[Attribute]
-  ): Either[(String, Seq[Attribute]), AuditLog] = {
+      attrs: Map[String, AttributeValue]
+  ): Either[(String, Map[String, AttributeValue]), AuditLog] = {
     for {
       account <- attrs
-        .find("j_account" == _.name)
-        .flatMap(_.value.s)
+        .find { case (name, _) => "j_account" == name }
+        .flatMap { case (_, value) => Some(value.s()) }
         .toRight("Could not extract account" -> attrs)
       username <- attrs
-        .find("j_username" == _.name)
-        .flatMap(_.value.s)
+        .find { case (name, _) => "j_username" == name }
+        .flatMap { case (_, value) => Some(value.s()) }
         .toRight("Could not extract username" -> attrs)
       dateTime <- attrs
-        .find("j_timestamp" == _.name)
-        .flatMap(_.value.n)
+        .find { case (name, _) => "j_timestamp" == name }
+        .flatMap { case (_, value) => Some(value.n()) }
         .map(ts => new DateTime(ts.toLong, DateTimeZone.UTC))
         .toRight("Could not extract dateTime" -> attrs)
       duration <- attrs
-        .find("j_duration" == _.name)
-        .flatMap(_.value.n)
+        .find { case (name, _) => "j_duration" == name }
+        .flatMap { case (_, value) => Some(value.n()) }
         .map(d => new Duration(d.toLong * 1000))
         .toRight("Could not extract duration" -> attrs)
       accessLevel <- attrs
-        .find("j_accessLevel" == _.name)
-        .flatMap(_.value.s)
+        .find { case (name, _) => "j_accessLevel" == name }
+        .flatMap { case (_, value) => Some(value.s()) }
         .toRight("Could not extract accessLevel" -> attrs)
       accessType <- attrs
-        .find("j_accessType" == _.name)
-        .flatMap(_.value.s)
+        .find { case (name, _) => "j_accessType" == name }
+        .flatMap { case (_, value) => Some(value.s()) }
         .flatMap(JanusAccessType.fromString)
         .toRight("Could not extract accessType" -> attrs)
       external <- attrs
-        .find("j_external" == _.name)
-        .flatMap(attr => attr.value.n)
+        .find { case (name, _) => "j_external" == name }
+        .flatMap { case (_, value) => Some(value.n()) }
         .flatMap {
           case "0" => Some(false)
           case "1" => Some(true)

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / organization := "com.gu"
 ThisBuild / licenses := Seq(License.Apache2)
 
 val awsSdkVersion = "1.12.780"
+val awsSdkV2Version = "2.30.12"
 val awscalaVersion = "0.9.2"
 val circeVersion = "0.14.10"
 val commonDependencies = Seq(
@@ -17,7 +18,6 @@ val commonDependencies = Seq(
   "org.joda" % "joda-convert" % "3.0.1",
   "com.github.seratch" %% "awscala-iam" % awscalaVersion,
   "com.github.seratch" %% "awscala-sts" % awscalaVersion,
-  "com.github.seratch" %% "awscala-dynamodb" % awscalaVersion,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,
   "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
@@ -86,7 +86,7 @@ lazy val root = (project in file("."))
       "com.gu.play-googleauth" %% "play-v30" % "19.0.0",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
+      "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3" // scala-steward:off
     ) ++ jacksonDatabindOverrides
       ++ jacksonOverrides
@@ -139,8 +139,7 @@ lazy val configTools = (project in file("configTools"))
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "io.circe" %% "circe-config" % "0.10.1",
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion
+      "io.circe" %% "circe-config" % "0.10.1"
     ) ++ jacksonDatabindOverrides,
     name := "janus-config-tools",
     description := "Library for reading and writing Janus configuration files"

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -5,6 +5,7 @@ import org.joda.time.{DateTime, DateTimeZone, Duration}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.KeyType.{HASH, RANGE}
 import software.amazon.awssdk.services.dynamodb.model._
 
 class AuditTrailDBTest extends AnyFreeSpec with Matchers {
@@ -69,12 +70,12 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
         KeySchemaElement
           .builder()
           .attributeName("j_account")
-          .keyType("HASH")
+          .keyType(HASH)
           .build(),
         KeySchemaElement
           .builder()
           .attributeName("j_timestamp")
-          .keyType("RANGE")
+          .keyType(RANGE)
           .build()
       )
       .attributeDefinitions(
@@ -102,12 +103,12 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
             KeySchemaElement
               .builder()
               .attributeName("j_username")
-              .keyType("HASH")
+              .keyType(HASH)
               .build(),
             KeySchemaElement
               .builder()
               .attributeName("j_timestamp")
-              .keyType("RANGE")
+              .keyType(RANGE)
               .build()
           )
           .projection(Projection.builder().projectionType("ALL").build())

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -1,15 +1,16 @@
 package aws
 
-import awscala.dynamodbv2._
 import com.gu.janus.model.{AuditLog, JConsole}
 import org.joda.time.{DateTime, DateTimeZone, Duration}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
 
 class AuditTrailDBTest extends AnyFreeSpec with Matchers {
 
   "test db stuff - use this to test DynamoDB stuff locally during development" - {
-    implicit val dynamoDB: DynamoDB = Clients.localDb
+    implicit val dynamoDB: DynamoDbClient = Clients.localDb
 
     "insertion and querying" ignore {
       val table = AuditTrailDB.getTable()
@@ -58,33 +59,84 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
     * If you update this then be sure to also update the CloudFormation
     * template's definition.
     */
-  private[aws] def createTable()(implicit dynamoDB: DynamoDB) = {
-    val auditTable = Table(
-      name = AuditTrailDB.tableName,
-      hashPK = "j_account",
-      rangePK = Some("j_timestamp"),
-      attributes = Seq(
-        AttributeDefinition("j_account", AttributeType.String),
-        AttributeDefinition("j_timestamp", AttributeType.Number),
-        AttributeDefinition("j_username", AttributeType.String)
-      ),
-      globalSecondaryIndexes = Seq(
-        GlobalSecondaryIndex(
-          name = "AuditTrailByUser",
-          keySchema = Seq(
-            KeySchema("j_username", KeyType.Hash),
-            KeySchema("j_timestamp", KeyType.Range)
-          ),
-          projection = Projection(ProjectionType.All),
-          provisionedThroughput = ProvisionedThroughput(15, 15)
-        )
-      ),
-      provisionedThroughput = Some(ProvisionedThroughput(15, 15))
-    )
+  private[aws] def createTable()(implicit
+      dynamoDB: DynamoDbClient
+  ): CreateTableResponse = {
+    val auditTableCreateRequest = CreateTableRequest
+      .builder()
+      .tableName(AuditTrailDB.tableName)
+      .keySchema(
+        KeySchemaElement
+          .builder()
+          .attributeName("j_account")
+          .keyType("HASH")
+          .build(),
+        KeySchemaElement
+          .builder()
+          .attributeName("j_timestamp")
+          .keyType("RANGE")
+          .build()
+      )
+      .attributeDefinitions(
+        AttributeDefinition
+          .builder()
+          .attributeName("j_account")
+          .attributeType("S")
+          .build(),
+        AttributeDefinition
+          .builder()
+          .attributeName("j_timestamp")
+          .attributeType("N")
+          .build(),
+        AttributeDefinition
+          .builder()
+          .attributeName("j_username")
+          .attributeType("S")
+          .build()
+      )
+      .globalSecondaryIndexes(
+        GlobalSecondaryIndex
+          .builder()
+          .indexName("AuditTrailByUser")
+          .keySchema(
+            KeySchemaElement
+              .builder()
+              .attributeName("j_username")
+              .keyType("HASH")
+              .build(),
+            KeySchemaElement
+              .builder()
+              .attributeName("j_timestamp")
+              .keyType("RANGE")
+              .build()
+          )
+          .projection(Projection.builder().projectionType("ALL").build())
+          .provisionedThroughput(
+            ProvisionedThroughput
+              .builder()
+              .readCapacityUnits(15L)
+              .writeCapacityUnits(15L)
+              .build()
+          )
+          .build()
+      )
+      .provisionedThroughput(
+        ProvisionedThroughput
+          .builder()
+          .readCapacityUnits(15L)
+          .writeCapacityUnits(15L)
+          .build()
+      )
+      .build()
 
-    dynamoDB.createTable(auditTable)
+    dynamoDB.createTable(auditTableCreateRequest)
   }
-  private[aws] def destroyTable()(implicit dynamoDB: DynamoDB) = {
-    AuditTrailDB.getTable().destroy()
+
+  private[aws] def destroyTable()(implicit
+      dynamoDB: DynamoDbClient
+  ): DeleteTableResponse = {
+    val request =
+      DeleteTableRequest.builder().tableName(AuditTrailDB.tableName).build()
+    dynamoDB.deleteTable(request)
   }
 }

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -1,12 +1,12 @@
 package logic
 
-import awscala.dynamodbv2.{Attribute, AttributeValue}
 import com.gu.janus.model.{AuditLog, JConsole, JCredentials}
 import com.gu.janus.testutils.{HaveMatchers, RightValues}
 import org.joda.time.{DateTime, DateTimeZone, Duration}
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.{OptionValues}
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 
 import scala.language.implicitConversions
 
@@ -71,17 +71,14 @@ class AuditTrailTest
 
   "auditLogFromAttrs" - {
     "given valid attributes" - {
-      val attrs = Seq(
-        Attribute("j_account", AttributeValue(s = Some("account"), l = Nil)),
-        Attribute("j_username", AttributeValue(s = Some("username"), l = Nil)),
-        Attribute(
-          "j_timestamp",
-          AttributeValue(n = Some("1446650520000"), l = Nil)
-        ),
-        Attribute("j_duration", AttributeValue(n = Some("3600"), l = Nil)),
-        Attribute("j_accessLevel", AttributeValue(s = Some("dev"), l = Nil)),
-        Attribute("j_accessType", AttributeValue(s = Some("console"), l = Nil)),
-        Attribute("j_external", AttributeValue(n = Some("1"), l = Nil))
+      val attrs = Map(
+        "j_account" -> AttributeValue.fromS("account"),
+        "j_username" -> AttributeValue.fromS("username"),
+        "j_timestamp" -> AttributeValue.fromN("1446650520000"),
+        "j_duration" -> AttributeValue.fromN("3600"),
+        "j_accessLevel" -> AttributeValue.fromS("dev"),
+        "j_accessType" -> AttributeValue.fromS("console"),
+        "j_external" -> AttributeValue.fromN("1")
       )
 
       "extracts an audit log from valid attributes" in {
@@ -105,17 +102,14 @@ class AuditTrailTest
     }
 
     "when missing a required field" - {
-      val attrs = Seq(
+      val attrs = Map(
         // missing account
-        Attribute("j_username", AttributeValue(s = Some("username"), l = Nil)),
-        Attribute(
-          "j_timestamp",
-          AttributeValue(n = Some("1446650520000"), l = Nil)
-        ),
-        Attribute("j_duration", AttributeValue(n = Some("3600"), l = Nil)),
-        Attribute("j_accessLevel", AttributeValue(s = Some("dev"), l = Nil)),
-        Attribute("j_accessType", AttributeValue(s = Some("console"), l = Nil)),
-        Attribute("j_external", AttributeValue(n = Some("1"), l = Nil))
+        "j_username" -> AttributeValue.fromS("username"),
+        "j_timestamp" -> AttributeValue.fromN("1446650520000"),
+        "j_duration" -> AttributeValue.fromN("3600"),
+        "j_accessLevel" -> AttributeValue.fromS("dev"),
+        "j_accessType" -> AttributeValue.fromS("console"),
+        "j_external" -> AttributeValue.fromN("1")
       )
 
       "fails to extract an AccessLog record" in {


### PR DESCRIPTION
## What is the purpose of this change?
To remove the deprecated AWS v1 Dynamo DB client and replace it with v2.
This is very difficult to do without also removing the awscala Dynamo DB library, which depends on the AWS v1 client.

## What is the value of this change and how do we measure success?
Code is up to date and easier to patch in future.
Should still be able to:
* search the audit page
* see the audit page updating 
