### PR TITLE
Refactor audit trail code

### DIFF
--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -30,7 +30,10 @@ object AuditTrailDB {
       .tableName(tableName)
       .keyConditions(
         Map(
-          attrEqualCondition(accountPartitionKeyName, AttributeValue.fromS(account)),
+          attrEqualCondition(
+            accountPartitionKeyName,
+            AttributeValue.fromS(account)
+          ),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -30,7 +30,7 @@ object AuditTrailDB {
       .tableName(tableName)
       .keyConditions(
         Map(
-          attrCondition(accountPartitionKeyName, AttributeValue.fromS(account)),
+          attrEqualCondition(accountPartitionKeyName, AttributeValue.fromS(account)),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )
@@ -50,7 +50,7 @@ object AuditTrailDB {
       .indexName(secondaryIndexName)
       .keyConditions(
         Map(
-          attrCondition(userNameAttrName, AttributeValue.fromS(username)),
+          attrEqualCondition(userNameAttrName, AttributeValue.fromS(username)),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )
@@ -59,7 +59,7 @@ object AuditTrailDB {
     queryResult(dynamoDB, request)
   }
 
-  private def attrCondition(
+  private def attrEqualCondition(
       attrName: String,
       attrValue: AttributeValue
   ) =

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -4,11 +4,7 @@ import com.gu.janus.model.AuditLog
 import logic.AuditTrail
 import org.joda.time.DateTime
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator.{
-  BETWEEN,
-  EQ
-}
-import software.amazon.awssdk.services.dynamodb.model.KeyType.{HASH, RANGE}
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator._
 import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.jdk.CollectionConverters._
@@ -16,65 +12,25 @@ import scala.jdk.CollectionConverters._
 object AuditTrailDB {
   import AuditTrail._
 
-  val tableName = "AuditTrail"
-  private val secondaryIndexName = "AuditTrailByUser"
-
-  def getTable()(implicit dynamoDB: DynamoDbClient): TableDescription = {
-    val request = DescribeTableRequest.builder().tableName(tableName).build()
-    dynamoDB.describeTable(request).table()
-  }
-
-  def insert(table: TableDescription, auditLog: AuditLog)(implicit
-      dynamoDB: DynamoDbClient
-  ): Unit = {
-    val keySchema = table.keySchema().asScala
-    val partitionKeyName =
-      keySchema.find(_.keyType() == HASH).get.attributeName()
-    val sortKeyName = keySchema.find(_.keyType() == RANGE).get.attributeName()
-    val (hash_project, range_date, attrs) = auditLogAttrs(auditLog)
-    val partitionKey = partitionKeyName -> AttributeValue.fromS(hash_project)
-    val sortKey = sortKeyName -> AttributeValue.fromN(range_date.toString)
-    val item = (attrs.toMap.view
-      .mapValues(toAttribValue)
-      .toMap + partitionKey + sortKey).asJava
-    val request = PutItemRequest
-      .builder()
-      .tableName(tableName)
-      .item(item)
-      .build()
+  def insert(auditLog: AuditLog)(implicit dynamoDB: DynamoDbClient): Unit = {
+    val auditLogDbAttrs = AuditLogDbEntryAttrs.fromAuditLog(auditLog)
+    val item = auditLogDbAttrs.toMap.asJava
+    val request =
+      PutItemRequest.builder().tableName(tableName).item(item).build()
     dynamoDB.putItem(request)
   }
 
-  private def toAttribValue(value: Any): AttributeValue = {
-    value match {
-      case s: String  => AttributeValue.fromS(s)
-      case i: Int     => AttributeValue.fromN(i.toString)
-      case l: Long    => AttributeValue.fromN(l.toString)
-      case d: Double  => AttributeValue.fromN(d.toString)
-      case b: Boolean => AttributeValue.fromBool(b)
-      case _ =>
-        throw new IllegalArgumentException(
-          s"Unsupported type: ${value.getClass}"
-        )
-    }
-  }
-
   def getAccountLogs(
-      table: TableDescription,
       account: String,
       startDate: DateTime,
       endDate: DateTime
   )(implicit dynamoDB: DynamoDbClient): Seq[Either[String, AuditLog]] = {
     val request = QueryRequest
       .builder()
-      .tableName(table.tableName())
+      .tableName(tableName)
       .keyConditions(
         Map(
-          "j_account" -> Condition
-            .builder()
-            .comparisonOperator(EQ)
-            .attributeValueList(AttributeValue.fromS(account))
-            .build(),
+          attrCondition(partitionKeyName, AttributeValue.fromS(account)),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )
@@ -84,22 +40,17 @@ object AuditTrailDB {
   }
 
   def getUserLogs(
-      table: TableDescription,
       username: String,
       startDate: DateTime,
       endDate: DateTime
   )(implicit dynamoDB: DynamoDbClient): Seq[Either[String, AuditLog]] = {
     val request = QueryRequest
       .builder()
-      .tableName(table.tableName())
+      .tableName(tableName)
       .indexName(secondaryIndexName)
       .keyConditions(
         Map(
-          "j_username" -> Condition
-            .builder()
-            .comparisonOperator(EQ)
-            .attributeValueList(AttributeValue.fromS(username))
-            .build(),
+          attrCondition(userNameAttrName, AttributeValue.fromS(username)),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )
@@ -108,11 +59,21 @@ object AuditTrailDB {
     queryResult(dynamoDB, request)
   }
 
+  private def attrCondition(
+      attrName: String,
+      attrValue: AttributeValue
+  ) =
+    attrName -> Condition
+      .builder()
+      .comparisonOperator(EQ)
+      .attributeValueList(attrValue)
+      .build()
+
   private def dateRangeCondition(
       startDate: DateTime,
       endDate: DateTime
   ): (String, Condition) = {
-    "j_timestamp" -> Condition
+    sortKeyName -> Condition
       .builder()
       .comparisonOperator(BETWEEN)
       .attributeValueList(

--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -30,7 +30,7 @@ object AuditTrailDB {
       .tableName(tableName)
       .keyConditions(
         Map(
-          attrCondition(partitionKeyName, AttributeValue.fromS(account)),
+          attrCondition(accountPartitionKeyName, AttributeValue.fromS(account)),
           dateRangeCondition(startDate, endDate)
         ).asJava
       )
@@ -73,7 +73,7 @@ object AuditTrailDB {
       startDate: DateTime,
       endDate: DateTime
   ): (String, Condition) = {
-    sortKeyName -> Condition
+    timestampSortKeyName -> Condition
       .builder()
       .comparisonOperator(BETWEEN)
       .attributeValueList(

--- a/app/controllers/Audit.scala
+++ b/app/controllers/Audit.scala
@@ -22,9 +22,7 @@ class Audit(
     ) flatMap Date.parseDateStr getOrElse Date.today
     val (startDate, endDate) = Date.weekAround(date)
     logger.info(s"Getting logs for $account from $startDate to $endDate")
-    val table = AuditTrailDB.getTable()
-    val auditLogs =
-      AuditTrailDB.getAccountLogs(table, account, startDate, endDate)
+    val auditLogs = AuditTrailDB.getAccountLogs(account, startDate, endDate)
     val prevNextWeeks = Date.prevNextAuditWeeks(date)
     Ok(
       views.html.audit(
@@ -44,9 +42,7 @@ class Audit(
     ) flatMap Date.parseDateStr getOrElse Date.today
     val (startDate, endDate) = Date.weekAround(date)
     logger.info(s"Getting logs for $username from $startDate to $endDate")
-    val table = AuditTrailDB.getTable()
-    val auditLogs =
-      AuditTrailDB.getUserLogs(table, username, startDate, endDate)
+    val auditLogs = AuditTrailDB.getUserLogs(username, startDate, endDate)
     val prevNextWeeks = Date.prevNextAuditWeeks(date)
     Ok(
       views.html.audit(

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -237,8 +237,8 @@ class Janus(
         duration,
         janusData.access
       )
+      _ = AuditTrailDB.insert(auditLog)
     } yield {
-      AuditTrailDB.insert(auditLog)
       logger.info(
         s"$accessType access to $permissionId granted for ${username(user)}"
       )

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -230,7 +230,6 @@ class Janus(
         stsClient,
         duration
       )
-      table = AuditTrailDB.getTable()
       auditLog = AuditTrail.createLog(
         user,
         permission,
@@ -239,7 +238,7 @@ class Janus(
         janusData.access
       )
     } yield {
-      AuditTrailDB.insert(table, auditLog)
+      AuditTrailDB.insert(auditLog)
       logger.info(
         s"$accessType access to $permissionId granted for ${username(user)}"
       )

--- a/app/logic/AuditTrail.scala
+++ b/app/logic/AuditTrail.scala
@@ -22,17 +22,15 @@ object AuditTrail extends Logging {
   val accessTypeAttrName = "j_accessType"
   val isExternalAttrName = "j_external"
 
-  private type DbAttr = (String, AttributeValue)
-
   /** Database item attributes for a single audit log entry. */
   case class AuditLogDbEntryAttrs(
-      partitionKey: DbAttr,
-      sortKey: DbAttr,
-      userName: DbAttr,
-      sessionDuration: DbAttr,
-      accessLevel: DbAttr,
-      accessType: DbAttr,
-      isExternal: DbAttr
+      partitionKey: (String, AttributeValue),
+      sortKey: (String, AttributeValue),
+      userName: (String, AttributeValue),
+      sessionDuration: (String, AttributeValue),
+      accessLevel: (String, AttributeValue),
+      accessType: (String, AttributeValue),
+      isExternal: (String, AttributeValue)
   ) {
     val toMap: Map[String, AttributeValue] = Seq(
       partitionKey,

--- a/app/logic/AuditTrail.scala
+++ b/app/logic/AuditTrail.scala
@@ -14,11 +14,20 @@ object AuditTrail extends Logging {
   val tableName = "AuditTrail"
   val secondaryIndexName = "AuditTrailByUser"
 
+  /* Database item attributes.
+   * Named with a 'j_' prefix to avoid conflicts with DynamoDB reserved keywords.
+   */
+  // AWS account name - used as the partition key for the table
   val accountPartitionKeyName = "j_account"
+  // Timestamp of the access attempt - used as the sort key for the table and for its secondary index
   val timestampSortKeyName = "j_timestamp"
+  // User name - indexed attribute
   val userNameAttrName = "j_username"
+  // TTL of the granted session, in seconds
   val durationAttrName = "j_duration"
+  // Access role requested
   val accessLevelAttrName = "j_accessLevel"
+  // Whether access request was for AWS console or credentials for local use
   val accessTypeAttrName = "j_accessType"
   val isExternalAttrName = "j_external"
 

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -68,24 +68,24 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
       .keySchema(
         KeySchemaElement
           .builder()
-          .attributeName(AuditTrail.partitionKeyName)
+          .attributeName(AuditTrail.accountPartitionKeyName)
           .keyType(HASH)
           .build(),
         KeySchemaElement
           .builder()
-          .attributeName(AuditTrail.sortKeyName)
+          .attributeName(AuditTrail.timestampSortKeyName)
           .keyType(RANGE)
           .build()
       )
       .attributeDefinitions(
         AttributeDefinition
           .builder()
-          .attributeName(AuditTrail.partitionKeyName)
+          .attributeName(AuditTrail.accountPartitionKeyName)
           .attributeType(S)
           .build(),
         AttributeDefinition
           .builder()
-          .attributeName(AuditTrail.sortKeyName)
+          .attributeName(AuditTrail.timestampSortKeyName)
           .attributeType(N)
           .build(),
         AttributeDefinition
@@ -106,7 +106,7 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
               .build(),
             KeySchemaElement
               .builder()
-              .attributeName(AuditTrail.sortKeyName)
+              .attributeName(AuditTrail.timestampSortKeyName)
               .keyType(RANGE)
               .build()
           )

--- a/test/aws/AuditTrailDBTest.scala
+++ b/test/aws/AuditTrailDBTest.scala
@@ -1,11 +1,13 @@
 package aws
 
 import com.gu.janus.model.{AuditLog, JConsole}
+import logic.AuditTrail
 import org.joda.time.{DateTime, DateTimeZone, Duration}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.KeyType.{HASH, RANGE}
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.{N, S}
 import software.amazon.awssdk.services.dynamodb.model._
 
 class AuditTrailDBTest extends AnyFreeSpec with Matchers {
@@ -14,7 +16,6 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
     implicit val dynamoDB: DynamoDbClient = Clients.localDb
 
     "insertion and querying" ignore {
-      val table = AuditTrailDB.getTable()
       val dateTime: DateTime =
         new DateTime(2015, 11, 5, 17, 35, DateTimeZone.UTC)
       val al = AuditLog(
@@ -26,10 +27,9 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
         JConsole,
         external = true
       )
-      AuditTrailDB.insert(table, al)
+      AuditTrailDB.insert(al)
 
       val accountResults = AuditTrailDB.getAccountLogs(
-        table,
         "account",
         dateTime.minusDays(1),
         dateTime.plusDays(1)
@@ -37,7 +37,6 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
       println(accountResults.toList)
 
       val userResults = AuditTrailDB.getUserLogs(
-        table,
         "username",
         dateTime.minusDays(1),
         dateTime.plusDays(1)
@@ -65,49 +64,49 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
   ): CreateTableResponse = {
     val auditTableCreateRequest = CreateTableRequest
       .builder()
-      .tableName(AuditTrailDB.tableName)
+      .tableName(AuditTrail.tableName)
       .keySchema(
         KeySchemaElement
           .builder()
-          .attributeName("j_account")
+          .attributeName(AuditTrail.partitionKeyName)
           .keyType(HASH)
           .build(),
         KeySchemaElement
           .builder()
-          .attributeName("j_timestamp")
+          .attributeName(AuditTrail.sortKeyName)
           .keyType(RANGE)
           .build()
       )
       .attributeDefinitions(
         AttributeDefinition
           .builder()
-          .attributeName("j_account")
-          .attributeType("S")
+          .attributeName(AuditTrail.partitionKeyName)
+          .attributeType(S)
           .build(),
         AttributeDefinition
           .builder()
-          .attributeName("j_timestamp")
-          .attributeType("N")
+          .attributeName(AuditTrail.sortKeyName)
+          .attributeType(N)
           .build(),
         AttributeDefinition
           .builder()
-          .attributeName("j_username")
-          .attributeType("S")
+          .attributeName(AuditTrail.userNameAttrName)
+          .attributeType(S)
           .build()
       )
       .globalSecondaryIndexes(
         GlobalSecondaryIndex
           .builder()
-          .indexName("AuditTrailByUser")
+          .indexName(AuditTrail.secondaryIndexName)
           .keySchema(
             KeySchemaElement
               .builder()
-              .attributeName("j_username")
+              .attributeName(AuditTrail.userNameAttrName)
               .keyType(HASH)
               .build(),
             KeySchemaElement
               .builder()
-              .attributeName("j_timestamp")
+              .attributeName(AuditTrail.sortKeyName)
               .keyType(RANGE)
               .build()
           )
@@ -137,7 +136,7 @@ class AuditTrailDBTest extends AnyFreeSpec with Matchers {
       dynamoDB: DynamoDbClient
   ): DeleteTableResponse = {
     val request =
-      DeleteTableRequest.builder().tableName(AuditTrailDB.tableName).build()
+      DeleteTableRequest.builder().tableName(AuditTrail.tableName).build()
     dynamoDB.deleteTable(request)
   }
 }

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -59,8 +59,8 @@ class AuditTrailTest
     "sets up other attributes with db fieldnames" in {
       val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
       attrs.toMap shouldEqual Map(
-        partitionKeyName -> AttributeValue.fromS("account"),
-        sortKeyName -> AttributeValue.fromN(1446650520000L.toString),
+        accountPartitionKeyName -> AttributeValue.fromS("account"),
+        timestampSortKeyName -> AttributeValue.fromN(1446650520000L.toString),
         userNameAttrName -> AttributeValue.fromS("username"),
         durationAttrName -> AttributeValue.fromN(3600.toString),
         accessLevelAttrName -> AttributeValue.fromS("accessLevel"),
@@ -80,9 +80,9 @@ class AuditTrailTest
   "auditLogFromAttrs" - {
     "given valid attributes" - {
       val attrs = Map(
-        partitionKeyName -> AttributeValue.fromS("account"),
+        accountPartitionKeyName -> AttributeValue.fromS("account"),
         userNameAttrName -> AttributeValue.fromS("username"),
-        sortKeyName -> AttributeValue.fromN("1446650520000"),
+        timestampSortKeyName -> AttributeValue.fromN("1446650520000"),
         durationAttrName -> AttributeValue.fromN("3600"),
         accessLevelAttrName -> AttributeValue.fromS("dev"),
         accessTypeAttrName -> AttributeValue.fromS("console"),
@@ -113,7 +113,7 @@ class AuditTrailTest
       val attrs = Map(
         // missing account
         userNameAttrName -> AttributeValue.fromS("username"),
-        sortKeyName -> AttributeValue.fromN("1446650520000"),
+        timestampSortKeyName -> AttributeValue.fromN("1446650520000"),
         durationAttrName -> AttributeValue.fromN("3600"),
         accessLevelAttrName -> AttributeValue.fromS("dev"),
         accessTypeAttrName -> AttributeValue.fromS("console"),

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -2,6 +2,7 @@ package logic
 
 import com.gu.janus.model.{AuditLog, JConsole, JCredentials}
 import com.gu.janus.testutils.{HaveMatchers, RightValues}
+import logic.AuditTrail._
 import org.joda.time.{DateTime, DateTimeZone, Duration}
 import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
@@ -28,13 +29,13 @@ class AuditTrailTest
     )
 
     "sets up the hash key" in {
-      val (hashKey, _, _) = AuditTrail.auditLogAttrs(al)
-      hashKey shouldEqual "account"
+      val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
+      attrs.partitionKey._2.s() shouldEqual "account"
     }
 
     "sets up the (date) range key as milliseconds" in {
-      val (_, rangeKey, _) = AuditTrail.auditLogAttrs(al)
-      rangeKey shouldEqual 1446650520000L
+      val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
+      attrs.sortKey._2.n().toLong shouldEqual 1446650520000L
     }
 
     "sets up the (date) range key correctly even when BST is in effect" in {
@@ -42,43 +43,45 @@ class AuditTrailTest
         new DateTime(2015, 11, 4, 16, 22, DateTimeZone.forOffsetHours(1))
       )
       //                        hour and timezone changed ---^--------------------^
-      val (_, rangeKey, _) = AuditTrail.auditLogAttrs(al2)
-      rangeKey shouldEqual 1446650520000L
+      val attrs = AuditLogDbEntryAttrs.fromAuditLog(al2)
+      attrs.sortKey._2.n().toLong shouldEqual 1446650520000L
     }
 
     "converts duration type to seconds" in {
-      val (_, _, attrs) = AuditTrail.auditLogAttrs(al)
-      attrs.find(_._1 == "j_duration").map(_._2).value shouldEqual 3600
+      val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
+      attrs.sessionDuration._2.n().toInt shouldEqual 3600
     }
 
     "sets up other attributes with db fieldnames" in {
-      val (_, _, attrs) = AuditTrail.auditLogAttrs(al)
-      attrs shouldEqual List(
-        "j_username" -> "username",
-        "j_duration" -> 3600,
-        "j_accessLevel" -> "accessLevel",
-        "j_accessType" -> "credentials",
-        "j_external" -> 1
+      val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
+      attrs.toMap shouldEqual Map(
+        partitionKeyName -> AttributeValue.fromS("account"),
+        sortKeyName -> AttributeValue.fromN(1446650520000L.toString),
+        userNameAttrName -> AttributeValue.fromS("username"),
+        durationAttrName -> AttributeValue.fromN(3600.toString),
+        accessLevelAttrName -> AttributeValue.fromS("accessLevel"),
+        accessTypeAttrName -> AttributeValue.fromS("credentials"),
+        isExternalAttrName -> AttributeValue.fromN(1.toString)
       )
     }
 
     "sets up console type correctly" in {
-      val (_, _, attrs) =
-        AuditTrail.auditLogAttrs(al.copy(accessType = JConsole))
-      attrs should contain("j_accessType" -> "console")
+      val attrs =
+        AuditLogDbEntryAttrs.fromAuditLog(al.copy(accessType = JConsole))
+      attrs.accessType._2.s() shouldEqual "console"
     }
   }
 
   "auditLogFromAttrs" - {
     "given valid attributes" - {
       val attrs = Map(
-        "j_account" -> AttributeValue.fromS("account"),
-        "j_username" -> AttributeValue.fromS("username"),
-        "j_timestamp" -> AttributeValue.fromN("1446650520000"),
-        "j_duration" -> AttributeValue.fromN("3600"),
-        "j_accessLevel" -> AttributeValue.fromS("dev"),
-        "j_accessType" -> AttributeValue.fromS("console"),
-        "j_external" -> AttributeValue.fromN("1")
+        partitionKeyName -> AttributeValue.fromS("account"),
+        userNameAttrName -> AttributeValue.fromS("username"),
+        sortKeyName -> AttributeValue.fromN("1446650520000"),
+        durationAttrName -> AttributeValue.fromN("3600"),
+        accessLevelAttrName -> AttributeValue.fromS("dev"),
+        accessTypeAttrName -> AttributeValue.fromS("console"),
+        isExternalAttrName -> AttributeValue.fromN("1")
       )
 
       "extracts an audit log from valid attributes" in {
@@ -104,12 +107,12 @@ class AuditTrailTest
     "when missing a required field" - {
       val attrs = Map(
         // missing account
-        "j_username" -> AttributeValue.fromS("username"),
-        "j_timestamp" -> AttributeValue.fromN("1446650520000"),
-        "j_duration" -> AttributeValue.fromN("3600"),
-        "j_accessLevel" -> AttributeValue.fromS("dev"),
-        "j_accessType" -> AttributeValue.fromS("console"),
-        "j_external" -> AttributeValue.fromN("1")
+        userNameAttrName -> AttributeValue.fromS("username"),
+        sortKeyName -> AttributeValue.fromN("1446650520000"),
+        durationAttrName -> AttributeValue.fromN("3600"),
+        accessLevelAttrName -> AttributeValue.fromS("dev"),
+        accessTypeAttrName -> AttributeValue.fromS("console"),
+        isExternalAttrName -> AttributeValue.fromN("1")
       )
 
       "fails to extract an AccessLog record" in {

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -30,12 +30,14 @@ class AuditTrailTest
 
     "sets up the hash key" in {
       val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
-      attrs.partitionKey._2.s() shouldEqual "account"
+      val (_, value) = attrs.partitionKey
+      value.s() shouldEqual "account"
     }
 
     "sets up the (date) range key as milliseconds" in {
       val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
-      attrs.sortKey._2.n().toLong shouldEqual 1446650520000L
+      val (_, value) = attrs.sortKey
+      value.n().toLong shouldEqual 1446650520000L
     }
 
     "sets up the (date) range key correctly even when BST is in effect" in {
@@ -44,12 +46,14 @@ class AuditTrailTest
       )
       //                        hour and timezone changed ---^--------------------^
       val attrs = AuditLogDbEntryAttrs.fromAuditLog(al2)
-      attrs.sortKey._2.n().toLong shouldEqual 1446650520000L
+      val (_, value) = attrs.sortKey
+      value.n().toLong shouldEqual 1446650520000L
     }
 
     "converts duration type to seconds" in {
       val attrs = AuditLogDbEntryAttrs.fromAuditLog(al)
-      attrs.sessionDuration._2.n().toInt shouldEqual 3600
+      val (_, value) = attrs.sessionDuration
+      value.n().toInt shouldEqual 3600
     }
 
     "sets up other attributes with db fieldnames" in {
@@ -68,7 +72,8 @@ class AuditTrailTest
     "sets up console type correctly" in {
       val attrs =
         AuditLogDbEntryAttrs.fromAuditLog(al.copy(accessType = JConsole))
-      attrs.accessType._2.s() shouldEqual "console"
+      val (_, value) = attrs.accessType
+      value.s() shouldEqual "console"
     }
   }
 


### PR DESCRIPTION
This change optimises and simplifies some of the code that manages interactions with the audit trail DB table.

## Changes
1. Removal of redundant [calls to describe table](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/app/aws/AuditTrailDB.scala#L22-L25).
   The name of the table and its key schema are already hardcoded throughout the code so it seems redundant to occasionally look these details up as well.
2. Removal of redundant table name parameter from various methods.
   As mentioned above, the table name is already hardcoded so need to pass it around as a parameter.
3. Replaced an awkward tuple with a case class, as suggested in [this comment](https://github.com/guardian/janus-app/pull/500#discussion_r1944762210).
4. Replaced repeated use of string literal table attribute names with shared constants.
   To make it clear where the same field is being used, what it is and avoid typos etc.
5. Some breakdown of functions to make them more readable.
6. Separation of concerns between [AuditTrail](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/app/logic/AuditTrail.scala) and [AuditTrailDB](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/app/aws/AuditTrailDB.scala) now clearer as the former does all marshalling of data between database and internal formats while AuditTableDB makes the requests.

## To test
These tests have been done locally and need to be repeated in production:

- [ ] Go to audit table and find a known access record => should appear correctly and correspond with what's in Dynamo DB table
- [ ] Sign into AWS console from Janus, go back to Janus and look at audit table => should see a new access record with fields as expected
- [ ] Request credentials from Janus and then look at audit table => should see a new access record with fields as expected
