### PR TITLE
Remove logout to support aws multiple console sessions

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -93,42 +93,13 @@ object Federation {
   def generateLoginUrl(
       temporaryCredentials: TemporaryCredentials,
       host: String,
-      autoLogout: Boolean,
       sts: STS
   ): String = {
-    val url = sts.loginUrl(
+    sts.loginUrl(
       credentials = temporaryCredentials,
       consoleUrl = "https://console.aws.amazon.com/",
       issuerUrl = host
     )
-    autoLogoutUrl(url, autoLogout)
-  }
-
-  /** Janus supports logging users out before redirecting them to the Console.
-    *
-    * If this setting is enabled we send the user to the console logout page,
-    * with their login URL as the post-logout redirect URL. This means AWS logs
-    * the user out of the console before sending them to log in with their
-    * temporary session.
-    *
-    * NOTE: us-east-1 is required in these URLs, as per
-    * https://serverfault.com/questions/985255/1097528#comment1469112_1097528
-    */
-  private[aws] def autoLogoutUrl(
-      loginUrl: String,
-      autoLogout: Boolean
-  ): String = {
-    if (autoLogout) {
-      s"https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=${URLEncoder.encode(
-          loginUrl.replace(
-            "https://signin.aws.amazon.com/",
-            "https://us-east-1.signin.aws.amazon.com/"
-          ),
-          "UTF-8"
-        )}"
-    } else {
-      loginUrl
-    }
   }
 
   def credentials(federationToken: FederationToken): TemporaryCredentials = {

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -96,11 +96,9 @@ class Janus(
         JConsole,
         Customisation.durationParams(request)
       )
-      autoLogout = Customisation.autoLogoutPreference(request.cookies)
       loginUrl = Federation.generateLoginUrl(
         credentials,
         host,
-        autoLogout,
         stsClient
       )
     } yield {
@@ -122,11 +120,9 @@ class Janus(
         JConsole,
         Customisation.durationParams(request)
       )
-      autoLogout = Customisation.autoLogoutPreference(request.cookies)
       loginUrl = Federation.generateLoginUrl(
         credentials,
         host,
-        autoLogout,
         stsClient
       )
     } yield {

--- a/app/logic/Customisation.scala
+++ b/app/logic/Customisation.scala
@@ -2,7 +2,7 @@ package logic
 
 import models.{DisplayMode, Festive, Normal, Spooky}
 import org.joda.time.{DateTimeZone, Duration}
-import play.api.mvc.{Cookies, RequestHeader}
+import play.api.mvc.RequestHeader
 
 import scala.util.Try
 
@@ -30,15 +30,5 @@ object Customisation {
       case Spooky  => "purple"
       case Festive => "red"
     }
-  }
-
-  /** The auto-logout functionality is controlled by a UI toggle that sets a
-    * Cookie.
-    *
-    * This function extracts the preference from the cookie for use on the
-    * server.
-    */
-  def autoLogoutPreference(cookies: Cookies): Boolean = {
-    cookies.get("janus_auto_logout").exists(_.value == "1")
   }
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -10,18 +10,6 @@
 @main("Your permissions", Some(user), janusData, displayMode) {
     <div class="container">
         <h1 class="header orange-text hide">Your permissions</h1>
-
-        <div class="row">
-            <div class="logout-button">
-                <a href="https://signin.aws.amazon.com/oauth?Action=logout"
-                   target="_blank"
-                   class="waves-effect waves-light btn">
-                    <i class="material-icons">exit_to_app</i>
-                    logout
-                </a>
-            </div>
-        </div>
-
         <div class="index-main__container">
             @form(routes.Janus.favourite()) {
                 @CSRF.formField

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -13,9 +13,6 @@
 
         <div class="row">
             <div class="logout-button">
-                <span class="switch" title="Automatically logout before entering a new account's console">
-                    <label><span>Auto-logout</span><input id="auto_logout_switch" type="checkbox"><span class="lever"></span></label>
-                </span>
                 <a href="https://signin.aws.amazon.com/oauth?Action=logout"
                    target="_blank"
                    class="waves-effect waves-light btn">

--- a/public/javascripts/janus.js
+++ b/public/javascripts/janus.js
@@ -279,18 +279,10 @@ jQuery(function($){
         }
     });
 
-    // auto-logout (preference persisted via cookie, so server-side can see it when redirecting to federation endpoint)
-    // see also `Customisation.scala` for the function that extracts this cookie value
-    $("#auto_logout_switch").each(function(_, autoLogoutSwitchElement){
-        const COOKIE__AUTO_LOGOUT = "janus_auto_logout"
-        autoLogoutSwitchElement.checked =
-          !!decodeURIComponent(document.cookie)
-              .split(";")
-              .find(_ => $.trim(_) === `${COOKIE__AUTO_LOGOUT}=1`);
-        autoLogoutSwitchElement.onchange = (event) => {
-            const isEnabled = event.target.checked ? "1" : "0";
-            document.cookie = `${COOKIE__AUTO_LOGOUT}=${isEnabled}; expires=Fri, 1 Jan 2038 23:59:59 GMT; path=/`
-        };
-    });
-
+    {
+        // disable old auto-logout cookie to tidy up
+        // this can be removed in the near future, when this cookie will have been cleared out of colleague's browsers
+        const COOKIE__AUTO_LOGOUT = "janus_auto_logout";
+        document.cookie = `${COOKIE__AUTO_LOGOUT}=; expires=Thu, 01 Jan 1970 12:00:00 UTC; path=/`;
+    }
 });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -17,15 +17,6 @@ main {
     vertical-align: -3px;
 }
 
