### PR TITLE
Read Play secret from param store

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -39,10 +39,13 @@ class AppComponents(context: ApplicationLoader.Context)
     case _         => "DEV"
   }
 
+  // Reads Play secret from SSM
   val secretStateSupplier: SnapshotProvider =
     new parameterstore.SecretSupplier(
       TransitionTiming(
+        // When a new secret value is read it isn't used immediately, to keep all EC2 instances in sync.  The new value is used after the usageDelay has passed.
         usageDelay = Duration.ofMinutes(3),
+        // Old secret values are still respected for an overlapDuration.
         overlapDuration = Duration.ofHours(2)
       ),
       s"/$stage/security/janus/play.http.secret.key",

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,5 +1,7 @@
 import aws.Clients
 import com.gu.googleauth.AuthAction
+import com.gu.play.secretrotation._
+import com.gu.play.secretrotation.aws.parameterstore
 import com.typesafe.config.ConfigException
 import conf.Config
 import controllers._
@@ -14,28 +16,48 @@ import router.Routes
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
+import java.time.Duration
+
 class AppComponents(context: ApplicationLoader.Context)
     extends BuiltInComponentsFromContext(context)
     with AhcWSComponents
     with AssetsComponents
     with HttpFiltersComponents
+    with RotatingSecretComponents
     with Logging {
 
   override def httpFilters: Seq[EssentialFilter] =
     super.httpFilters :+ new HstsFilter
 
+  // used by the template to detect development environment
+  // in that situation, it'll load assets directly from npm vs production, where they'll come from the bundled files
+  val mode: Mode = context.environment.mode
+
+  // Janus has no Code stage
+  private val stage = mode match {
+    case Mode.Prod => "PROD"
+    case _         => "DEV"
+  }
+
+  val secretStateSupplier: SnapshotProvider =
+    new parameterstore.SecretSupplier(
+      TransitionTiming(
+        usageDelay = Duration.ofMinutes(3),
+        overlapDuration = Duration.ofHours(2)
+      ),
+      s"/$stage/security/janus/play.http.secret.key",
+      parameterstore.AwsSdkV2(Clients.ssm)
+    )
+
   val host = Config.host(configuration)
-  val googleAuthConfig = Config.googleSettings(configuration, httpConfiguration)
+  val googleAuthConfig =
+    Config.googleSettings(configuration, secretStateSupplier)
   val googleGroupChecker = Config.googleGroupChecker(configuration)
   val requiredGoogleGroups = Set(Config.twoFAGroup(configuration))
   val dynamodDB =
     if (context.environment.mode == play.api.Mode.Prod)
       DynamoDbClient.builder().region(EU_WEST_1).build()
     else Clients.localDb
-
-  // used by the template to detect development environment
-  // in that situation, it'll load assets directly from npm vs production, where they'll come from the bundled files
-  val mode: Mode = context.environment.mode
 
   val janusData = Config.janusData(configuration)
 

--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -1,6 +1,5 @@
 package conf
 
-import java.io.{File, FileInputStream}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.gu.googleauth.{
   AntiForgeryChecker,
@@ -9,11 +8,11 @@ import com.gu.googleauth.{
 }
 import com.gu.janus.JanusConfig
 import com.gu.janus.model._
+import com.gu.play.secretrotation.SnapshotProvider
 import models._
 import play.api.Configuration
-import play.api.http.HttpConfiguration
 
-import scala.annotation.nowarn
+import java.io.{File, FileInputStream}
 import scala.util.Try
 
 object Config {
@@ -58,23 +57,19 @@ object Config {
 
   def googleSettings(
       config: Configuration,
-      httpConfiguration: HttpConfiguration
+      secretStateSupplier: SnapshotProvider
   ): GoogleAuthConfig = {
     val clientId = requiredString(config, "auth.google.clientId")
     val clientSecret = requiredString(config, "auth.google.clientSecret")
     val domain = requiredString(config, "auth.domain")
     val redirectUrl = s"${requiredString(config, "host")}/oauthCallback"
 
-    @nowarn
-    val legacyAntiForgeryChecker =
-      AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
-
     GoogleAuthConfig(
       clientId = clientId,
       clientSecret = clientSecret,
       redirectUrl = redirectUrl,
       domains = List(domain),
-      antiForgeryChecker = legacyAntiForgeryChecker
+      antiForgeryChecker = AntiForgeryChecker(secretStateSupplier)
     )
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,8 @@ lazy val root: Project = (project in file("."))
       ws,
       filters,
       "com.gu.play-googleauth" %% "play-v30" % "20.3.0",
+      "com.gu.play-secret-rotation" %% "play-v30" % "13.2.0",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % "13.2.0",
       "software.amazon.awssdk" % "iam" % awsSdkVersion,
       "software.amazon.awssdk" % "sts" % awsSdkVersion,
       "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,18 +1,6 @@
 # This is the main configuration file for the application.
 # ~~~~~
 
-# Secret key
-# ~~~~~
-# The secret key is used to secure cryptographics functions.
-#
-# This must be changed for production, but we recommend not changing it in this file.
-#
-# See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-# Note, only play.http.secret.key is relevant to 2.8. The others can be removed shortly.
-application.secret=${APPLICATION_SECRET}
-play.crypto.secret=${APPLICATION_SECRET}
-play.http.secret.key=${APPLICATION_SECRET}
-
 # The application languages
 # ~~~~~
 application.langs="en"
@@ -87,4 +75,3 @@ auth {
     2faGroupId=${2FA_GROUP_ID}
   }
 }
-


### PR DESCRIPTION
## What is the purpose of this change?
This change integrates [Play secret rotation](https://github.com/guardian/play-secret-rotation) into the app.  The secret is now read from SSM param store, rather than from a config file.  We aren't yet automatically rotating the secret - that is still a manual step for now.

## What is the value of this change and how do we measure success?
Once this has been fully set up, we will have an automatically updated secret, which will safe us some toil and keep us secure.

## Any additional notes?
Before this can be merged:
- [x] EC2 instance profile needs permission to read from parameter store

## To verify in production
- [ ] App loads successfully with no new errors in log

Co-authored-by: @tjsilver