### PR TITLE
docs: add info about Node bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ access to AWS resources.
 
 ## Running Janus
 
-Janus is a Scala application built on the Play Framework.
+Janus is a Scala application built on the Play Framework with a Node frontend build.
 
 Wherever you run Janus, you need to provide three configuration files:
 
@@ -112,6 +112,10 @@ Use Scala's build tool
 ([sbt](https://www.scala-sbt.org/download.html)) to build and run
 Janus.
 
+#### Install Node
+
+The version is specified in `.nvmrc`. Dependencies will be installed as part of the sbt run command.
+
 #### Obtain configuration
 
 The configuration section below explains the requirements in more
@@ -127,8 +131,11 @@ This will likely involve DNS or a hosts entry as well as a webserver
 
 #### Run Janus
 
-Use sbt to run Janus in development mode. The server will
-automatically recompile and reload when changes are made.
+Use sbt to run Janus in development mode. 
+
+The Node bundle is built using a `PlayRunHook`.
+
+The server will automatically recompile and reload when changes are made.
 
     sbt -Dconfig.file=<PATH>/janus.local.conf run
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ Janus.
 
 #### Install Node
 
-The version is specified in `.nvmrc`. Dependencies will be installed as part of the sbt run command.
+The version is specified in `.nvmrc`. Dependencies will be installed as part of the sbt run command. 
+
+When developing locally, you can also run `npm --prefix frontend i` from the project root to install dependencies.
 
 #### Obtain configuration
 
@@ -133,11 +135,12 @@ This will likely involve DNS or a hosts entry as well as a webserver
 
 Use sbt to run Janus in development mode. 
 
-The Node bundle is built using a `PlayRunHook`.
-
-The server will automatically recompile and reload when changes are made.
-
     sbt -Dconfig.file=<PATH>/janus.local.conf run
+
+The Node bundle is built using a [`PlayRunHook`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/project/RunClientHook.scala#L1) which is [configured in `build.sbt`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/build.sbt#L80).
+
+The frontend dev-server will automatically recompile and reload when changes are made.
+
 
 #### Local audit log support
 

--- a/project/RunClientHook.scala
+++ b/project/RunClientHook.scala
@@ -4,7 +4,7 @@ import sbt._
 import scala.sys.process.Process
 
 /** Frontend build play run hook.
-  * https://www.playframework.com/documentation/2.8.x/SBTCookbook
+  * https://www.playframework.com/documentation/3.0.x/sbtCookbook#Hooking-into-Plays-dev-mode
   */
 object RunClientHook {
   def apply(base: File): PlayRunHook = {


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

- Adds information to the documentation outlining the addition of a Node frontend bundle.
- Updates the link to the `PlayRunHook` docs.