-.switch label:has(> #auto_logout_switch) span {
-    margin-top: -2px;
-    font-size: 1rem;
-}
-
-.switch label:has(> #auto_logout_switch) .lever{
-    margin-left: 10px;
-}
-
 .switch label input[type=checkbox]:checked+.lever {
     background-color: #efb57c;
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -39,12 +39,7 @@ main {
 }
 
 .index-main__container {
-    padding-top: 10px;
-}
-
-.logout-button {
-    padding: 20px 10px 0px;
-    float: right;
+    padding-top: 30px;
 }
 
 .controls__hero {

--- a/test/aws/FederationTest.scala
+++ b/test/aws/FederationTest.scala
@@ -149,41 +149,6 @@ class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
     }
   }
 
-  "autoLogoutUrl" - {
-    val signinUrl = "https://signin.aws.amazon.com/path/to/resource?foo=bar"
-
-    "if autoLogout is enabled" - {
-      "the returned URL is for the console logout endpoint" in {
-        val url = autoLogoutUrl(signinUrl, autoLogout = true)
-        url should startWith(
-          "https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&"
-        )
-      }
-
-      "the provided URL is included (URL-encoded) in the redirect_uri GET parameter" - {
-        "with its hostname changed to point to us-east-1" in {
-          // Note: at time of writing the use of us-east-1 is required, so we enforce it here
-          // https://serverfault.com/questions/985255/1097528#comment1469112_1097528
-          val url = autoLogoutUrl(signinUrl, autoLogout = true)
-          val redirectUri = extractRedirectUri(url)
-          redirectUri should startWith(
-            "https://us-east-1.signin.aws.amazon.com/"
-          )
-        }
-
-        "and the rest of the URL unchanged" in {
-          val url = autoLogoutUrl(signinUrl, autoLogout = true)
-          val redirectUri = extractRedirectUri(url)
-          redirectUri should endWith("/path/to/resource?foo=bar")
-        }
-      }
-    }
-
-    "returns the provided URL unchanged if autoLogout is not enabled" in {
-      autoLogoutUrl(signinUrl, autoLogout = false) shouldEqual signinUrl
-    }
-  }
-
   "getRoleName" - {
     "fetches role name from example" in {
       getRoleName(


### PR DESCRIPTION
## What is the purpose of this change?

Makes Janus compatible with the new multi-login support in the AWS console. The existing logout (and auto-logout) functionality exists to support users' ability to easily switch between AWS accounts with Janus, but the ability to crteate multiple concurrent AWS console logins means this is no longer required.

We now encourage users to turn on AWS' multi-session support, and remove the now redundant (and broken) login functionality from Janus. Users obtain AWS access from Janus as before, and can now manage their sessions directly from the AWS console via the drop-down at the top right.

## What is the value of this change and how do we measure success?

Our colleagues will be able to use Janus to seamlessly log into multiple AWS accounts.

## Images

This shows how to enable multi-session support in the AWS console, using the drop-down in the top right of the AWS Console. Users need to individually enable this for themselves:

<img width="310" alt="enable-aws-multi-session" src="https://github.com/user-attachments/assets/b4e2b3da-247f-4239-b4c6-8b91adcd1667" />

and here it is in action:

<img width="639" alt="aws-multi-accounts" src="https://github.com/user-attachments/assets/c2804077-53bc-4e69-b81a-a504f18df9fb" />

Users can now switch between sessions, and log out of all/specific sessions from the AWS console.

## Any additional notes?

I've already tested that the multi-session functionality works without auto-logout enabled, this change tjust removes that feature. We'll check this carefully post-deploy, and roll back if required.
