### PR TITLE
Managed policy support

### DIFF
--- a/app/data/Policies.scala
+++ b/app/data/Policies.scala
@@ -24,20 +24,4 @@ object Policies {
       revokeAccess,
       true
     )
-
-  /** A policy that grants no permissions.
-    *
-    * This is used as the inline policy
-    */
-  val noOp = Policy(
-    Seq(
-      Statement(
-        Effect.Allow,
-        Seq(
-          Action("sts:GetCallerIdentity")
-        ),
-        Seq(Resource("*"))
-      )
-    )
-  )
 }

--- a/app/data/Policies.scala
+++ b/app/data/Policies.scala
@@ -24,4 +24,21 @@ object Policies {
       revokeAccess,
       true
     )
+
+  /**
+   * A policy that grants no permissions.
+   *
+   * This is used as the inline policy
+   */
+  val noOp = Policy(
+    Seq(
+      Statement(
+        Effect.Allow,
+        Seq(
+          Action("sts:GetCallerIdentity")
+        ),
+        Seq(Resource("*"))
+      )
+    )
+  )
 }

--- a/app/data/Policies.scala
+++ b/app/data/Policies.scala
@@ -25,11 +25,10 @@ object Policies {
       true
     )
 
-  /**
-   * A policy that grants no permissions.
-   *
-   * This is used as the inline policy
-   */
+  /** A policy that grants no permissions.
+    *
+    * This is used as the inline policy
+    */
   val noOp = Policy(
     Seq(
       Statement(

--- a/configTools/src/main/scala/com/gu/janus/Validation.scala
+++ b/configTools/src/main/scala/com/gu/janus/Validation.scala
@@ -18,9 +18,13 @@ object Validation {
       largePermission <- allPermissions.filter { perm =>
         // session policy limit includes the managed ARNs and inline policy document
         val totalLength =
-              perm.policy.map(_.length).getOrElse(0) + // the inline policy document's size
-                        perm.managedPolicyArns.map(_.length).sum // and the attached managed policy ARNs
-                totalLength >= sizeLimit
+          perm.policy // the inline policy document's size
+            .map(_.length)
+            .getOrElse(0) +
+            perm.managedPolicyArns // and the total size of the attached managed policy ARNs
+              .map(_.map(_.length).sum)
+              .getOrElse(0)
+        totalLength >= sizeLimit
       }
     } yield s"${largePermission.label} (${largePermission.description})"
 

--- a/configTools/src/main/scala/com/gu/janus/Validation.scala
+++ b/configTools/src/main/scala/com/gu/janus/Validation.scala
@@ -15,7 +15,13 @@ object Validation {
       janusData.support.supportAccess
 
     val largePermissions = for {
-      largePermission <- allPermissions.filter(_.policy.length >= sizeLimit)
+      largePermission <- allPermissions.filter { perm =>
+        // session policy limit includes the managed ARNs and inline policy document
+        val totalLength =
+              perm.policy.map(_.length).getOrElse(0) + // the inline policy document's size
+                        perm.managedPolicyArns.map(_.length).sum // and the attached managed policy ARNs
+                totalLength >= sizeLimit
+      }
     } yield s"${largePermission.label} (${largePermission.description})"
 
     if (largePermissions.isEmpty) {

--- a/configTools/src/main/scala/com/gu/janus/config/Loader.scala
+++ b/configTools/src/main/scala/com/gu/janus/config/Loader.scala
@@ -83,6 +83,7 @@ object Loader {
               label = configuredPermission.label,
               description = configuredPermission.description,
               policy = configuredPermission.policy,
+              managedPolicyArns = configuredPermission.managedPolicyArns,
               shortTerm = configuredPermission.shortTerm
             )
           }

--- a/configTools/src/main/scala/com/gu/janus/model/configuredRepresentation.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/configuredRepresentation.scala
@@ -16,7 +16,8 @@ case class ConfiguredPermission(
     account: String,
     label: String,
     description: String,
-    policy: String,
+    policy: Option[String],
+    managedPolicyArns: Option[List[String]],
     shortTerm: Boolean = false
 )
 

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -124,7 +124,7 @@ object Permission {
       label,
       description,
       None,
-      Some(managedPolicyArns),
+      if (managedPolicyArns.nonEmpty) Some(managedPolicyArns) else None,
       shortTerm
     )
   }
@@ -148,7 +148,7 @@ object Permission {
       label,
       description,
       Some(inlinePolicy.asJson.noSpaces),
-      Some(managedPolicyArns),
+      if (managedPolicyArns.nonEmpty) Some(managedPolicyArns) else None,
       shortTerm
     )
   }

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -81,7 +81,7 @@ object Permission {
 
   /** Creates a permission using an inline policy document.
     *
-    * This is the normal way to define permissions in Janus, so we have an
+    * This is the normal way to define permissions in Janus so that we have an
     * immutable record of exactly what access each user has, tied to the audit
     * trail of approvals.
     */
@@ -105,16 +105,12 @@ object Permission {
   /** Create a permission that's based on managed IAM policies instead of
     * providing a policy document.
     *
-    * These should usually be AWS-managed policies, and this gives us two useful
+    * These should usually be AWS-managed policies, and this provides two useful
     * features:
     *   - set up service-specific permissions that are automatically kept up to
     *     date with AWS changes
     *   - bypass the size limit on inline policies for complex permissions (e.g.
     *     global read access)
-    *
-    * We can also optionally provide an inline policy to further refine the
-    * resulting permission, by explicitly allowing or denying additional
-    * operations.
     */
   def fromManagedPolicyArns(
       account: AwsAccount,
@@ -134,10 +130,10 @@ object Permission {
   }
 
   /** Creates a permission that combines managed policy ARNs with an inline
-    * policy document.
+    * policy document. More information on each of these options is above.
     *
-    * More information on each of these options is above, this combination
-    * allows us to customise a managed policy.
+    * This combination allows us to take managed policies as a baseline and
+    * customise the resulting permission with an inline policy document.
     */
   def withManagedPolicyArns(
       account: AwsAccount,

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -65,7 +65,7 @@ case class AwsAccountAccess(
     isFavourite: Boolean
 )
 
-case class Permission private (
+case class Permission(
     account: AwsAccount,
     label: String,
     description: String,
@@ -78,6 +78,13 @@ case class Permission private (
   override def toString: String = s"Permission<$id>"
 }
 object Permission {
+
+  /** Creates a permission using an inline policy document.
+    *
+    * This is the normal way to define permissions in Janus, so we have an
+    * immutable record of exactly what access each user has, tied to the audit
+    * trail of approvals.
+    */
   def apply(
       account: AwsAccount,
       label: String,
@@ -114,7 +121,30 @@ object Permission {
       label: String,
       description: String,
       managedPolicyArns: List[String],
-      inlinePolicy: Option[Policy] = None,
+      shortTerm: Boolean = false
+  ): Permission = {
+    Permission(
+      account,
+      label,
+      description,
+      None,
+      Some(managedPolicyArns),
+      shortTerm
+    )
+  }
+
+  /** Creates a permission that combines managed policy ARNs with an inline
+    * policy document.
+    *
+    * More information on each of these options is above, this combination
+    * allows us to customise a managed policy.
+    */
+  def withManagedPolicyArns(
+      account: AwsAccount,
+      label: String,
+      description: String,
+      inlinePolicy: Policy,
+      managedPolicyArns: List[String],
       shortTerm: Boolean = false
   ): Permission = {
     Permission(

--- a/configTools/src/main/twirl/com/gu/janus/config/templates/janusData.scala.txt
+++ b/configTools/src/main/twirl/com/gu/janus/config/templates/janusData.scala.txt
@@ -69,7 +69,22 @@ janus {
                 label = "@permission.label"
                 description = "@permission.description"
                 shortTerm = @if(permission.shortTerm) {true} else {false}
-                policy = """@permission.policy"""
+                @permission.policy match {
+                    case Some(policy) => {
+                policy = """@policy"""
+                    }
+                    case None => {}
+                }
+                @permission.managedPolicyArns match {
+                    case Some(managedPolicyArns) => {
+                managedPolicyArns = [
+                    @for(arn <- managedPolicyArns) {
+                    """@arn""",
+                    }
+                ]
+                    }
+                    case None => {}
+                }
             },
         }
     ]

--- a/configTools/src/test/resources/example-without-permissions-repo.conf
+++ b/configTools/src/test/resources/example-without-permissions-repo.conf
@@ -68,19 +68,19 @@ janus {
     , label = "test-permission"
     , description = "A test permission"
     , shortTerm = true
-    , policy = ""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
     },
     { account = "aws-test-account"
     , label = "default-test"
     , description = "Default test access"
     , shortTerm = false
-    , policy = ""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
     },
     { account = "website"
     , label = "developer"
     , description = "Developer access"
     , shortTerm = false
-    , policy = ""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
     },
     { account = "website"
     , label = "s3-manager"
@@ -98,7 +98,7 @@ janus {
     , label = "developer"
     , description = "Developer access"
     , shortTerm = false
-    , policy = ""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
     }
   ]
 }

--- a/configTools/src/test/resources/example.conf
+++ b/configTools/src/test/resources/example.conf
@@ -77,24 +77,26 @@ janus {
     , description = "Default test access"
     , shortTerm = false
     , policy = ""
+    , managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess""", """arn:aws:iam::aws:policy/EC2InstanceConnect"""]
     },
     { account = "website"
     , label = "developer"
     , description = "Developer access"
     , shortTerm = false
-    , policy = ""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
     },
     { account = "website"
     , label = "s3-manager"
     , description = "Read and write access to S3"
     , shortTerm = false
-    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
+    , managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonS3FullAccess"""]
     },
     { account = "website"
     , label = "admin"
     , description = "Account admin"
     , shortTerm = true
-    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["*"],"Resource":["*"]}]}"""
+    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
+    , managedPolicyArns = [ """arn:aws:iam::aws:policy/ReadOnlyAccess""" ]
     },
     { account = "aws-test-account"
     , label = "developer"

--- a/configTools/src/test/resources/example.conf
+++ b/configTools/src/test/resources/example.conf
@@ -2,15 +2,9 @@ janus {
   permissionsRepo = "https://example.com/"
 
   accounts = [
-    { name = "Main account"
-    , key = "main-account"
-    },
-    { name = "Website account"
-    , key = "website"
-    },
-    { name = "Testing account"
-    , key = "aws-test-account"
-    }
+    { name = "Main account", key = "main-account" },
+    { name = "Website account", key = "website" },
+    { name = "Testing account", key = "aws-test-account"  }
   ]
 
   support {
@@ -20,14 +14,17 @@ janus {
     ]
 
     rota = [
-      { startTime = "2018-12-27T11:00:00.000Z"
-      , supporting = [ employee1, employee2 ]
+      {
+        startTime = "2018-12-27T11:00:00.000Z"
+        supporting = [ employee1, employee2 ]
       },
-      { startTime = "2019-01-03T11:00:00.000Z"
-      , supporting = [ employee2, employee4 ]
+      {
+        startTime = "2019-01-03T11:00:00.000Z"
+        supporting = [ employee2, employee4 ]
       },
-      { startTime = "2019-01-10T11:00:00.000Z"
-      , supporting = [ employee2, employee5 ]
+      {
+        startTime = "2019-01-10T11:00:00.000Z"
+        supporting = [ employee2, employee5 ]
       }
     ]
 
@@ -41,16 +38,17 @@ janus {
     ]
 
     acl {
-      employee1 = [
+      "employee1" = [
         { account = "website", label = "developer" }
       ]
-      employee2 = [
+      "employee2" = [
         { account = "website", label = "developer" }
       ]
-      employee3 = [
-        { account = "website", label = "s3-manager" }
+      "employee3" = [
+        { account = "website", label = "s3-manager" },
+        { account = "aws-test-account", label = "hybrid-permission" }
       ]
-      employee4 = [
+      "employee4" = [
         { account = "website", label = "s3-manager" },
         { account = "aws-test-account", label = "developer" }
       ]
@@ -66,43 +64,60 @@ janus {
   }
 
   permissions = [
-    { account = "main-account"
-    , label = "test-permission"
-    , description = "A test permission"
-    , shortTerm = true
-    , policy = ""
+    {
+        account = "main-account"
+        label = "test-permission"
+        description = "A test permission"
+        shortTerm = true
+        policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
     },
-    { account = "aws-test-account"
-    , label = "default-test"
-    , description = "Default test access"
-    , shortTerm = false
-    , policy = ""
-    , managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess""", """arn:aws:iam::aws:policy/EC2InstanceConnect"""]
+    {
+        account = "aws-test-account"
+        label = "default-test"
+        description = "Default test access"
+        shortTerm = false
+        managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess""", """arn:aws:iam::aws:policy/EC2InstanceConnect"""]
     },
-    { account = "website"
-    , label = "developer"
-    , description = "Developer access"
-    , shortTerm = false
-    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
+    {
+        account = "website"
+        label = "developer"
+        description = "Developer access"
+        shortTerm = false
+        policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
     },
-    { account = "website"
-    , label = "s3-manager"
-    , description = "Read and write access to S3"
-    , shortTerm = false
-    , managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonS3FullAccess"""]
+    {
+        account = "website"
+        label = "s3-manager"
+        description = "Read and write access to S3"
+        shortTerm = false
+        managedPolicyArns = ["""arn:aws:iam::aws:policy/AmazonS3FullAccess"""]
     },
-    { account = "website"
-    , label = "admin"
-    , description = "Account admin"
-    , shortTerm = true
-    , policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
-    , managedPolicyArns = [ """arn:aws:iam::aws:policy/ReadOnlyAccess""" ]
+    {
+        account = "website"
+        label = "admin"
+        description = "Account admin"
+        shortTerm = true
+        policy = """{"Version":"2012-10-17","Statement":[{"Sid":"1","Effect":"Allow","Action":["s3:*"],"Resource":["*"]}]}"""
+        managedPolicyArns = [
+            """arn:aws:iam::aws:policy/ReadOnlyAccess"""
+        ]
     },
-    { account = "aws-test-account"
-    , label = "developer"
-    , description = "Developer access"
-    , shortTerm = false
-    , policy = ""
+    {
+        account = "aws-test-account"
+        label = "developer"
+        description = "Developer access"
+        shortTerm = false
+        policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
+    }
+    {
+        account = "aws-test-account"
+        label = "hybrid-permission"
+        description = "Managed and inline access control"
+        shortTerm = false
+        policy = """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
+        managedPolicyArns = [
+            """arn:aws:iam::aws:policy/ReadOnlyAccess"""
+        ]
     }
   ]
 }

--- a/configTools/src/test/resources/example.conf
+++ b/configTools/src/test/resources/example.conf
@@ -38,17 +38,17 @@ janus {
     ]
 
     acl {
-      "employee1" = [
+      employee1 = [
         { account = "website", label = "developer" }
       ]
-      "employee2" = [
+      employee2 = [
         { account = "website", label = "developer" }
       ]
-      "employee3" = [
+      employee3 = [
         { account = "website", label = "s3-manager" },
         { account = "aws-test-account", label = "hybrid-permission" }
       ]
-      "employee4" = [
+      employee4 = [
         { account = "website", label = "s3-manager" },
         { account = "aws-test-account", label = "developer" }
       ]

--- a/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
@@ -70,6 +70,10 @@ class ConfigIntegrationTests
   }
 
   "development helpers" - {
+    // leave this ignored!
+    // it's useful to switch `ignore` to `in` temporarily when working on the config format
+    // run just this test with
+    //     testOnly com.gu.janus.config.ConfigIntegrationTests -- -z "print the generated config file to the console for manual inspection"
     "print the generated config file to the console for manual inspection" ignore {
       val testConfig = ConfigFactory.load("example.conf")
       val result = Loader.fromConfig(testConfig)

--- a/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
@@ -198,5 +198,45 @@ class WriterTest extends AnyFreeSpec with Matchers {
       )
       Writer.toConfig(janusData) should not include "permissionsRepo"
     }
+
+    "includes the inline policy for a permission" in {
+      val permission = Permission(
+        account1,
+        "perm1",
+        "Test permission",
+        simplePolicy,
+        false
+      )
+      val janusData = JanusData(
+        Set(account1),
+        access = ACL(Map("user1" -> Set(permission)), Set.empty),
+        admin = ACL(Map.empty, Set.empty),
+        SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
+        None
+      )
+      Writer.toConfig(janusData) should include(
+        """{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["sts:GetCallerIdentity"],"Resource":["*"]}]}"""
+      )
+    }
+
+    "includes the managed policy ARNs for a permission" in {
+      val permission = Permission.fromManagedPolicyArns(
+        account1,
+        "perm1",
+        "Test permission",
+        List("arn:aws:iam::aws:policy/ReadOnlyAccess"),
+        false
+      )
+      val janusData = JanusData(
+        Set(account1),
+        access = ACL(Map("user1" -> Set(permission)), Set.empty),
+        admin = ACL(Map.empty, Set.empty),
+        SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
+        None
+      )
+      Writer.toConfig(janusData) should include(
+        """arn:aws:iam::aws:policy/ReadOnlyAccess"""
+      )
+    }
   }
 }

--- a/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
@@ -1,6 +1,8 @@
 package com.gu.janus.config
 
 import com.gu.janus.model._
+import com.gu.janus.policy.Iam.{Action, Policy, Resource, Statement}
+import com.gu.janus.policy.Iam.Effect.Allow
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -9,13 +11,19 @@ import java.time.Duration
 class WriterTest extends AnyFreeSpec with Matchers {
   val account1 = AwsAccount("Test 1", "test1")
   val account2 = AwsAccount("Test 2", "test2")
+  val simpleStatement = Statement(
+    Allow,
+    Seq(Action("sts:GetCallerIdentity")),
+    Seq(Resource("*"))
+  )
+  val simplePolicy = Policy(Seq(simpleStatement))
 
   "allPermissions" - {
     "returns nothing for an empty JanusData" in {
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
         None
       )
@@ -24,11 +32,11 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes default access permissions" in {
       val permission =
-        Permission(account1, "perm1", "Test permission", "", false)
+        Permission(account1, "perm1", "Test permission", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set(permission)),
-        ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
         None
       )
@@ -37,11 +45,11 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes access permissions" in {
       val permission =
-        Permission(account1, "perm1", "Test permission", "", false)
+        Permission(account1, "perm1", "Test permission", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map("user1" -> Set(permission)), Set.empty),
-        ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
         None
       )
@@ -50,9 +58,9 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes access permissions from mulitple users" in {
       val permission1 =
-        Permission(account1, "perm1", "Test permission 1", "", false)
+        Permission(account1, "perm1", "Test permission 1", simplePolicy, false)
       val permission2 =
-        Permission(account1, "perm2", "Test permission 2", "", false)
+        Permission(account1, "perm2", "Test permission 2", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
         access = ACL(
@@ -62,7 +70,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
           ),
           Set.empty
         ),
-        ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(100)),
         None
       )
@@ -71,12 +79,12 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes admin permissions" in {
       val permission1 =
-        Permission(account1, "perm1", "Test permission 1", "", false)
+        Permission(account1, "perm1", "Test permission 1", simplePolicy, false)
       val permission2 =
-        Permission(account1, "perm2", "Test permission 2", "", false)
+        Permission(account1, "perm2", "Test permission 2", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
         admin = ACL(
           Map(
             "admin1" -> Set(permission1),
@@ -92,11 +100,11 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes support permissions" in {
       val permission =
-        Permission(account1, "perm", "Test permission", "", false)
+        Permission(account1, "perm", "Test permission", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         support = SupportACL
           .create(Map.empty, Set(permission), Duration.ofSeconds(100)),
         None
@@ -106,15 +114,15 @@ class WriterTest extends AnyFreeSpec with Matchers {
 
     "includes permissions from all sources" in {
       val permission1 =
-        Permission(account1, "perm1", "Test permission 1", "", false)
+        Permission(account1, "perm1", "Test permission 1", simplePolicy, false)
       val permission2 =
-        Permission(account1, "perm2", "Test permission 2", "", false)
+        Permission(account1, "perm2", "Test permission 2", simplePolicy, false)
       val permission3 =
-        Permission(account1, "perm3", "Test permission 3", "", false)
+        Permission(account1, "perm3", "Test permission 3", simplePolicy, false)
       val permission4 =
-        Permission(account1, "perm4", "Test permission 4", "", false)
+        Permission(account1, "perm4", "Test permission 4", simplePolicy, false)
       val permission5 =
-        Permission(account1, "perm5", "Test permission 5", "", false)
+        Permission(account1, "perm5", "Test permission 5", simplePolicy, false)
       val janusData = JanusData(
         Set.empty,
         access = ACL(
@@ -148,8 +156,8 @@ class WriterTest extends AnyFreeSpec with Matchers {
     "includes the support period" in {
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofSeconds(123456789)),
         None
       )
@@ -159,8 +167,8 @@ class WriterTest extends AnyFreeSpec with Matchers {
     "includes the support period even if it was specified using a non-second period" in {
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofDays(7)),
         None
       )
@@ -170,8 +178,8 @@ class WriterTest extends AnyFreeSpec with Matchers {
     "includes the permissionsRepo" in {
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofDays(7)),
         Some("https://example.com/")
       )
@@ -183,8 +191,8 @@ class WriterTest extends AnyFreeSpec with Matchers {
     "excludes permissionsRepo entry if it is empty" in {
       val janusData = JanusData(
         Set.empty,
-        ACL(Map.empty, Set.empty),
-        ACL(Map.empty, Set.empty),
+        access = ACL(Map.empty, Set.empty),
+        admin = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty, Duration.ofDays(7)),
         None
       )


### PR DESCRIPTION
Adds support for managed policies in Janus permissions, alongside our typical inline policy document approach.

This is groundwork to unlock the ability to add support for a read-only permission in Janus. This addresses [a years-old request](https://github.com/guardian/janus/issues/2859) from Janus users, and has been requested by InfoSec.

We update the `Permission` model so that it can contain an inline policy (as now) and/or a list of managed policies ARNs, and provide some helpful (and clear) constructors for the new combinations. This involves updating the code that writes and loads Janus configuration files so that it supports these new permission definitions. We also update the actual `Federation.assumeRole` implementation, so that it provides the permission's policies whether they are inline or managed (or both).

Because this is a fairly fundamental change in Janus, we also expand the test coverage around the Janus data serialisation. We no longer use empty dummy policies, and add a bunch of extra cases to cover the old and new functionality.

## Background

This change is mildly controversial but the ability to add a read-only permission feels essential today, which motivates this work.

Historically Janus permissions have been immutable policy documents in the configuration repository. This means when approving access changes it's very clear what level of access is being talked about, that access cannot change without further updates, and it connects our audit trail and approvals process up directly with the definition of access. Lots of benefits!

The ability to refer to externally defined policies breaks these assumptions. These policies are not transparent at the point of approval and they can be changed after access has been given.

However, the constraint to only use inline policies has always caused a lot of friction. The strict size limit imposed by inline policy documents has always constrained what we're able to do, and often Janus is trying to bestow a level of access that enables a practical AWS workflow. Maintaining bespoke policies that address specific AWS use cases is either impossible (if the policy is too large, as with read-only access) or difficult (if the service is being updated and the actions a user needs changes).

Allowing us to use AWS managed policies would let us easily provide a read-only permission, and seems to provide a sensible balance between these trade-offs. These policies are transparent since they are a shared global resource, documented clearly by AWS. While they aren't immutable, we do trust AWS to manage these sensibly, and the fact that they are AWS-managed means they'll be kept up to date as AWS services evolve.

If we agree that we only want to use AWS-managed policies, I'd expect us to enforce this business logic in our configuration, rather than have that appear here in the janus-app repository, so we'll revisit this discussion when we get to the final step of this multi-step process (see the additional notes section, below).

## Future

As well as directly unlocking a read-only permission, this will let us simplify a number of existing bespoke policies. It may also be a jumping off point for us generally using much tigher permissions for day-to-day work.

## What is the value of this change and how do we measure success?

For now, success would be that nothing changes. This has no user-facing impact, and just adds support for managed policy ARNs. We won't create any permissions that use this new feature until all clients are updated.

## Any additional notes?

This is part 1 of a multi-step launch of read only permissions.

- [ ] Add support for managed policies in Janus webapp and config library     `◀️  we are here`
- [ ] Update all the consumers of Janus' config data (e.g. Security HQ)
- [ ] Add a read-only permission to the Janus config

