### PR TITLE
feat: use nvmrc file for node version

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with: 
-          node-version: '22' # Ensure this matches the version in Janus: https://github.com/guardian/janus/blob/main/.nvmrc
+          node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,2 @@
+# Ensure this matches the version in Janus: https://github.com/guardian/janus/blob/main/.nvmrc
+22


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Adds an `.nvmrc` file for the Node version and references this in the 'Install Node' step of the `trigger-private-janus-build` action. 

## What is the value of this change and how do we measure success?

This follows from a [comment on the related Janus PR](https://github.com/guardian/janus/pull/4612#discussion_r1973545446), which will also reference the `.nvmrc` file.