### PR TITLE
Update the accounts information page

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -113,7 +113,7 @@ class AppComponents(context: ApplicationLoader.Context)
       googleGroupChecker,
       requiredGoogleGroups
     )(wsClient, executionContext, mode, assetsFinder),
-    new Utility(janusData, controllerComponents, authAction)(
+    new Utility(janusData, controllerComponents, authAction, configuration)(
       mode,
       assetsFinder
     ),

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -2,16 +2,21 @@ package controllers
 
 import com.gu.googleauth.AuthAction
 import com.gu.janus.model.JanusData
+import conf.Config
 import logic.Owners
-import play.api.Mode
+import play.api.{Configuration, Logging, Mode}
 import play.api.mvc._
+
+import scala.util.{Failure, Try}
 
 class Utility(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
-    authAction: AuthAction[AnyContent]
+    authAction: AuthAction[AnyContent],
+    configuration: Configuration
 )(implicit mode: Mode, assetsFinder: AssetsFinder)
-    extends AbstractController(controllerComponents) {
+    extends AbstractController(controllerComponents)
+    with Logging {
 
   def healthcheck = Action {
     Ok("ok")
@@ -19,9 +24,22 @@ class Utility(
 
   def accounts = authAction { implicit request =>
     val sortedAccounts = janusData.accounts.toList.sortBy(_.name.toLowerCase)
-    val owners = sortedAccounts.map(account =>
-      account -> Owners.accountOwners(account, janusData.access)
-    )
-    Ok(views.html.accounts(owners, request.user, janusData))
+    val accountData =
+      sortedAccounts.map { awsAccount =>
+        (
+          awsAccount,
+          Owners.accountPermissions(awsAccount, janusData.access),
+          Config.accountNumber(awsAccount.authConfigKey, configuration)
+        )
+      }
+    // log any account number errors we accumulated
+    accountData
+      .collect { case (account, _, Failure(err)) =>
+        (account, err)
+      }
+      .foreach { case (account, err) =>
+        logger.warn(s"Couldn't lookup account number for ${account.name}", err)
+      }
+    Ok(views.html.accounts(accountData, request.user, janusData))
   }
 }

--- a/app/logic/Owners.scala
+++ b/app/logic/Owners.scala
@@ -1,43 +1,16 @@
 package logic
 
-import com.gu.janus.model.{ACL, AccountOwners, AwsAccount}
+import com.gu.janus.model.{ACL, AwsAccount, Permission}
 
 object Owners {
-  def accountOwners(account: AwsAccount, acl: ACL): AccountOwners = {
-    val permissions = accountPermissions(account, acl)
-
-    // hard-coded admin/dev conventions for now, TODO: improve accounts page
-    val admins = permissions
-      .filter { case (_, userPerms) =>
-        userPerms.exists(_.label == "cloudformation")
-      }
-      .keys
-      .toList
-      .sorted
-    val devs = permissions
-      .filter { case (username, userPerms) =>
-        userPerms.exists(_.label == "dev") && !admins.contains(username)
-      }
-      .keys
-      .toList
-      .sorted
-    val others = permissions
-      .filter { case (username, _) =>
-        !admins.contains(username) && !devs.contains(username)
-      }
-      .keys
-      .toList
-      .sorted
-
-    AccountOwners(admins, devs, others)
-  }
-
-  def accountPermissions(account: AwsAccount, acl: ACL) = {
+  def accountPermissions(account: AwsAccount, acl: ACL): List[(String, Set[Permission])] = {
     acl.userAccess
       .flatMap { case (username, permissions) =>
         if (permissions.exists(_.account == account))
           Some(username -> permissions.filter(_.account == account))
         else None
       }
+      .toList
+      .sortBy(_._1)
   }
 }

--- a/app/logic/Owners.scala
+++ b/app/logic/Owners.scala
@@ -3,7 +3,10 @@ package logic
 import com.gu.janus.model.{ACL, AwsAccount, Permission}
 
 object Owners {
-  def accountPermissions(account: AwsAccount, acl: ACL): List[(String, Set[Permission])] = {
+  def accountPermissions(
+      account: AwsAccount,
+      acl: ACL
+  ): List[(String, Set[Permission])] = {
     acl.userAccess
       .flatMap { case (username, permissions) =>
         if (permissions.exists(_.account == account))

--- a/app/logic/Owners.scala
+++ b/app/logic/Owners.scala
@@ -32,7 +32,11 @@ object Owners {
       .sortBy(_._1)
   }
 
-  def accountIdErrors(accountData: Seq[(AwsAccount, List[(String, Set[Permission])], Try[String])]): Seq[(AwsAccount, Throwable)] = {
+  def accountIdErrors(
+      accountData: Seq[
+        (AwsAccount, List[(String, Set[Permission])], Try[String])
+      ]
+  ): Seq[(AwsAccount, Throwable)] = {
     accountData
       .collect { case (account, _, Failure(err)) =>
         (account, err)

--- a/app/logic/ViewHelpers.scala
+++ b/app/logic/ViewHelpers.scala
@@ -18,7 +18,10 @@ object ViewHelpers {
   }
 
   // Scala function so we can test it properly
-  private[logic] def columnify[A](columnCount: Int, as: List[A]): List[List[A]] = {
+  private[logic] def columnify[A](
+      columnCount: Int,
+      as: List[A]
+  ): List[List[A]] = {
     val emptyAcc: Map[Int, List[A]] =
       (0.until(columnCount)).map(i => i -> Nil).toMap
     as.zipWithIndex

--- a/app/logic/ViewHelpers.scala
+++ b/app/logic/ViewHelpers.scala
@@ -16,4 +16,34 @@ object ViewHelpers {
          | aws configure set aws_session_token ${credentials.sessionToken} --profile ${account.authConfigKey}""".stripMargin
     }).mkString(start = "", sep = " && \\\n", end = "\n")
   }
+
+  // Scala function so we can test it properly
+  private[logic] def columnify[A](columnCount: Int, as: List[A]): List[List[A]] = {
+    val emptyAcc: Map[Int, List[A]] =
+      (0.until(columnCount)).map(i => i -> Nil).toMap
+    as.zipWithIndex
+      .foldRight[Map[Int, List[A]]](emptyAcc) { case ((a, i), acc) =>
+        val column = i % columnCount
+        acc.updated(column, a :: acc(column))
+      }
+      .toList
+      .sortBy(_._1)
+      .map(_._2)
+  }
+
+  def getColumn[A](columnCount: Int, as: List[A], column: Int): List[A] = {
+    assert(columnCount > 0, "column count must be at least 1")
+    assert(
+      column >= 0,
+      "columns are 0 indexed, so column selection must be at least 0"
+    )
+    assert(
+      column < columnCount,
+      "column selection needs to be within the number of columns"
+    )
+
+    columnify(columnCount, as)
+      .lift(column)
+      .getOrElse(Nil)
+  }
 }

--- a/app/views/accounts.scala.html
+++ b/app/views/accounts.scala.html
@@ -1,33 +1,49 @@
-@import com.gu.janus.model.{AwsAccount, AccountOwners, JanusData}
+@import com.gu.janus.model.{AwsAccount, JanusData}
 @import com.gu.googleauth.UserIdentity
 @import play.api.Mode
+@import scala.util.Try
 
-@(accountOwners: List[(AwsAccount, AccountOwners)], user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@import com.gu.janus.model.Permission
+@import scala.util.Failure
+@import scala.util.Success
+@import logic.ViewHelpers
+@(accountOwners: List[(AwsAccount, List[(String, Set[Permission])], Try[String])], user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Accounts", Some(user), janusData) {
     <div class="container" xmlns="http://www.w3.org/1999/html">
         <h1 class="header orange-text">Accounts</h1>
+        @janusData.permissionsRepo match {
+          case Some(permissionsRepo) => {
+              <p>
+                  Refer to <a href="@permissionsRepo">Janus' configuration</a> for full details on who has what access to each AWS account.
+              </p>
+          }
+          case None => {
+              <p>Refer to Janus' configuration for full details on who has what access to each AWS account.</p>
+          }
+        }
         <ul class="collapsible collapsible-accordion">
-        @for((account, owners) <- accountOwners) {
+        @for((account, owners, tryAccountNumber) <- accountOwners) {
             <li class="owners__container">
                 <div class="owners__header collapsible-header">
+                    <span>
                     @account.name
-                    <div class="right hide-on-small-only">
-                        <div class="chip">
-                            admins: @owners.admins.size
-                        </div>
 
-                        <div class="chip">
-                            devs: @owners.devs.size
-                        </div>
-
-                        <div class="chip">
-                            other: @owners.others.size
-                        </div>
-                    </div>
-                    <div class="right hide-on-med-and-up">
-                        <div class="chip">
-                            accounts: @{owners.admins.size + owners.devs.size + owners.others.size}
+                    </span>
+                    <div class="right">
+                        <span class="chip">
+                            @tryAccountNumber match {
+                                case Failure(_) => {
+                                    No account number
+                            }
+                                case Success(accountNumber) => {
+                                    @accountNumber
+                                }
+                            }
+                        </span>
+                        <div class="owner-count right-align">
+                            @owners.size
+                            <i class="material-icons tiny minor-header-icon">person</i>
                         </div>
                     </div>
                 </div>
@@ -41,36 +57,54 @@
                             @if(owners.isEmpty) {
                                 <p>There are no Janus-managed users for this account.</p>
                             } else {
-                                    @if(owners.admins.nonEmpty) {
-                                        <div class="col m4">
-                                            <p class="owners__list--heading">Admins</p>
-                                            <ul class="owners__list">
-                                            @for(admin <- owners.admins) {
-                                                <li>@admin</li>
-                                            }
+                                @* We generate 1, 2 and 3 col versions of this and show/hide responsively *@
+                                <div class="hide-on-med-and-up">
+                                    @* 1 column on small devices *@
+                                    <div class="row">
+                                        <div class="col s12">
+                                            <ul class="collection">
+                                                @for(user <- owners) {
+                                                    <li class="collection-item">@user._1</li>
+                                                }
                                             </ul>
                                         </div>
-                                    }
-                                    @if(owners.devs.nonEmpty) {
-                                        <div class="col m4">
-                                            <p class="owners__list--heading">Devs</p>
-                                            <ul class="owners__list">
-                                            @for(dev <- owners.devs) {
-                                                <li>@dev</li>
+                                    </div>
+                                </div>
+                                <div class="show-on-medium hide-on-large-only hide-on-small-and-down">
+                                    @* 2 columns on medium devices *@
+                                    <div class="row">
+                                        <ul class="collection col m6">
+                                            @for(user <- ViewHelpers.getColumn(2, owners, 0)) {
+                                                <li class="collection-item">@user._1</li>
                                             }
-                                            </ul>
-                                        </div>
-                                    }
-                                    @if(owners.others.nonEmpty) {
-                                        <div class="col m4">
-                                            <p class="owners__list--heading">Others</p>
-                                            <ul class="owners__list">
-                                            @for(other <- owners.others) {
-                                                <li>@other</li>
+                                        </ul>
+                                        <ul class="collection col m6">
+                                            @for(user <- ViewHelpers.getColumn(2, owners, 1)) {
+                                                <li class="collection-item">@user._1</li>
                                             }
-                                            </ul>
-                                        </div>
-                                    }
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="hide-on-med-and-down">
+                                    @* 3 columns on large devices *@
+                                    <div class="row">
+                                        <ul class="collection col l4">
+                                            @for(user <- ViewHelpers.getColumn(3, owners, 0)) {
+                                                <li class="collection-item">@user._1</li>
+                                            }
+                                        </ul>
+                                        <ul class="collection col l4">
+                                            @for(user <- ViewHelpers.getColumn(3, owners, 1)) {
+                                                <li class="collection-item">@user._1</li>
+                                            }
+                                        </ul>
+                                        <ul class="collection col l4">
+                                            @for(user <- ViewHelpers.getColumn(3, owners, 2)) {
+                                                <li class="collection-item">@user._1</li>
+                                            }
+                                        </ul>
+                                    </div>
+                                </div>
                             }
                         </div>
                     </div>

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -108,14 +108,3 @@ case class AuditLog(
     accessType: JanusAccessType,
     external: Boolean
 )
-
-case class AccountOwners(
-    admins: List[String],
-    devs: List[String],
-    others: List[String]
-) {
-  val isEmpty = admins.isEmpty && devs.isEmpty && others.isEmpty
-}
-object AccountOwners {
-  def empty = AccountOwners(Nil, Nil, Nil)
-}

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -362,6 +362,7 @@ a.copy-text--button__small {
 
 .account-summary__container {
     position: relative;
+    padding-top: 42px;
 }
 
 .account-summary__button--audit {
@@ -386,12 +387,15 @@ a.copy-text--button__small {
     line-height: 3rem;
 }
 
-.owners__list {
-    font-size: 0.9rem;
+.owners__header.collapsible-header i.minor-header-icon {
+    font-size: 1rem;
+    width: auto;
+    margin-right: 0;
 }
 
-.owners__list--heading {
-    font-weight: bold;
+.owners__header .owner-count {
+    display: inline-block;
+    min-width: 50px;
 }
 
 .collapsible-body--small-padding {

--- a/test/conf/ConfigTest.scala
+++ b/test/conf/ConfigTest.scala
@@ -21,7 +21,7 @@ class ConfigTest extends AnyFreeSpec with Matchers {
             |    foo.aws.roleArn="arn:aws:iam::123456789012:role/test-role"
             |  }
             |}
-            """.stripMargin
+            |""".stripMargin
         )
       )
       Config.roleArn(
@@ -40,7 +40,7 @@ class ConfigTest extends AnyFreeSpec with Matchers {
             |    foo.aws.roleArn="arn:aws:iam::123456789012:role/test-role"
             |  }
             |}
-            """.stripMargin
+            |""".stripMargin
         )
       )
       Config.accountNumber("foo", config) shouldEqual Success("123456789012")
@@ -54,7 +54,7 @@ class ConfigTest extends AnyFreeSpec with Matchers {
             |    foo.aws.roleArn="arn:aws:iam::123456789012:role/test-role"
             |  }
             |}
-            """.stripMargin
+            |""".stripMargin
         )
       )
       Config.accountNumber("bar", config).isFailure shouldBe true
@@ -68,7 +68,7 @@ class ConfigTest extends AnyFreeSpec with Matchers {
             |    foo.aws.roleArn="not a role ARN like we expect"
             |  }
             |}
-            """.stripMargin
+            |""".stripMargin
         )
       )
       Config.accountNumber("foo", config).isFailure shouldBe true
@@ -109,11 +109,10 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should succeed if both account lists are empty" in {
         val emptyConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |   }
-               | }
+            s"""{
+               |  federation {
+               |  }
+               |}
              """.stripMargin
           )
         )
@@ -128,15 +127,14 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should succeed if janusData and config contain the exact same accounts" in {
         val exampleConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |     foo.aws.roleArn=role
-               |     bar.aws.roleArn=role
-               |     baz.aws.roleArn=role
-               |   }
-               | }
-             """.stripMargin
+            s"""{
+               |  federation {
+               |    foo.aws.roleArn=role
+               |    bar.aws.roleArn=role
+               |    baz.aws.roleArn=role
+               |  }
+               |}
+               |""".stripMargin
           )
         )
         val janusData =
@@ -151,13 +149,12 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should return an error including the account missing from the config" in {
         val exampleConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |     foo.aws.roleArn=role
-               |     baz.aws.roleArn=role
-               |   }
-               | }
+            s"""{
+               |  federation {
+               |    foo.aws.roleArn=role
+               |    baz.aws.roleArn=role
+               |  }
+               |}
            """.stripMargin
           )
         )
@@ -173,12 +170,11 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should return an error including all of the accounts missing from the config" in {
         val exampleConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |     foo.aws.roleArn=role
-               |   }
-               | }
+            s"""{
+               |  federation {
+               |    foo.aws.roleArn=role
+               |  }
+               |}
            """.stripMargin
           )
         )
@@ -194,15 +190,14 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should warn if janusData is missing an account" in {
         val exampleConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |     foo.aws.roleArn=role
-               |     bar.aws.roleArn=role
-               |     baz.aws.roleArn=role
-               |   }
-               | }
-             """.stripMargin
+            s"""{
+               |  federation {
+               |    foo.aws.roleArn=role
+               |    bar.aws.roleArn=role
+               |    baz.aws.roleArn=role
+               |  }
+               |}
+               |""".stripMargin
           )
         )
         val janusData = testJanusData.copy(accounts = Set(fooAct, bazAct))
@@ -216,15 +211,14 @@ class ConfigTest extends AnyFreeSpec with Matchers {
       "should warn if janusData is missing more than one account" in {
         val exampleConfig = Configuration(
           ConfigFactory.parseString(
-            s"""
-               | {
-               |   federation {
-               |     foo.aws.roleArn=role
-               |     bar.aws.roleArn=role
-               |     baz.aws.roleArn=role
-               |   }
-               | }
-             """.stripMargin
+            s"""{
+               |  federation {
+               |    foo.aws.roleArn=role
+               |    bar.aws.roleArn=role
+               |    baz.aws.roleArn=role
+               |  }
+               |}
+               |""".stripMargin
           )
         )
         val janusData = testJanusData.copy(accounts = Set(fooAct))

--- a/test/logic/OwnersTest.scala
+++ b/test/logic/OwnersTest.scala
@@ -1,6 +1,6 @@
 package logic
 
-import com.gu.janus.model.{ACL, AccountOwners}
+import com.gu.janus.model.ACL
 import fixtures.Fixtures._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -21,50 +21,25 @@ class OwnersTest extends AnyFreeSpec with Matchers {
     Set.empty
   )
 
-  "accountOwners" - {
+  "accountPermissions" - {
     "returns empty account owners if there are no owners" in {
-      accountOwners(bazAct, acl) shouldEqual AccountOwners.empty
+      accountPermissions(bazAct, acl) shouldEqual Nil
     }
 
-    "fetches all the admins for an account" in {
-      accountOwners(fooAct, acl).admins.toSet shouldEqual Set(
-        "test.admin",
-        "test.all"
+    "fetches all the permissions for an account, ordered by username" in {
+      accountPermissions(fooAct, acl) shouldEqual List(
+        "test.admin" -> Set(fooCf),
+        "test.all" -> Set(fooDev, fooCf),
+        "test.other" -> Set(fooS3),
+        "test.user" -> Set(fooDev),
+        "test.yet-another-user" -> Set(fooDev),
+        "test.zzz-other" -> Set(fooS3)
       )
     }
 
-    "orders admins by username" in {
-      accountOwners(fooAct, acl).admins shouldEqual List(
-        "test.admin",
-        "test.all"
-      )
-    }
-
-    "fetches developers and excludes those that are also admins" in {
-      accountOwners(fooAct, acl).devs.toSet shouldEqual Set(
-        "test.user",
-        "test.yet-another-user"
-      )
-    }
-
-    "orders developers by username" in {
-      accountOwners(fooAct, acl).devs shouldEqual List(
-        "test.user",
-        "test.yet-another-user"
-      )
-    }
-
-    "fetches 'other users' and excludes those that are also admins and devs" in {
-      accountOwners(fooAct, acl).others.toSet shouldEqual Set(
-        "test.other",
-        "test.zzz-other"
-      )
-    }
-
-    "orders 'other users' by username" in {
-      accountOwners(fooAct, acl).others shouldEqual List(
-        "test.other",
-        "test.zzz-other"
+    "fetches all the permissions for a different account" in {
+      accountPermissions(barAct, acl) shouldEqual List(
+        "test.different-account" -> Set(barDev)
       )
     }
   }

--- a/test/logic/OwnersTest.scala
+++ b/test/logic/OwnersTest.scala
@@ -2,12 +2,21 @@ package logic
 
 import com.gu.janus.model.ACL
 import fixtures.Fixtures._
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class OwnersTest extends AnyFreeSpec with Matchers {
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
+
+class OwnersTest
+    extends AnyFreeSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks {
   import Owners._
 
+  val accounts = List(fooAct, barAct, bazAct, quxAct)
   val acl = ACL(
     Map(
       "test.user" -> Set(fooDev),
@@ -20,6 +29,31 @@ class OwnersTest extends AnyFreeSpec with Matchers {
     ),
     Set.empty
   )
+
+  "accountOwnerInformation" - {
+    "uses the provided lookup function to populate the role for each account" in {
+      forAll { (roleArn: String) =>
+        val result = accountOwnerInformation(accounts, acl)(account =>
+          Success(s"${account.authConfigKey}-$roleArn")
+        )
+        result.foreach { case (account, _, populatedRole) =>
+          populatedRole shouldEqual Success(
+            s"${account.authConfigKey}-$roleArn"
+          )
+        }
+      }
+    }
+
+    "sorts AWS accounts" in {
+      val shuffledAccounts1 = scala.util.Random.shuffle(accounts)
+      val shuffledAccounts2 = scala.util.Random.shuffle(accounts)
+      val result1 =
+        accountOwnerInformation(shuffledAccounts1, acl)(_ => Success("role"))
+      val result2 =
+        accountOwnerInformation(shuffledAccounts2, acl)(_ => Success("role"))
+      result1 shouldEqual result2
+    }
+  }
 
   "accountPermissions" - {
     "returns empty account owners if there are no owners" in {
@@ -41,6 +75,29 @@ class OwnersTest extends AnyFreeSpec with Matchers {
       accountPermissions(barAct, acl) shouldEqual List(
         "test.different-account" -> Set(barDev)
       )
+    }
+  }
+
+  "accountIdErrors" - {
+    "returns an empty list if all accounts were successfully looked up" in {
+      val accountData = List(
+        (fooAct, List.empty, Success("foo-role")),
+        (barAct, List.empty, Success("bar-role")),
+        (bazAct, List.empty, Success("baz-role")),
+        (quxAct, List.empty, Success("qux-role"))
+      )
+      accountIdErrors(accountData) shouldEqual Nil
+    }
+
+    "returns a list of accounts that failed their lookup" in {
+      val accountData = List(
+        (fooAct, List.empty, Success("foo-role")),
+        (barAct, List.empty, Success("bar-role")),
+        (bazAct, List.empty, Failure(new RuntimeException("baz-error"))),
+        (quxAct, List.empty, Failure(new RuntimeException("qux-error")))
+      )
+      val errorAccounts = accountIdErrors(accountData).map(_._1)
+      errorAccounts shouldEqual List(bazAct, quxAct)
     }
   }
 }

--- a/test/logic/ViewHelpersTest.scala
+++ b/test/logic/ViewHelpersTest.scala
@@ -1,7 +1,7 @@
 package logic
 
 import fixtures.Fixtures._
-import logic.ViewHelpers.shellCredentials
+import logic.ViewHelpers.{shellCredentials, columnify, getColumn}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.sts.model.Credentials
@@ -79,6 +79,88 @@ class ViewHelpersTest extends AnyFreeSpec with Matchers {
         val lines = shellCredentials(multiCreds).split('\n')
         all(lines.init) should endWith("&& \\")
       }
+    }
+  }
+
+  "columnify" - {
+    "returns the original list if 1 column is specified" in {
+      val list = List(1, 2, 3, 4, 5)
+      columnify(1, list) shouldEqual List(list)
+    }
+
+    "splits the list into 2 even columns" in {
+      val list = List(1, 2, 3, 4, 5, 6)
+      columnify(2, list) shouldEqual List(List(1, 3, 5), List(2, 4, 6))
+    }
+
+    "splits the list into 2 columns with a remainder" in {
+      val list = List(1, 2, 3, 4, 5)
+      columnify(2, list) shouldEqual List(List(1, 3, 5), List(2, 4))
+    }
+
+    "splits the list into 3 even columns" in {
+      val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9)
+      columnify(3, list) shouldEqual List(
+        List(1, 4, 7),
+        List(2, 5, 8),
+        List(3, 6, 9)
+      )
+    }
+
+    "splits the list into 3 columns with a remainder" in {
+      val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+      columnify(3, list) shouldEqual List(
+        List(1, 4, 7, 10),
+        List(2, 5, 8),
+        List(3, 6, 9)
+      )
+    }
+
+    "splits the list into 3 columns with two remainders" in {
+      val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+      columnify(3, list) shouldEqual List(
+        List(1, 4, 7, 10),
+        List(2, 5, 8, 11),
+        List(3, 6, 9)
+      )
+    }
+  }
+
+  "getColumn" - {
+    "throws an exception if column count is less than 1" in {
+      val list = List(1, 2, 3, 4, 5)
+      assertThrows[AssertionError] {
+        getColumn(0, list, 0)
+      }
+    }
+
+    "throws an exception if column is less than 0" in {
+      val list = List(1, 2, 3, 4, 5)
+      assertThrows[AssertionError] {
+        getColumn(1, list, -1)
+      }
+    }
+
+    "throws an exception if column is greater than or equal to column count" in {
+      val list = List(1, 2, 3, 4, 5)
+      assertThrows[AssertionError] {
+        getColumn(1, list, 1)
+      }
+    }
+
+    "returns the column at the specified index" in {
+      val list = List(1, 2, 3, 4, 5)
+      getColumn(1, list, 0) shouldEqual List(1, 2, 3, 4, 5)
+    }
+
+    "returns the column at the specified index for a 2 column list" in {
+      val list = List(1, 2, 3, 4, 5, 6)
+      getColumn(2, list, 0) shouldEqual List(1, 3, 5)
+    }
+
+    "returns the column at the specified index for a 3 column list" in {
+      val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9)
+      getColumn(3, list, 1) shouldEqual List(2, 5, 8)
     }
   }
 }


### PR DESCRIPTION

## What is the purpose of this change?

This adds the account number to the accounts page, which is a critical piece of information for properly understanding which account is which.

This version of the page pulls the account number from the configured role, which is a nice simple way to go about it. A more complete solution would use the configured role to call `STS.getCallerIdentity` but this isn't currently required and would make this all more complicated.

We also tidy up and simplify the "owners" display. The previous implementation dates back to Janus' early versions, where there were only "devs" and "admins". This assumption no longer holds, so we instead list everyone that has any access, and tell users to look at the Janus access config to find out more detail.

Here again, a future version could show the JSON policy(s) available to each listed user, but since this duplicates the information in Janus' configuration there's no need to add this until it is asked for.

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->



## What is the value of this change and how do we measure success?

We have an open ticket to integrate an AWS account, it would be nice for us to be able to quickly and easily check whether the account is already integrated on the Accounts page (using its account ID).

This should also make the accounts page less confusing, since it doesn't include the old dev/admin assumption.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

I'm ommitting screenshots here because they necessarily include account numbers and user details from the Janus configuration (and this is a public repository). I can screen share the layout, or you can run it locally to see how things look. 


