### PR TITLE
Upgrade AWS STS client to v2

### DIFF
--- a/app/aws/Clients.scala
+++ b/app/aws/Clients.scala
@@ -1,17 +1,9 @@
 package aws
 
-import awscala.sts.STS
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{
-  AWSCredentialsProviderChain,
-  InstanceProfileCredentialsProvider
-}
-import software.amazon.awssdk.auth.credentials.{
-  AwsBasicCredentials,
-  StaticCredentialsProvider
-}
+import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.sts.StsClient
 
 import java.net.URI
 
@@ -21,16 +13,15 @@ object Clients {
   // different to the credentials you normally want to use
   val profileName = "janus"
 
-  lazy val credentialsProviderChain: AWSCredentialsProviderChain = {
-    new AWSCredentialsProviderChain(
-      InstanceProfileCredentialsProvider.getInstance(),
-      new ProfileCredentialsProvider(profileName)
-    )
-  }
+  private lazy val credentialsProviderChain: AwsCredentialsProviderChain =
+    AwsCredentialsProviderChain
+      .builder()
+      .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+      .addCredentialsProvider(ProfileCredentialsProvider.create(profileName))
+      .build()
 
-  lazy val stsClient: STS = {
-    STS(credentialsProviderChain)
-  }
+  lazy val stsClient: StsClient =
+    StsClient.builder().credentialsProvider(credentialsProviderChain).build()
 
   def localDb: DynamoDbClient =
     DynamoDbClient

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -1,13 +1,13 @@
 package aws
 
 import awscala.iam._
+import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.services.identitymanagement.model.GetRoleRequest
 import com.gu.janus.model.{AwsAccount, Permission}
 import data.Policies
 import logic.Date
 import org.joda.time.{DateTime, DateTimeZone, Duration, Period}
 import play.api.libs.json.Json
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.model.{
   AssumeRoleRequest,
@@ -171,15 +171,13 @@ object Federation {
       stsClient,
       Federation.awsMinimumSessionLength
     )
-    val sessionCredentials = AwsSessionCredentials.create(
-      creds.accessKeyId(),
-      creds.secretAccessKey(),
-      creds.sessionToken()
+    val sessionCredentials = awscala.Credentials(
+      creds.accessKeyId,
+      creds.secretAccessKey,
+      creds.sessionToken
     )
-    val iamClient = IAM(
-      sessionCredentials.accessKeyId(),
-      sessionCredentials.secretAccessKey()
-    )
+    val provider = new AWSStaticCredentialsProvider(sessionCredentials)
+    val iamClient = IAM(provider)
 
     // remove access from assumed role
     val roleName = getRoleName(roleArn)

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -7,6 +7,7 @@ import data.Policies
 import logic.Date
 import org.joda.time.{DateTime, DateTimeZone, Duration, Period}
 import play.api.libs.json.Json
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.model.{
   AssumeRoleRequest,
@@ -170,7 +171,15 @@ object Federation {
       stsClient,
       Federation.awsMinimumSessionLength
     )
-    val iamClient = IAM(creds.accessKeyId(), creds.secretAccessKey())
+    val sessionCredentials = AwsSessionCredentials.create(
+      creds.accessKeyId(),
+      creds.secretAccessKey(),
+      creds.sessionToken()
+    )
+    val iamClient = IAM(
+      sessionCredentials.accessKeyId(),
+      sessionCredentials.secretAccessKey()
+    )
 
     // remove access from assumed role
     val roleName = getRoleName(roleArn)

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -33,8 +33,7 @@ object Federation {
   private val awsMinimumSessionLength = 900.seconds
 
   private val signInUrl = "https://signin.aws.amazon.com/federation"
-  private val consoleUrl =
-    URLEncoder.encode("https://console.aws.amazon.com/", UTF_8)
+  private val consoleUrl = "https://console.aws.amazon.com/"
 
   /** Calculates the duration of a login session.
     *
@@ -104,8 +103,9 @@ object Federation {
     // See https://github.com/seratch/AWScala/blob/5d9012dec25eafc4275765bfc5cbe46c3ed37ba2/sts/src/main/scala/awscala/sts/STS.scala
     val token = URLEncoder.encode(signinToken(temporaryCredentials), UTF_8)
     val issuer = URLEncoder.encode(host, UTF_8)
+    val destination = URLEncoder.encode(consoleUrl, UTF_8)
     val url =
-      s"$signInUrl?Action=login&SigninToken=$token&Issuer=$issuer&Destination=$consoleUrl"
+      s"$signInUrl?Action=login&SigninToken=$token&Issuer=$issuer&Destination=$destination"
     autoLogoutUrl(url, autoLogout)
   }
 

--- a/app/controllers/RevokePermissions.scala
+++ b/app/controllers/RevokePermissions.scala
@@ -1,21 +1,21 @@
 package controllers
 
 import aws.Federation
-import awscala.sts.STS
 import com.gu.googleauth.AuthAction
 import com.gu.janus.model.JanusData
 import conf.Config
 import logic.Revocation
 import logic.UserAccess._
 import org.joda.time.{DateTime, DateTimeZone}
-import play.api.{Configuration, Logging}
 import play.api.mvc.{AbstractController, AnyContent, ControllerComponents}
+import play.api.{Configuration, Logging}
+import software.amazon.awssdk.services.sts.StsClient
 
 class RevokePermissions(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
     authAction: AuthAction[AnyContent],
-    stsClient: STS,
+    stsClient: StsClient,
     configuration: Configuration
 )(implicit assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)

--- a/app/logic/Date.scala
+++ b/app/logic/Date.scala
@@ -1,7 +1,14 @@
 package logic
 
 import models.{DisplayMode, Festive, Normal, Spooky}
-import org.joda.time._
+import org.joda.time.{
+  DateTime,
+  DateTimeConstants,
+  DateTimeZone,
+  Duration,
+  Interval,
+  Period
+}
 import org.joda.time.format.{
   DateTimeFormat,
   ISODateTimeFormat,
@@ -9,19 +16,24 @@ import org.joda.time.format.{
 }
 
 object Date {
-  val simpleDateFormatter =
+  private val simpleDateFormatter =
     DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
-  val dateTimeFormatter =
+  private val dateTimeFormatter =
     DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ss").withZoneUTC()
-  val timeFormatter = DateTimeFormat.forPattern("HH:mm:ss z").withZoneUTC()
-  val friendlyDateFormatter =
+  private val timeFormatter =
+    DateTimeFormat.forPattern("HH:mm:ss z").withZoneUTC()
+  private val friendlyDateFormatter =
     DateTimeFormat.forPattern("d MMMM, yyyy").withZoneUTC()
+
+  private def toJodaDateTime(instant: java.time.Instant): DateTime = {
+    new DateTime(instant.toEpochMilli, DateTimeZone.UTC)
+  }
 
   def formatDateTime(date: DateTime): String =
     dateTimeFormatter.print(date)
 
-  def formatTime(date: DateTime): String =
-    timeFormatter.print(date)
+  def formatTime(instant: java.time.Instant): String =
+    timeFormatter.print(toJodaDateTime(instant))
 
   def formatDate(date: DateTime): String = {
     friendlyDateFormatter.print(date)
@@ -31,15 +43,21 @@ object Date {
     simpleDateFormatter.print(date)
   }
 
+  def isoDateString(instant: java.time.Instant): String = {
+    ISODateTimeFormat.dateTime().print(toJodaDateTime(instant))
+  }
+
   def isoDateString(date: DateTime): String = {
     ISODateTimeFormat.dateTime().print(date)
   }
 
   def formatInterval(
-      date: DateTime,
+      instant: java.time.Instant,
       comparison: DateTime = DateTime.now
-  ): String =
+  ): String = {
+    val date = toJodaDateTime(instant)
     formatPeriod(new Interval(comparison, date).toPeriod)
+  }
 
   def formatDuration(duration: Duration): String =
     formatPeriod(duration.toPeriod)
@@ -88,7 +106,7 @@ object Date {
         simpleDateFormatter.parseDateTime(dateStr)
       }
     } catch {
-      case e: IllegalArgumentException => None
+      case _: IllegalArgumentException => None
     }
   }
 

--- a/app/logic/ViewHelpers.scala
+++ b/app/logic/ViewHelpers.scala
@@ -1,11 +1,12 @@
 package logic
 
 import com.gu.janus.model.AwsAccount
+import software.amazon.awssdk.services.sts.model.Credentials
 
 object ViewHelpers {
   // created as Scala function to make it easier to control whitespace
   def shellCredentials(
-      accountsCredentials: List[(AwsAccount, awscala.sts.TemporaryCredentials)]
+      accountsCredentials: List[(AwsAccount, Credentials)]
   ): String = {
     (for {
       (account, credentials) <- accountsCredentials

--- a/app/views/consoleUrl.scala.html
+++ b/app/views/consoleUrl.scala.html
@@ -1,8 +1,8 @@
-@import awscala.sts.TemporaryCredentials
+@import software.amazon.awssdk.services.sts.model.Credentials
 @import com.gu.googleauth.UserIdentity
 @import com.gu.janus.model.JanusData
 
-@(url: String, accountName: String, credentials: TemporaryCredentials, user: UserIdentity, janusData: JanusData)(implicit assetsFinder: AssetsFinder)
+@(url: String, accountName: String, credentials: Credentials, user: UserIdentity, janusData: JanusData)(implicit assetsFinder: AssetsFinder)
 
 @import logic.Date
 

--- a/app/views/credentials.scala.html
+++ b/app/views/credentials.scala.html
@@ -1,9 +1,9 @@
 @import com.gu.googleauth.UserIdentity
 @import com.gu.janus.model.{AwsAccount, JanusData}
-@import awscala.sts.TemporaryCredentials
+@import software.amazon.awssdk.services.sts.model.Credentials
+@import java.time.Instant
 
-
-@(expiry: awscala.DateTime, accountsCredentials: List[(AwsAccount, TemporaryCredentials)], user: UserIdentity, janusData: JanusData)(implicit assetsFinder: AssetsFinder)
+@(expiry: Instant, accountsCredentials: List[(AwsAccount, Credentials)], user: UserIdentity, janusData: JanusData)(implicit assetsFinder: AssetsFinder)
 
 @import logic.Date
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,6 @@ val commonDependencies = Seq(
   "joda-time" % "joda-time" % "2.13.0",
   "org.joda" % "joda-convert" % "3.0.1",
   "com.github.seratch" %% "awscala-iam" % awscalaVersion,
-  "com.github.seratch" %% "awscala-sts" % awscalaVersion,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,
   "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
@@ -85,7 +84,7 @@ lazy val root = (project in file("."))
       filters,
       "com.gu.play-googleauth" %% "play-v30" % "19.0.0",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
+      "software.amazon.awssdk" % "sts" % awsSdkV2Version,
       "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3" // scala-steward:off
     ) ++ jacksonDatabindOverrides

--- a/test/logic/ViewHelpersTest.scala
+++ b/test/logic/ViewHelpersTest.scala
@@ -1,22 +1,35 @@
 package logic
 
 import fixtures.Fixtures._
-import awscala.sts.TemporaryCredentials
-import org.joda.time.DateTime
-import ViewHelpers.shellCredentials
+import logic.ViewHelpers.shellCredentials
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.sts.model.Credentials
+
+import java.time.Instant
 
 class ViewHelpersTest extends AnyFreeSpec with Matchers {
+
+  private def mkCredentials(
+      accessKeyId: String,
+      secretAccessKey: String,
+      sessionToken: String
+  ) =
+    Credentials
+      .builder()
+      .accessKeyId(accessKeyId)
+      .secretAccessKey(secretAccessKey)
+      .sessionToken(sessionToken)
+      .expiration(Instant.now())
+      .build()
 
   "shellCredentials" - {
     "for a single account" - {
       val creds = List(
-        fooAct -> TemporaryCredentials(
+        fooAct -> mkCredentials(
           "foo-key",
           "foo-secret",
-          "foo-token",
-          DateTime.now()
+          "foo-token"
         )
       )
 
@@ -52,17 +65,15 @@ class ViewHelpersTest extends AnyFreeSpec with Matchers {
 
     "for multiple accounts" - {
       val multiCreds = List(
-        fooAct -> TemporaryCredentials(
+        fooAct -> mkCredentials(
           "foo-key",
           "foo-secret",
-          "foo-token",
-          DateTime.now()
+          "foo-token"
         ),
-        barAct -> TemporaryCredentials(
+        barAct -> mkCredentials(
           "bar-key",
           "bar-secret",
-          "bar-token",
-          DateTime.now()
+          "bar-token"
         )
       )
 

--- a/test/logic/ViewHelpersTest.scala
+++ b/test/logic/ViewHelpersTest.scala
@@ -10,27 +10,16 @@ import java.time.Instant
 
 class ViewHelpersTest extends AnyFreeSpec with Matchers {
 
-  private def mkCredentials(
-      accessKeyId: String,
-      secretAccessKey: String,
-      sessionToken: String
-  ) =
-    Credentials
-      .builder()
-      .accessKeyId(accessKeyId)
-      .secretAccessKey(secretAccessKey)
-      .sessionToken(sessionToken)
-      .expiration(Instant.now())
-      .build()
-
   "shellCredentials" - {
     "for a single account" - {
       val creds = List(
-        fooAct -> mkCredentials(
-          "foo-key",
-          "foo-secret",
-          "foo-token"
-        )
+        fooAct -> Credentials
+          .builder()
+          .accessKeyId("foo-key")
+          .secretAccessKey("foo-secret")
+          .sessionToken("foo-token")
+          .expiration(Instant.now())
+          .build()
       )
 
       "includes provided key" in {
@@ -65,16 +54,20 @@ class ViewHelpersTest extends AnyFreeSpec with Matchers {
 
     "for multiple accounts" - {
       val multiCreds = List(
-        fooAct -> mkCredentials(
-          "foo-key",
-          "foo-secret",
-          "foo-token"
-        ),
-        barAct -> mkCredentials(
-          "bar-key",
-          "bar-secret",
-          "bar-token"
-        )
+        fooAct -> Credentials
+          .builder()
+          .accessKeyId("foo-key")
+          .secretAccessKey("foo-secret")
+          .sessionToken("foo-token")
+          .expiration(Instant.now())
+          .build(),
+        barAct -> Credentials
+          .builder()
+          .accessKeyId("bar-key")
+          .secretAccessKey("bar-secret")
+          .sessionToken("bar-token")
+          .expiration(Instant.now())
+          .build()
       )
 
       "puts leading space on all commands to exclude from bash history" in {


### PR DESCRIPTION
## What is the purpose of this change?
To remove the deprecated AWS v1 STS client and replace it with v2.  
And to remove the awscala STS library which has a dependence on the v1 client.

## What is the value of this change and how do we measure success?
Code is up to date and easier to patch in future.
Should still be able to:
* get temporary credentials to sign in to the AWS console
* get temporary credentials to access AWS locally
* have temporary credentials that expire at the expected time
* revoke access to an account for credentials created before a threshold datetime

## Any additional notes?
This is part of a series of PRs to upgrade AWS clients to v2.
See also:
* #500 
