### PR TITLE
refactor: update application.conf filters

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -67,7 +67,7 @@ play {
 
   filters {
     hosts.allowed = [ "." ]  # allow all hosts because we're behind an ELB with a dynamic hostname
-    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline'"
+    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'"
   }
 
   # Trust all proxies (the internet can't reach us directly so this is safe)


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

- Resolve the console errors observed in Chrome `Refused to load the font...` because it violates the following Content Security Policy directive: "font-src 'self' ` by adding `data:` to the font source CSP
- Remove the external fonts sources from the CSP - we now include fonts as part of the bundle. These sources are not referenced anywhere else in the codebase so should be safe to remove.

## What is the value of this change and how do we measure success?

No console errors

