### PR TITLE
Bump config-tools dependency in example project

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "example",
     libraryDependencies ++= Seq(
-      "com.gu" %% "janus-config-tools" % "2.0.0",
+      "com.gu" %% "janus-config-tools" % "3.0.0",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test
     )
   )

--- a/example/src/main/scala/com/example/Support.scala
+++ b/example/src/main/scala/com/example/Support.scala
@@ -1,8 +1,9 @@
 package com.example
 
-import Policies.AccountExtensions
+import com.example.Policies.AccountExtensions
 import com.gu.janus.model.{Permission, SupportACL}
-import org.joda.time.{DateTime, DateTimeZone, Period}
+
+import java.time.{Duration, Instant, ZoneId, ZonedDateTime}
 
 object Support {
   import Accounts._
@@ -10,7 +11,7 @@ object Support {
   // helper for adding half a rota
   val tbd = ""
 
-  private val supportPeriod = Period.weeks(1)
+  private val supportPeriod = Duration.ofDays(7)
 
   /** Support rota entries.
     *
@@ -39,21 +40,23 @@ object Support {
     SupportACL.create(rota.toMap map convertRota, supportAccess, supportPeriod)
 
   /** Helper so the rota can be simply hand-written.
-    */
+   */
   private def convertRota(
       rotaEntry: ((Int, Int, Int), (String, String))
-  ): (DateTime, (String, String)) = {
+  ): (Instant, (String, String)) = {
     rotaEntry match {
       case ((year, month, day), users) =>
         // this rota changes over at 11am London time
-        new DateTime(
+        ZonedDateTime.of(
           year,
           month,
           day,
           11,
           0,
-          DateTimeZone.forID("Europe/London")
-        ) -> users
+          0,
+          0,
+          ZoneId.of("Europe/London")
+        ).toInstant -> users
     }
   }
 }

--- a/example/src/test/scala/com/example/SupportTest.scala
+++ b/example/src/test/scala/com/example/SupportTest.scala
@@ -1,12 +1,13 @@
 package com.example
 
-import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.time.Instant
+
 class SupportTest extends AnyFreeSpec with Matchers {
   "Future support rotas should not contain users that are not on the user access list" in {
-    val now = DateTime.now
+    val now = Instant.now
     val supportUsers = Support.acl.rota
       .filter { case (dateTime, _) => dateTime.isAfter(now) }
       .flatMap { case (_, (user1, user2)) => Seq(user1, user2) }


### PR DESCRIPTION
This change applies the migration from Joda time to java.time introduced in #525 to the example config-generating sub-project.

In the config generated by the project, timestamps now appear without nanoseconds, eg. `1970-01-06T10:00:00Z` instead of `1970-01-06T10:00:00.000Z`.  But as they are both ISO-8601 strings with UTC timezones and and we don't use non-zero nanoseconds anywhere, they are decoded identically whether as Joda `DateTime`s or as java.time `Instance`s.
