### PR TITLE
Upgrade AWS IAM v1 client to v2

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -152,6 +152,8 @@ object Federation {
       .builder()
       .roleName(roleName)
       .policyName("janus-role-revocation-policy")
+      //           ^
+      // this name should match policy in cloudformation/federation.template.yaml
       .policyDocument(revocationPolicyDocument)
       .build()
     iamClient.putRolePolicy(roleRevocationPolicy)

--- a/app/data/Policies.scala
+++ b/app/data/Policies.scala
@@ -1,7 +1,7 @@
 package data
 
-import awscala._
 import com.gu.janus.model.{AwsAccount, Permission}
+import com.gu.janus.policy.Iam._
 
 object Policies {
   val revokeAccess = Policy(

--- a/build.sbt
+++ b/build.sbt
@@ -8,15 +8,12 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 ThisBuild / organization := "com.gu"
 ThisBuild / licenses := Seq(License.Apache2)
 
-val awsSdkVersion = "1.12.781"
-val awsSdkV2Version = "2.30.20"
-val awscalaVersion = "0.9.2"
+val awsSdkVersion = "2.30.20"
 val circeVersion = "0.14.10"
 val commonDependencies = Seq(
   "org.typelevel" %% "cats-core" % "2.12.0",
   "joda-time" % "joda-time" % "2.13.0",
   "org.joda" % "joda-convert" % "3.0.1",
-  "com.github.seratch" %% "awscala-iam" % awscalaVersion,
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,
   "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
@@ -83,9 +80,9 @@ lazy val root = (project in file("."))
       ws,
       filters,
       "com.gu.play-googleauth" %% "play-v30" % "19.0.0",
-      "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
-      "software.amazon.awssdk" % "sts" % awsSdkV2Version,
-      "software.amazon.awssdk" % "dynamodb" % awsSdkV2Version,
+      "software.amazon.awssdk" % "iam" % awsSdkVersion,
+      "software.amazon.awssdk" % "sts" % awsSdkVersion,
+      "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3" // scala-steward:off
     ) ++ jacksonDatabindOverrides
       ++ jacksonOverrides

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -1,6 +1,7 @@
 package com.gu.janus.model
 
-import awscala.Policy
+import com.gu.janus.policy.Iam.Policy
+import io.circe.syntax.EncoderOps
 import org.joda.time._
 
 case class JanusData(
@@ -87,7 +88,7 @@ object Permission {
       policy: Policy,
       shortTerm: Boolean = false
   ): Permission = {
-    Permission(account, label, description, policy.asJson, shortTerm)
+    Permission(account, label, description, policy.asJson.noSpaces, shortTerm)
   }
 }
 

--- a/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
@@ -73,12 +73,12 @@ object Iam {
         .groupBy(_.typeName)
         .view
         .mapValues(conditions =>
-          Json.obj(
+          Json.fromFields(
             conditions.map(condition =>
               condition.key -> Json.fromValues(
                 condition.conditionValues.map(Json.fromString)
               )
-            ): _*
+            )
           )
         )
         .toMap

--- a/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
@@ -40,13 +40,6 @@ object Iam {
   )
 
   case class Principal(id: String, provider: String)
-  object Principal {
-    implicit val encoder: Encoder[Principal] = Encoder.instance { principal =>
-      Json.obj(
-        principal.provider -> Json.fromString(principal.id)
-      )
-    }
-  }
 
   case class Statement(
       effect: Effect,

--- a/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
@@ -38,17 +38,6 @@ object Iam {
       typeName: String,
       conditionValues: Seq[String]
   )
-  object Condition {
-    implicit val encoder: Encoder[Condition] = Encoder.instance { condition =>
-      Json.obj(
-        condition.typeName -> Json.obj(
-          condition.key -> Json.fromValues(
-            condition.conditionValues.map(Json.fromString)
-          )
-        )
-      )
-    }
-  }
 
   case class Principal(id: String, provider: String)
   object Principal {

--- a/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
@@ -1,0 +1,148 @@
+package com.gu.janus.policy
+
+import io.circe.syntax._
+import io.circe.{Encoder, Json, JsonObject}
+
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+
+/** This models the AWS IAM policy types and subtypes.
+  *
+  * See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html
+  * for the logic of the Json encoding.
+  */
+object Iam {
+
+  sealed trait Effect
+  object Effect {
+    case object Allow extends Effect
+    case object Deny extends Effect
+
+    implicit val encoder: Encoder[Effect] = Encoder.instance {
+      case Allow => Json.fromString("Allow")
+      case Deny  => Json.fromString("Deny")
+    }
+  }
+
+  case class Action(name: String)
+  object Action {
+    implicit val encoder: Encoder[Action] = Encoder[String].contramap(_.name)
+  }
+
+  case class Resource(id: String)
+  object Resource {
+    implicit val encoder: Encoder[Resource] = Encoder[String].contramap(_.id)
+  }
+
+  case class Condition(
+      key: String,
+      typeName: String,
+      conditionValues: Seq[String]
+  )
+  object Condition {
+    implicit val encoder: Encoder[Condition] = Encoder.instance { condition =>
+      Json.obj(
+        condition.typeName -> Json.obj(
+          condition.key -> Json.fromValues(
+            condition.conditionValues.map(Json.fromString)
+          )
+        )
+      )
+    }
+  }
+
+  case class Principal(id: String, provider: String)
+  object Principal {
+    implicit val encoder: Encoder[Principal] = Encoder.instance { principal =>
+      Json.obj(
+        principal.provider -> Json.fromString(principal.id)
+      )
+    }
+  }
+
+  case class Statement(
+      effect: Effect,
+      actions: Seq[Action],
+      resources: Seq[Resource],
+      id: Option[String] = None,
+      conditions: Seq[Condition] = Nil,
+      principals: Seq[Principal] = Nil
+  )
+  object Statement {
+    private def conditionsAsJson(conditions: Seq[Condition]): Json = {
+      val mergedConditions = conditions
+        .groupBy(_.typeName)
+        .view
+        .mapValues(conditions =>
+          Json.obj(
+            conditions.map(condition =>
+              condition.key -> Json.fromValues(
+                condition.conditionValues.map(Json.fromString)
+              )
+            ): _*
+          )
+        )
+        .toMap
+      Json.fromJsonObject(JsonObject.fromMap(mergedConditions))
+    }
+
+    private def principalsAsJson(principals: Seq[Principal]): Json = {
+      val principalMap = principals
+        .groupBy(_.provider)
+        .view
+        .mapValues(principals =>
+          Json.fromValues(
+            principals.map(p => Json.fromString(p.id))
+          )
+        )
+        .toMap
+      Json.fromJsonObject(JsonObject.fromMap(principalMap))
+    }
+
+    implicit val encoder: Encoder[Statement] = Encoder.instance { statement =>
+      // Using ListMap to preserve order of fields, which is easier to debug
+      val baseFields = ListMap(
+        "Effect" -> statement.effect.asJson,
+        "Action" -> statement.actions.asJson,
+        "Resource" -> statement.resources.asJson
+      )
+
+      val withSid = statement.id.fold(baseFields)(id =>
+        baseFields + ("Sid" -> Json.fromString(id))
+      )
+
+      val withConditions =
+        if (statement.conditions.nonEmpty)
+          withSid + ("Condition" -> conditionsAsJson(statement.conditions))
+        else withSid
+
+      val withPrincipals =
+        if (statement.principals.nonEmpty)
+          withConditions + ("Principal" -> principalsAsJson(
+            statement.principals
+          ))
+        else withConditions
+
+      Json.fromJsonObject(JsonObject.fromMap(withPrincipals))
+    }
+  }
+
+  case class Policy(
+      statements: Seq[Statement],
+      id: Option[String] = None
+  )
+
+  object Policy {
+    private val PolicyVersion = "2012-10-17"
+
+    implicit val encoder: Encoder[Policy] = Encoder.instance { policy =>
+      val baseObj = JsonObject(
+        "Version" -> Json.fromString(PolicyVersion),
+        "Statement" -> policy.statements.asJson
+      )
+      Json.fromJsonObject(
+        policy.id.fold(baseObj)(id => baseObj.add("Id", Json.fromString(id)))
+      )
+    }
+  }
+}

--- a/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Iam.scala
@@ -4,7 +4,6 @@ import io.circe.syntax._
 import io.circe.{Encoder, Json, JsonObject}
 
 import scala.collection.immutable.ListMap
-import scala.collection.mutable
 
 /** This models the AWS IAM policy types and subtypes.
   *

--- a/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
+++ b/configTools/src/main/scala/com/gu/janus/policy/Statements.scala
@@ -1,7 +1,6 @@
 package com.gu.janus.policy
 
-import awscala._
-import com.amazonaws.auth.policy.Statement.Effect
+import com.gu.janus.policy.Iam._
 
 object Statements {
 

--- a/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
@@ -61,15 +61,14 @@ class IamSpec extends AnyFreeSpec with Matchers {
       effect = Effect.Allow,
       actions = List(Action("iam:PutRolePolicy"), Action("iam:getRole")),
       resources = List(Resource("*")),
-      id = Some("1")
+      id = None
     )
 
     "should encode basic statement correctly" in {
       val expected = """{
                          |"Effect":"Allow",
                          |"Action":["iam:PutRolePolicy","iam:getRole"],
-                         |"Resource":["*"],
-                         |"Sid":"1"
+                         |"Resource":["*"]
                          |}""".stripMargin.replaceAll("\\s", "")
 
       basicStatement.asJson.noSpaces shouldBe expected
@@ -98,7 +97,6 @@ class IamSpec extends AnyFreeSpec with Matchers {
                          |"Effect":"Allow",
                          |"Action":["iam:PutRolePolicy","iam:getRole"],
                          |"Resource":["*"],
-                         |"Sid":"1",
                          |"Condition":{"StringEquals":{"aws:SourceIp":["203.0.113.0/24"]}}
                          |}""".stripMargin.replaceAll("\\s", "")
 
@@ -118,7 +116,6 @@ class IamSpec extends AnyFreeSpec with Matchers {
                          |"Effect":"Allow",
                          |"Action":["iam:PutRolePolicy","iam:getRole"],
                          |"Resource":["*"],
-                         |"Sid":"1",
                          |"Principal":{
                          |"AWS":["AROAXXXXXXXXXXXXXXX1","AROAXXXXXXXXXXXXXXX2"],
                          |"Kubernetes":["ServiceAccount1"]

--- a/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
@@ -23,14 +23,6 @@ class IamSpec extends AnyFreeSpec with Matchers {
     }
   }
 
-  "Principal" - {
-    "should encode single principal correctly" in {
-      val principal = Principal("AROAXXXXXXXXXXXXXXX", "AWS")
-      val expected = """{"AWS":"AROAXXXXXXXXXXXXXXX"}"""
-      principal.asJson.noSpaces shouldBe expected
-    }
-  }
-
   "Statement" - {
     val basicStatement = Statement(
       effect = Effect.Allow,
@@ -160,7 +152,31 @@ class IamSpec extends AnyFreeSpec with Matchers {
       statementWithConditions.asJson.spaces2 shouldBe expected
     }
 
-    "should encode statement with principals correctly" in {
+    "should encode statement with single principal correctly" in {
+      val statementWithPrincipal = basicStatement.copy(principals =
+        List(Principal("AROAXXXXXXXXXXXXXXX1", "AWS"))
+      )
+
+      val expected = """{
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Principal" : {
+                       |    "AWS" : [
+                       |      "AROAXXXXXXXXXXXXXXX1"
+                       |    ]
+                       |  }
+                       |}""".stripMargin
+
+      statementWithPrincipal.asJson.spaces2 shouldBe expected
+    }
+
+    "should encode statement with multiple principals correctly" in {
       val statementWithPrincipals = basicStatement.copy(
         principals = List(
           Principal("AROAXXXXXXXXXXXXXXX1", "AWS"),

--- a/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
@@ -169,7 +169,7 @@ class IamSpec extends AnyFreeSpec with Matchers {
       policy.asJson.noSpaces shouldBe expected
     }
 
-    "should encode complex policy correctly" in {
+    "should encode complex policy correctly" - {
       val complexPolicy = Policy(
         statements = List(
           Statement(
@@ -193,17 +193,80 @@ class IamSpec extends AnyFreeSpec with Matchers {
       )
 
       val json = complexPolicy.asJson.noSpaces
-      // Verify that the generated JSON is valid
       decode[JsonObject](json).isRight shouldBe true
 
-      // Verify specific elements
-      json should include(""""Version":"2012-10-17"""")
-      json should include(""""Id":"ComplexPolicy"""")
-      json should include(""""Effect":"Allow"""")
-      json should include(""""Sid":"statement1"""")
-      json should include(""""aws:SourceIp":["203.0.113.0/24"]""")
-      json should include(""""AWS":["AROAXXXXXXXXXXXXXXX"]""")
-      json should include(""""Kubernetes":["ServiceAccount1"]""")
+      "with correct version" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""Version":"2012-10-17"""")
+      }
+
+      "with correct ID" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""Id":"ComplexPolicy"""")
+      }
+
+      "with correct effect" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""Effect":"Allow"""")
+      }
+
+      "with explicitly set statement ID" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""Sid":"statement1"""")
+      }
+
+      "with correct condition" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""aws:SourceIp":["203.0.113.0/24"]""")
+      }
+
+      "with correct principal" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""AWS":["AROAXXXXXXXXXXXXXXX"]""")
+      }
+
+      "with correct second principal" in {
+        val json = complexPolicy.asJson.noSpaces
+        json should include(""""Kubernetes":["ServiceAccount1"]""")
+      }
+
+      "with correct complete json string" in {
+        val json = complexPolicy.asJson.spaces2
+        val expected = """{
+                         |  "Version" : "2012-10-17",
+                         |  "Statement" : [
+                         |    {
+                         |      "Effect" : "Allow",
+                         |      "Action" : [
+                         |        "s3:GetObject",
+                         |        "s3:PutObject"
+                         |      ],
+                         |      "Resource" : [
+                         |        "arn:aws:s3:::my-bucket/*",
+                         |        "arn:aws:s3:::my-bucket-2/*"
+                         |      ],
+                         |      "Sid" : "statement1",
+                         |      "Condition" : {
+                         |        "StringEquals" : {
+                         |          "aws:SourceIp" : [
+                         |            "203.0.113.0/24"
+                         |          ]
+                         |        }
+                         |      },
+                         |      "Principal" : {
+                         |        "AWS" : [
+                         |          "AROAXXXXXXXXXXXXXXX"
+                         |        ],
+                         |        "Kubernetes" : [
+                         |          "ServiceAccount1"
+                         |        ]
+                         |      }
+                         |    }
+                         |  ],
+                         |  "Id" : "ComplexPolicy"
+                         |}""".stripMargin
+        json shouldBe expected
+      }
     }
   }
 }

--- a/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
@@ -23,31 +23,6 @@ class IamSpec extends AnyFreeSpec with Matchers {
     }
   }
 
-  "Condition" - {
-    "should encode single condition correctly" in {
-      val condition = Condition(
-        key = "aws:SourceIp",
-        typeName = "StringEquals",
-        conditionValues = List("203.0.113.0/24")
-      )
-
-      val expected = """{"StringEquals":{"aws:SourceIp":["203.0.113.0/24"]}}"""
-      condition.asJson.noSpaces shouldBe expected
-    }
-
-    "should encode multiple condition values correctly" in {
-      val condition = Condition(
-        key = "aws:SourceIp",
-        typeName = "StringEquals",
-        conditionValues = List("203.0.113.0/24", "203.0.113.1/24")
-      )
-
-      val expected =
-        """{"StringEquals":{"aws:SourceIp":["203.0.113.0/24","203.0.113.1/24"]}}"""
-      condition.asJson.noSpaces shouldBe expected
-    }
-  }
-
   "Principal" - {
     "should encode single principal correctly" in {
       val principal = Principal("AROAXXXXXXXXXXXXXXX", "AWS")
@@ -86,7 +61,7 @@ class IamSpec extends AnyFreeSpec with Matchers {
       statementWithId.asJson.noSpaces shouldBe expected
     }
 
-    "should encode statement with conditions correctly" in {
+    "should encode statement with single condition correctly" in {
       val statementWithCondition = basicStatement.copy(
         conditions = List(
           Condition("aws:SourceIp", "StringEquals", List("203.0.113.0/24"))
@@ -94,13 +69,95 @@ class IamSpec extends AnyFreeSpec with Matchers {
       )
 
       val expected = """{
-                         |"Effect":"Allow",
-                         |"Action":["iam:PutRolePolicy","iam:getRole"],
-                         |"Resource":["*"],
-                         |"Condition":{"StringEquals":{"aws:SourceIp":["203.0.113.0/24"]}}
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Condition" : {
+                       |    "StringEquals" : {
+                       |      "aws:SourceIp" : [
+                       |        "203.0.113.0/24"
+                       |      ]
+                       |    }
+                       |  }
+                       |}""".stripMargin
 
-      statementWithCondition.asJson.noSpaces shouldBe expected
+      statementWithCondition.asJson.spaces2 shouldBe expected
+    }
+
+    "should encode statement with single condition with multiple values correctly" in {
+      val statementWithCondition = basicStatement.copy(
+        conditions = List(
+          Condition(
+            "aws:SourceIp",
+            "StringEquals",
+            List("203.0.113.0/24", "203.0.113.1/24")
+          )
+        )
+      )
+
+      val expected = """{
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Condition" : {
+                       |    "StringEquals" : {
+                       |      "aws:SourceIp" : [
+                       |        "203.0.113.0/24",
+                       |        "203.0.113.1/24"
+                       |      ]
+                       |    }
+                       |  }
+                       |}""".stripMargin
+
+      statementWithCondition.asJson.spaces2 shouldBe expected
+    }
+
+    "should encode statement with multiple conditions correctly" in {
+      val statementWithConditions = basicStatement.copy(
+        conditions = List(
+          Condition("aws:SourceIp", "StringEquals", List("203.0.113.0/24")),
+          Condition(
+            "aws:TokenIssueTime",
+            "DateLessThan",
+            List("2025-02-27T09:33:01.000Z")
+          )
+        )
+      )
+
+      val expected = """{
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Condition" : {
+                       |    "StringEquals" : {
+                       |      "aws:SourceIp" : [
+                       |        "203.0.113.0/24"
+                       |      ]
+                       |    },
+                       |    "DateLessThan" : {
+                       |      "aws:TokenIssueTime" : [
+                       |        "2025-02-27T09:33:01.000Z"
+                       |      ]
+                       |    }
+                       |  }
+                       |}""".stripMargin
+
+      statementWithConditions.asJson.spaces2 shouldBe expected
     }
 
     "should encode statement with principals correctly" in {

--- a/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamSpec.scala
@@ -1,0 +1,209 @@
+package com.gu.janus.policy
+
+import com.gu.janus.policy.Iam._
+import io.circe.JsonObject
+import io.circe.parser.decode
+import io.circe.syntax._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class IamSpec extends AnyFreeSpec with Matchers {
+
+  "Action" - {
+    "should encode action name correctly" in {
+      Action("s3:GetObject").asJson.noSpaces shouldBe """"s3:GetObject""""
+    }
+  }
+
+  "Resource" - {
+    "should encode resource id correctly" in {
+      Resource(
+        "arn:aws:s3:::my-bucket/*"
+      ).asJson.noSpaces shouldBe """"arn:aws:s3:::my-bucket/*""""
+    }
+  }
+
+  "Condition" - {
+    "should encode single condition correctly" in {
+      val condition = Condition(
+        key = "aws:SourceIp",
+        typeName = "StringEquals",
+        conditionValues = List("203.0.113.0/24")
+      )
+
+      val expected = """{"StringEquals":{"aws:SourceIp":["203.0.113.0/24"]}}"""
+      condition.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode multiple condition values correctly" in {
+      val condition = Condition(
+        key = "aws:SourceIp",
+        typeName = "StringEquals",
+        conditionValues = List("203.0.113.0/24", "203.0.113.1/24")
+      )
+
+      val expected =
+        """{"StringEquals":{"aws:SourceIp":["203.0.113.0/24","203.0.113.1/24"]}}"""
+      condition.asJson.noSpaces shouldBe expected
+    }
+  }
+
+  "Principal" - {
+    "should encode single principal correctly" in {
+      val principal = Principal("AROAXXXXXXXXXXXXXXX", "AWS")
+      val expected = """{"AWS":"AROAXXXXXXXXXXXXXXX"}"""
+      principal.asJson.noSpaces shouldBe expected
+    }
+  }
+
+  "Statement" - {
+    val basicStatement = Statement(
+      effect = Effect.Allow,
+      actions = List(Action("iam:PutRolePolicy"), Action("iam:getRole")),
+      resources = List(Resource("*")),
+      id = Some("1")
+    )
+
+    "should encode basic statement correctly" in {
+      val expected = """{
+                         |"Effect":"Allow",
+                         |"Action":["iam:PutRolePolicy","iam:getRole"],
+                         |"Resource":["*"],
+                         |"Sid":"1"
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      basicStatement.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode statement with ID correctly" in {
+      val statementWithId = basicStatement.copy(id = Some("statement1"))
+      val expected = """{
+                         |"Effect":"Allow",
+                         |"Action":["iam:PutRolePolicy","iam:getRole"],
+                         |"Resource":["*"],
+                         |"Sid":"statement1"
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      statementWithId.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode statement with conditions correctly" in {
+      val statementWithCondition = basicStatement.copy(
+        conditions = List(
+          Condition("aws:SourceIp", "StringEquals", List("203.0.113.0/24"))
+        )
+      )
+
+      val expected = """{
+                         |"Effect":"Allow",
+                         |"Action":["iam:PutRolePolicy","iam:getRole"],
+                         |"Resource":["*"],
+                         |"Sid":"1",
+                         |"Condition":{"StringEquals":{"aws:SourceIp":["203.0.113.0/24"]}}
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      statementWithCondition.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode statement with principals correctly" in {
+      val statementWithPrincipals = basicStatement.copy(
+        principals = List(
+          Principal("AROAXXXXXXXXXXXXXXX1", "AWS"),
+          Principal("AROAXXXXXXXXXXXXXXX2", "AWS"),
+          Principal("ServiceAccount1", "Kubernetes")
+        )
+      )
+
+      val expected = """{
+                         |"Effect":"Allow",
+                         |"Action":["iam:PutRolePolicy","iam:getRole"],
+                         |"Resource":["*"],
+                         |"Sid":"1",
+                         |"Principal":{
+                         |"AWS":["AROAXXXXXXXXXXXXXXX1","AROAXXXXXXXXXXXXXXX2"],
+                         |"Kubernetes":["ServiceAccount1"]
+                         |}
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      statementWithPrincipals.asJson.noSpaces shouldBe expected
+    }
+  }
+
+  "Policy" - {
+    val basicStatement = Statement(
+      effect = Effect.Allow,
+      actions = List(Action("s3:GetObject")),
+      resources = List(Resource("arn:aws:s3:::my-bucket/*"))
+    )
+
+    "should encode basic policy correctly" in {
+      val policy = Policy(statements = List(basicStatement))
+      val expected = """{
+                         |"Version":"2012-10-17",
+                         |"Statement":[{
+                         |"Effect":"Allow",
+                         |"Action":["s3:GetObject"],
+                         |"Resource":["arn:aws:s3:::my-bucket/*"]
+                         |}]
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      policy.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode policy with ID correctly" in {
+      val policy = Policy(
+        statements = List(basicStatement),
+        id = Some("MyPolicyId")
+      )
+
+      val expected = """{
+                         |"Version":"2012-10-17",
+                         |"Statement":[{
+                         |"Effect":"Allow",
+                         |"Action":["s3:GetObject"],
+                         |"Resource":["arn:aws:s3:::my-bucket/*"]
+                         |}],
+                         |"Id":"MyPolicyId"
+                         |}""".stripMargin.replaceAll("\\s", "")
+
+      policy.asJson.noSpaces shouldBe expected
+    }
+
+    "should encode complex policy correctly" in {
+      val complexPolicy = Policy(
+        statements = List(
+          Statement(
+            effect = Effect.Allow,
+            actions = List(Action("s3:GetObject"), Action("s3:PutObject")),
+            resources = List(
+              Resource("arn:aws:s3:::my-bucket/*"),
+              Resource("arn:aws:s3:::my-bucket-2/*")
+            ),
+            id = Some("statement1"),
+            conditions = List(
+              Condition("aws:SourceIp", "StringEquals", List("203.0.113.0/24"))
+            ),
+            principals = List(
+              Principal("AROAXXXXXXXXXXXXXXX", "AWS"),
+              Principal("ServiceAccount1", "Kubernetes")
+            )
+          )
+        ),
+        id = Some("ComplexPolicy")
+      )
+
+      val json = complexPolicy.asJson.noSpaces
+      // Verify that the generated JSON is valid
+      decode[JsonObject](json).isRight shouldBe true
+
+      // Verify specific elements
+      json should include(""""Version":"2012-10-17"""")
+      json should include(""""Id":"ComplexPolicy"""")
+      json should include(""""Effect":"Allow"""")
+      json should include(""""Sid":"statement1"""")
+      json should include(""""aws:SourceIp":["203.0.113.0/24"]""")
+      json should include(""""AWS":["AROAXXXXXXXXXXXXXXX"]""")
+      json should include(""""Kubernetes":["ServiceAccount1"]""")
+    }
+  }
+}

--- a/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
@@ -7,7 +7,7 @@ import io.circe.syntax._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class IamSpec extends AnyFreeSpec with Matchers {
+class IamTest extends AnyFreeSpec with Matchers {
 
   "Action" - {
     "should encode action name correctly" in {

--- a/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
@@ -33,24 +33,34 @@ class IamTest extends AnyFreeSpec with Matchers {
 
     "should encode basic statement correctly" in {
       val expected = """{
-                         |"Effect":"Allow",
-                         |"Action":["iam:PutRolePolicy","iam:getRole"],
-                         |"Resource":["*"]
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ]
+                       |}""".stripMargin
 
-      basicStatement.asJson.noSpaces shouldBe expected
+      basicStatement.asJson.spaces2 shouldBe expected
     }
 
     "should encode statement with ID correctly" in {
       val statementWithId = basicStatement.copy(id = Some("statement1"))
       val expected = """{
-                         |"Effect":"Allow",
-                         |"Action":["iam:PutRolePolicy","iam:getRole"],
-                         |"Resource":["*"],
-                         |"Sid":"statement1"
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Sid" : "statement1"
+                       |}""".stripMargin
 
-      statementWithId.asJson.noSpaces shouldBe expected
+      statementWithId.asJson.spaces2 shouldBe expected
     }
 
     "should encode statement with single condition correctly" in {
@@ -186,16 +196,26 @@ class IamTest extends AnyFreeSpec with Matchers {
       )
 
       val expected = """{
-                         |"Effect":"Allow",
-                         |"Action":["iam:PutRolePolicy","iam:getRole"],
-                         |"Resource":["*"],
-                         |"Principal":{
-                         |"AWS":["AROAXXXXXXXXXXXXXXX1","AROAXXXXXXXXXXXXXXX2"],
-                         |"Kubernetes":["ServiceAccount1"]
-                         |}
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Principal" : {
+                       |    "AWS" : [
+                       |      "AROAXXXXXXXXXXXXXXX1",
+                       |      "AROAXXXXXXXXXXXXXXX2"
+                       |    ],
+                       |    "Kubernetes" : [
+                       |      "ServiceAccount1"
+                       |    ]
+                       |  }
+                       |}""".stripMargin
 
-      statementWithPrincipals.asJson.noSpaces shouldBe expected
+      statementWithPrincipals.asJson.spaces2 shouldBe expected
     }
   }
 
@@ -209,15 +229,21 @@ class IamTest extends AnyFreeSpec with Matchers {
     "should encode basic policy correctly" in {
       val policy = Policy(statements = List(basicStatement))
       val expected = """{
-                         |"Version":"2012-10-17",
-                         |"Statement":[{
-                         |"Effect":"Allow",
-                         |"Action":["s3:GetObject"],
-                         |"Resource":["arn:aws:s3:::my-bucket/*"]
-                         |}]
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Version" : "2012-10-17",
+                       |  "Statement" : [
+                       |    {
+                       |      "Effect" : "Allow",
+                       |      "Action" : [
+                       |        "s3:GetObject"
+                       |      ],
+                       |      "Resource" : [
+                       |        "arn:aws:s3:::my-bucket/*"
+                       |      ]
+                       |    }
+                       |  ]
+                       |}""".stripMargin
 
-      policy.asJson.noSpaces shouldBe expected
+      policy.asJson.spaces2 shouldBe expected
     }
 
     "should encode policy with ID correctly" in {
@@ -227,16 +253,22 @@ class IamTest extends AnyFreeSpec with Matchers {
       )
 
       val expected = """{
-                         |"Version":"2012-10-17",
-                         |"Statement":[{
-                         |"Effect":"Allow",
-                         |"Action":["s3:GetObject"],
-                         |"Resource":["arn:aws:s3:::my-bucket/*"]
-                         |}],
-                         |"Id":"MyPolicyId"
-                         |}""".stripMargin.replaceAll("\\s", "")
+                       |  "Version" : "2012-10-17",
+                       |  "Statement" : [
+                       |    {
+                       |      "Effect" : "Allow",
+                       |      "Action" : [
+                       |        "s3:GetObject"
+                       |      ],
+                       |      "Resource" : [
+                       |        "arn:aws:s3:::my-bucket/*"
+                       |      ]
+                       |    }
+                       |  ],
+                       |  "Id" : "MyPolicyId"
+                       |}""".stripMargin
 
-      policy.asJson.noSpaces shouldBe expected
+      policy.asJson.spaces2 shouldBe expected
     }
 
     "should encode complex policy correctly" - {

--- a/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/IamTest.scala
@@ -162,6 +162,42 @@ class IamTest extends AnyFreeSpec with Matchers {
       statementWithConditions.asJson.spaces2 shouldBe expected
     }
 
+    "should encode statement with multiple conditions of same type correctly" in {
+      val statementWithConditions = basicStatement.copy(
+        conditions = List(
+          Condition("aws:SourceIp", "StringEquals", List("203.0.113.0/24")),
+          Condition(
+            "aws:TokenIssueTime",
+            "StringEquals",
+            List("2025-02-27T09:33:01.000Z")
+          )
+        )
+      )
+
+      val expected = """{
+                       |  "Effect" : "Allow",
+                       |  "Action" : [
+                       |    "iam:PutRolePolicy",
+                       |    "iam:getRole"
+                       |  ],
+                       |  "Resource" : [
+                       |    "*"
+                       |  ],
+                       |  "Condition" : {
+                       |    "StringEquals" : {
+                       |      "aws:SourceIp" : [
+                       |        "203.0.113.0/24"
+                       |      ],
+                       |      "aws:TokenIssueTime" : [
+                       |        "2025-02-27T09:33:01.000Z"
+                       |      ]
+                       |    }
+                       |  }
+                       |}""".stripMargin
+
+      statementWithConditions.asJson.spaces2 shouldBe expected
+    }
+
     "should encode statement with single principal correctly" in {
       val statementWithPrincipal = basicStatement.copy(principals =
         List(Principal("AROAXXXXXXXXXXXXXXX1", "AWS"))

--- a/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/policy/StatementsTest.scala
@@ -1,6 +1,6 @@
 package com.gu.janus.policy
 
-import Statements._
+import com.gu.janus.policy.Statements._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/test/aws/FederationTest.scala
+++ b/test/aws/FederationTest.scala
@@ -1,19 +1,15 @@
 package aws
 
-import awscala.Policy
 import com.gu.janus.model.{AwsAccount, Permission}
-import org.joda.time.{DateTime, DateTimeZone}
+import com.gu.janus.policy.Iam.Policy
+import org.joda.time.DateTimeZone
 import org.scalactic.source
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.routing.sird.{
-  QueryStringParameterExtractor,
-  RequiredQueryStringParameter
-}
+import play.api.routing.sird.QueryStringParameterExtractor
 import testutils.JodaTimeUtils
 
-import java.net.URLDecoder
-import java.nio.charset.Charset
+import java.net.{URI, URLDecoder}
 
 class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
   import Federation._
@@ -169,7 +165,7 @@ class FederationTest extends AnyFreeSpec with Matchers with JodaTimeUtils {
   private def extractRedirectUri(
       url: String
   )(implicit pos: source.Position): String = {
-    new java.net.URL(url) match {
+    new URI(url) match {
       case RedirectUri(redirectUri) => URLDecoder.decode(redirectUri, "UTF-8")
       case result =>
         fail(s"redirect_uri parameter not present on resulting URL $result")

--- a/test/fixtures/Fixtures.scala
+++ b/test/fixtures/Fixtures.scala
@@ -1,7 +1,7 @@
 package fixtures
 
-import awscala.Policy
 import com.gu.janus.model.{AwsAccount, Permission}
+import com.gu.janus.policy.Iam.Policy
 
 object Fixtures {
   val fooAct = AwsAccount("Foo", "foo")

--- a/test/logic/UserAccessTest.scala
+++ b/test/logic/UserAccessTest.scala
@@ -1,10 +1,9 @@
 package logic
 
-import awscala.DateTime
 import com.gu.googleauth.UserIdentity
 import fixtures.Fixtures._
 import com.gu.janus.model.{ACL, SupportACL}
-import org.joda.time.{DateTimeZone, Period}
+import org.joda.time.{DateTime, DateTimeZone, Period}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{Inspectors, OptionValues}


### PR DESCRIPTION
## What is the purpose of this change?
This change removes all dependence on [AWS v1 SDKs](https://github.com/aws/aws-sdk-java) and on the [archived awscala library](https://github.com/seratch/AWScala).
All interaction with AWS is now done through [v2 SDKs](https://github.com/aws/aws-sdk-java-v2/).

## What is the value of this change and how do we measure success?
This will make the code more secure and easier to maintain.

## Any additional notes?
AWS provides a [library for modelling IAM policies](https://mvnrepository.com/artifact/software.amazon.awssdk/iam-policy-builder) but to make use of this library would involve changing a lot of code in this repo and in the call sites of the [configTools library](https://github.com/guardian/janus-app/tree/fd3f01d5db3f2d407b168438da15d381988fa807/configTools/src), making the change history difficult to navigate.
Instead we have created case classes to model policies that duplicate the pre-existing awscala case classes.
This has the benefit of only needing to change imports in most cases so preserving the change history.  But it comes at the cost of having to generate a json representation of policies, which is more complicated than just auto-encoding the case class structure.

## To test
Verify in production that:

- [ ] Can still sign into AWS console from Janus
- [ ] Can sign out from console and back in again from Janus
- [ ] Can retrieve credentials and use them in command line locally
- [ ] Can revoke all credentials for an account and see policy condition has correct threshold time and console and local credentials unusable
- [ ] Logs have no new errors

## See also
* #500
* #504 
