### PR TITLE
Group GitHub actions version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups: # group github-provided action bumps (exclude major changes)
+      github-actions:
+        patterns:
+          - "actions/*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
We currently have multiple dependabot PRs open to bump version updates in GitHub actions. This takes time, because the app needs to be rebuilt after each PR is merged. For patch and minor version bumps on GitHub provided acitons, we're probably ok to tackle them as a group.