### PR TITLE
Set AWS STS client's region explicitly

### DIFF
--- a/app/aws/Clients.scala
+++ b/app/aws/Clients.scala
@@ -21,7 +21,11 @@ object Clients {
       .build()
 
   lazy val stsClient: StsClient =
-    StsClient.builder().credentialsProvider(credentialsProviderChain).build()
+    StsClient
+      .builder()
+      .credentialsProvider(credentialsProviderChain)
+      .region(EU_WEST_1)
+      .build()
 
   def localDb: DynamoDbClient =
     DynamoDbClient


### PR DESCRIPTION
The region for the AWS Java STS client was being read from the local users' config but this can't be relied on.
So now setting it explicitly in the code.