### PR TITLE
feat: create placeholder npm build step in CI

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -30,12 +30,14 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with: 
           node-version: '20'
-      
-      - name: Install frontend build dependencies
+
+      - name: Install dependencies
         run: npm ci
+        working-directory: frontend
 
       - name: Build frontend app
         run: npm run build
+        working-directory: frontend
 
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
 

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -30,6 +30,8 @@ jobs:
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with: 
           node-version: '22' # Ensure this matches the version in Janus: https://github.com/guardian/janus/blob/main/.nvmrc
+          cache: 'npm'
+          cache-dependency-path: 'frontend/package-lock.json'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -26,6 +26,17 @@ jobs:
       - name: Install Scala
         uses: guardian/setup-scala@v1
 
+      - name: Install Node
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with: 
+          node-version: '20'
+      
+      - name: Install frontend build dependencies
+        run: npm ci
+
+      - name: Build frontend app
+        run: npm run build
+
       - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
 
       - name: Test Report for Janus-App

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: npm ci
         working-directory: frontend
 

--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with: 
-          node-version: '20'
+          node-version: '22' # Ensure this matches the version in Janus: https://github.com/guardian/janus/blob/main/.nvmrc
 
       - name: Install dependencies
         run: npm ci

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "janus-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "janus-app",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "janus-app",
+  "version": "1.0.0",
+  "description": "Use Google Authentication to provide audited temporary access to AWS resources",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "description": "Use Google Authentication to provide audited temporary access to AWS resources",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "echo \"Running pretend build\""
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
## What is the purpose of this change?

Adds an NPM step to the CI to install and build node dependencies. For the moment, `npm run build` only echoes out a message, but when #512  is implemented, it will run the parcel build for the frontend app.

## What is the value of this change and how do we measure success?

This will allow us to ensure that when #512  is merged, the CI is in place to successfully deploy the frontend build.

This PR will need to be merged ahead of the [related PR in the janus repo](https://github.com/guardian/janus/pull/4612).
