### PR TITLE
fix: console error in audit page

### DIFF
--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -103,7 +103,7 @@
                         <div class="file-path-wrapper">
                             <input type="date" name="audit-date" id="datepicker-audit" class="datepicker audit-log" min="2015-10-02" max="@rawDate(new org.joda.time.DateTime())">
                         </div>
-                        <button class="btn" id="audit-submit">submit</button>
+                        <button type="submit" class="btn" id="audit-submit" form="audit-form">Submit</button>
                     </div>
                 </form>
             </div>

--- a/frontend/janus.js
+++ b/frontend/janus.js
@@ -15,12 +15,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const dropdownInstances = M.Dropdown.init(dropdownElems);  
     const tooltipElems = document.querySelectorAll('.tooltipped');
     const instances = M.Tooltip.init(tooltipElems);
-
-    const auditContainer = document.querySelectorAll('.container.audit');
-    if (auditContainer.length) {
-        const dateForm = document.getElementById('audit-form');
-        document.getElementById('audit-submit').on('change',() => dateForm.submit());
-    }    
   });
 
 jQuery(function($){


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

There was a console error on the audit trail page about the submit functionality: `Uncaught TypeError: document.getElementById(...).on is not a function`.

The javascript code was calling an `.on('submit')` function for the button element. It turns out this functionality isn't required anyway, as the `<button>` element by default has the type of 'submit' and will submit the form without the need for javascript. 

I have removed the javascript and made the functionality of the button more explicit by specifying its parent form id and giving it the type of 'submit'.

## What is the value of this change and how do we measure success?

No console error and datepicker continues to work as expected.
