### PR TITLE
feat: add routes for passkey registration

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,2 @@
 version = 3.9.3
-
 runner.dialect = scala213
-maxColumn = 80

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ automatically recompile and reload when changes are made.
 To get the audit endpoints to work and test audit logging locally, follow the instructions in this 
 [README](local-dev/README.md).
 
+#### Local Passkeys support
+
+To test passkey authentication, follow the instructions in this 
+[README](local-dev/README.md).
+
 
 ## Configuration
 
@@ -163,8 +168,7 @@ ecosystem makes it easy to (for example) run tests over your
 configuration.
 
 This repository includes an example project, full documentation of
-using `janus-config-tools` is included in [that project's
-README](configTools/README.md).
+using `janus-config-tools` is included in [that project's code](example).
 
 ### Application configuration
 

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -113,6 +113,10 @@ class AppComponents(context: ApplicationLoader.Context)
       googleGroupChecker,
       requiredGoogleGroups
     )(wsClient, executionContext, mode, assetsFinder),
+    new PasskeyController(controllerComponents, authAction, host, janusData)(
+      mode,
+      assetsFinder
+    ),
     new Utility(janusData, controllerComponents, authAction, configuration)(
       mode,
       assetsFinder

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -114,6 +114,7 @@ class AppComponents(context: ApplicationLoader.Context)
       requiredGoogleGroups
     )(wsClient, executionContext, mode, assetsFinder),
     new PasskeyController(controllerComponents, authAction, host, janusData)(
+      dynamodDB,
       mode,
       assetsFinder
     ),

--- a/app/aws/PasskeyChallengeDB.scala
+++ b/app/aws/PasskeyChallengeDB.scala
@@ -1,0 +1,92 @@
+package aws
+
+import aws.PasskeyChallengeDB.UserChallenge.toDynamoItem
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.data.client.challenge.{Challenge, DefaultChallenge}
+import com.webauthn4j.util.Base64UrlUtil
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+object PasskeyChallengeDB {
+
+  private[aws] val tableName = "PasskeyChallenges"
+
+  case class UserChallenge(
+      user: UserIdentity,
+      challenge: Challenge,
+      // TTL can take up to 48 hours to take effect so this will be a fallback rather than something to rely on
+      expiresAt: Instant = Instant.now().plusSeconds(60)
+  )
+
+  object UserChallenge {
+    def toDynamoItem(
+        userChallenge: UserChallenge
+    ): Map[String, AttributeValue] = {
+      Map(
+        "userName" -> AttributeValue.fromS(userChallenge.user.username),
+        "challenge" -> AttributeValue.fromS(
+          Base64UrlUtil.encodeToString(userChallenge.challenge.getValue)
+        ),
+        "expiresAt" -> AttributeValue.fromN(
+          userChallenge.expiresAt.getEpochSecond.toString
+        )
+      )
+    }
+  }
+
+  def insert(
+      userChallenge: UserChallenge
+  )(implicit dynamoDB: DynamoDbClient): Try[Unit] = {
+    val item = toDynamoItem(userChallenge).asJava
+    val request =
+      PutItemRequest.builder().tableName(tableName).item(item).build()
+    Try(dynamoDB.putItem(request))
+  }
+
+  def load(
+      user: UserIdentity
+  )(implicit dynamoDB: DynamoDbClient): Try[Option[Challenge]] = {
+    val key = Map(
+      "userName" -> AttributeValue.fromS(user.username)
+    ).asJava
+
+    val request = GetItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(key)
+      .build()
+
+    Try {
+      val result = dynamoDB.getItem(request)
+      if (result.hasItem) {
+        val item = result.item()
+        val challenge = Base64UrlUtil.decode(
+          item.get("challenge").s().getBytes(UTF_8)
+        )
+        Some(new DefaultChallenge(challenge))
+      } else
+        Option.empty
+    }
+  }
+
+  def delete(
+      user: UserIdentity
+  )(implicit dynamoDB: DynamoDbClient): Try[Unit] = {
+    val key = Map(
+      "userName" -> AttributeValue.fromS(user.username)
+    ).asJava
+
+    val request = DeleteItemRequest
+      .builder()
+      .tableName(tableName)
+      .key(key)
+      .build()
+
+    Try(dynamoDB.deleteItem(request))
+  }
+}

--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -1,0 +1,57 @@
+package aws
+
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.converter.AttestedCredentialDataConverter
+import com.webauthn4j.converter.util.ObjectConverter
+import com.webauthn4j.credential.CredentialRecord
+import com.webauthn4j.util.Base64UrlUtil
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model._
+
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+object PasskeyDB {
+
+  private[aws] val tableName = "Passkeys"
+
+  private val credentialDataConverter = new AttestedCredentialDataConverter(
+    new ObjectConverter()
+  )
+
+  case class UserCredentialRecord(
+      user: UserIdentity,
+      credentialRecord: CredentialRecord
+  )
+
+  object UserCredentialRecord {
+    def toDynamoItem(
+        userCredentialRecord: UserCredentialRecord
+    ): Map[String, AttributeValue] = {
+      Map(
+        "userName" -> AttributeValue.fromS(userCredentialRecord.user.username),
+        "credentialId" -> AttributeValue.fromS(
+          Base64UrlUtil.encodeToString(
+            userCredentialRecord.credentialRecord.getAttestedCredentialData.getCredentialId
+          )
+        ),
+        "credential" -> AttributeValue.fromS(
+          Base64UrlUtil.encodeToString(
+            credentialDataConverter.convert(
+              userCredentialRecord.credentialRecord.getAttestedCredentialData
+            )
+          )
+        )
+      )
+    }
+  }
+
+  def insert(
+      userCredentialRecord: UserCredentialRecord
+  )(implicit dynamoDB: DynamoDbClient): Try[Unit] = {
+    val item = UserCredentialRecord.toDynamoItem(userCredentialRecord).asJava
+    val request =
+      PutItemRequest.builder().tableName(tableName).item(item).build()
+    Try(dynamoDB.putItem(request))
+  }
+}

--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -5,12 +5,13 @@ import com.webauthn4j.converter.AttestedCredentialDataConverter
 import com.webauthn4j.converter.util.ObjectConverter
 import com.webauthn4j.credential.CredentialRecord
 import com.webauthn4j.util.Base64UrlUtil
-import models.AwsCallException
+import models.JanusException
+import play.api.http.Status.INTERNAL_SERVER_ERROR
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model._
 
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Try}
 
 object PasskeyDB {
 
@@ -20,55 +21,49 @@ object PasskeyDB {
     new ObjectConverter()
   )
 
-  case class UserCredentialRecord(
+  /** See
+    * [[https://webauthn4j.github.io/webauthn4j/en/#credentialrecord-serialization-and-deserialization]]
+    * for serialisation details.
+    */
+  def toDynamoItem(
       user: UserIdentity,
       credentialRecord: CredentialRecord
-  )
-
-  object UserCredentialRecord {
-
-    /** See
-      * [[https://webauthn4j.github.io/webauthn4j/en/#credentialrecord-serialization-and-deserialization]]
-      * for serialisation details.
-      */
-    def toDynamoItem(
-        userCredentialRecord: UserCredentialRecord
-    ): Map[String, AttributeValue] = {
-      Map(
-        "username" -> AttributeValue.fromS(userCredentialRecord.user.username),
-        // TODO: does this correspond to the type of passkey? What happens if you try to register the same passkey twice?
-        "credentialId" -> AttributeValue.fromS(
-          Base64UrlUtil.encodeToString(
-            userCredentialRecord.credentialRecord.getAttestedCredentialData.getCredentialId
-          )
-        ),
-        "credential" -> AttributeValue.fromS(
-          Base64UrlUtil.encodeToString(
-            credentialDataConverter.convert(
-              userCredentialRecord.credentialRecord.getAttestedCredentialData
-            )
+  ): Map[String, AttributeValue] =
+    Map(
+      "username" -> AttributeValue.fromS(user.username),
+      // TODO: does this correspond to the type of passkey? What happens if you try to register the same passkey twice?
+      "credentialId" -> AttributeValue.fromS(
+        Base64UrlUtil.encodeToString(
+          credentialRecord.getAttestedCredentialData.getCredentialId
+        )
+      ),
+      "credential" -> AttributeValue.fromS(
+        Base64UrlUtil.encodeToString(
+          credentialDataConverter.convert(
+            credentialRecord.getAttestedCredentialData
           )
         )
       )
-    }
-  }
+    )
 
   def insert(
-      userCredentialRecord: UserCredentialRecord
-  )(implicit dynamoDB: DynamoDbClient): Either[AwsCallException, Unit] = Try {
-    val item = UserCredentialRecord.toDynamoItem(userCredentialRecord)
+      user: UserIdentity,
+      credentialRecord: CredentialRecord
+  )(implicit dynamoDB: DynamoDbClient): Try[Unit] = Try {
+    val item = toDynamoItem(user, credentialRecord)
     val request =
       PutItemRequest.builder().tableName(tableName).item(item.asJava).build()
     dynamoDB.putItem(request)
-  } match {
-    case Failure(exception) =>
-      Left(
-        AwsCallException(
-          "Failed to store credential",
-          s"Failed to store credential for user ${userCredentialRecord.user.username}: ${exception.getMessage}",
-          exception
+  }.map(_ => ())
+    .recoverWith(exception =>
+      Failure(
+        JanusException(
+          userMessage = "Failed to store credential",
+          engineerMessage =
+            s"Failed to store credential for user ${user.username}: ${exception.getMessage}",
+          httpCode = INTERNAL_SERVER_ERROR,
+          causedBy = Some(exception)
         )
       )
-    case Success(_) => Right(())
-  }
+    )
 }

--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -25,11 +25,17 @@ object PasskeyDB {
   )
 
   object UserCredentialRecord {
+
+    /** See
+      * [[https://webauthn4j.github.io/webauthn4j/en/#credentialrecord-serialization-and-deserialization]]
+      * for serialisation details.
+      */
     def toDynamoItem(
         userCredentialRecord: UserCredentialRecord
     ): Map[String, AttributeValue] = {
       Map(
         "userName" -> AttributeValue.fromS(userCredentialRecord.user.username),
+        // TODO: does this correspond to the type of passkey? What happens if you try to register the same passkey twice?
         "credentialId" -> AttributeValue.fromS(
           Base64UrlUtil.encodeToString(
             userCredentialRecord.credentialRecord.getAttestedCredentialData.getCredentialId

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -1,0 +1,92 @@
+package controllers
+
+import com.gu.googleauth.AuthAction
+import com.gu.janus.model.JanusData
+import com.webauthn4j.util.Base64UrlUtil
+import io.circe.Json
+import io.circe.syntax.EncoderOps
+import logic.Passkey
+import models.Passkey._
+import play.api.mvc._
+import play.api.{Logging, Mode}
+
+/** Controller for handling passkey registration and authentication. */
+class PasskeyController(
+    controllerComponents: ControllerComponents,
+    authAction: AuthAction[AnyContent],
+    host: String,
+    janusData: JanusData
+)(implicit mode: Mode, assetsFinder: AssetsFinder)
+    extends AbstractController(controllerComponents)
+    with Logging {
+
+  private val appName = "Janus"
+
+  // TODO persist instead of using session - store with TTL
+  private val challengeAttribName = "passkeyChallenge"
+
+  def registrationOptions: Action[AnyContent] = authAction { request =>
+    Passkey.registrationOptions(appName, host, request.user) match {
+
+      case Left(failure) =>
+        logger.error(
+          s"Failed to create registration options for user ${request.user.username}: ${failure.details}",
+          failure.cause
+        )
+        BadRequest("Failed to create registration options")
+
+      case Right(options) =>
+        val challenge =
+          Base64UrlUtil.encodeToString(options.getChallenge.getValue)
+        logger.info(
+          s"Created registration options for user ${request.user.username}"
+        )
+        Ok(options.asJson.noSpaces)
+          .withSession(request.session + (challengeAttribName -> challenge))
+    }
+  }
+
+  def register: Action[AnyContent] = authAction { request =>
+    val result = for {
+      challenge <- request.session.get(challengeAttribName).toRight {
+        logger.error(
+          s"Missing challenge in session for user ${request.user.username}"
+        )
+        BadRequest("Registration session invalid")
+      }
+
+      body <- request.body.asText.toRight {
+        logger.error(
+          s"Missing body in registration request for user ${request.user.username}"
+        )
+        BadRequest("Invalid request format")
+      }
+
+      credRecord <- Passkey
+        .verifiedRegistration(host, challenge, body)
+        .left
+        .map { failure =>
+          logger.error(
+            s"Registration verification failed for user ${request.user.username}: ${failure.details}",
+            failure.cause
+          )
+          BadRequest("Registration verification failed")
+        }
+
+      _ <- Passkey.store(request.user, credRecord).left.map { failure =>
+        logger.error(
+          s"Failed to store credential for user ${request.user.username}: ${failure.details}",
+          failure.cause
+        )
+        InternalServerError("Failed to store credential")
+      }
+    } yield {
+      logger.info(
+        s"Successfully registered passkey for user ${request.user.username}"
+      )
+      NoContent.withSession(request.session - challengeAttribName)
+    }
+
+    result.merge
+  }
+}

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -24,12 +24,18 @@ class PasskeyController(
     extends AbstractController(controllerComponents)
     with Logging {
 
+  private val appName = mode match {
+    case Mode.Dev  => "Janus-Dev"
+    case Mode.Test => "Janus-Test"
+    case Mode.Prod => "Janus-Prod"
+  }
+
   /** See
     * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
     */
   def registrationOptions: Action[AnyContent] = authAction { request =>
     (for {
-      options <- Passkey.registrationOptions(host, request.user)
+      options <- Passkey.registrationOptions(appName, host, request.user)
       _ <- PasskeyChallengeDB.insert(
         UserChallenge(request.user, options.getChallenge)
       )

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -5,6 +5,7 @@ import aws.{PasskeyChallengeDB, PasskeyDB}
 import com.gu.googleauth.{AuthAction, UserIdentity}
 import com.gu.janus.model.JanusData
 import io.circe.syntax.EncoderOps
+import io.circe.{Encoder, Json}
 import logic.Passkey
 import models.JanusException
 import models.Passkey._
@@ -13,6 +14,7 @@ import play.api.{Logging, Mode}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import scala.util.control.NonFatal
+import scala.util.{Success, Try}
 
 /** Controller for handling passkey registration and authentication. */
 class PasskeyController(
@@ -30,39 +32,57 @@ class PasskeyController(
     case Mode.Prod => "Janus-Prod"
   }
 
+  private def apiResponse[A](
+      action: => Try[A]
+  )(implicit encoder: Encoder[A]): Result =
+    action match {
+      case Left(err: JanusException) =>
+        logger.error(err.engineerMessage, err.causedBy.orNull)
+        val json = Json.obj(
+          "status" -> Json.fromString("error"),
+          "message" -> Json.fromString(err.userMessage)
+        )
+        Status(err.httpCode)(json.noSpaces)
+      case NonFatal(err) =>
+        logger.error(err.getMessage, err)
+        val json = Json.obj(
+          "status" -> Json.fromString("error"),
+          "message" -> Json.fromString(err.getClass.getSimpleName)
+        )
+        Status(INTERNAL_SERVER_ERROR)(json.noSpaces)
+      case Success(a) =>
+        Ok(a.asJson.noSpaces)
+    }
+
   /** See
     * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
     */
   def registrationOptions: Action[AnyContent] = authAction { request =>
-    (for {
-      options <- Passkey.registrationOptions(appName, host, request.user)
-      _ <- PasskeyChallengeDB.insert(
-        UserChallenge(request.user, options.getChallenge)
-      )
-    } yield {
-      logger.info(
-        s"Created registration options for user ${request.user.username}"
-      )
-      Ok(options.asJson.noSpaces)
-    }).fold(handleErrors, identity)
+    apiResponse (
+      for {
+        options <- Passkey.registrationOptions(appName, host, request.user)
+        _ <- PasskeyChallengeDB.insert(
+          UserChallenge(request.user, options.getChallenge)
+        )
+        _ = logger.info(s"Created registration options for user ${request.user.username}")
+      } yield options
+    )
   }
 
   /** See
     * [[https://webauthn4j.github.io/webauthn4j/en/#registering-the-webauthn-public-key-credential-on-the-server]].
     */
   def register: Action[AnyContent] = authAction { request =>
-    (for {
-      challenge <- PasskeyChallengeDB.load(request.user)
-      body <- extractRequestBody(request.body.asText, request.user)
-      credRecord <- Passkey.verifiedRegistration(host, challenge, body)
-      _ <- PasskeyDB.insert(request.user, credRecord)
-      _ <- PasskeyChallengeDB.delete(request.user)
-    } yield {
-      logger.info(
-        s"Registered passkey for user ${request.user.username}"
-      )
-      NoContent
-    }).fold(handleErrors, identity)
+    apiResponse (
+      for {
+        challenge <- PasskeyChallengeDB.load(request.user)
+        body <- extractRequestBody(request.body.asText, request.user)
+        credRecord <- Passkey.verifiedRegistration(host, challenge, body)
+        _ <- PasskeyDB.insert(request.user, credRecord)
+        _ <- PasskeyChallengeDB.delete(request.user)
+        _ = logger.info(s"Registered passkey for user ${request.user.username}")
+      } yield ()
+    )
   }
 
   private def extractRequestBody(body: Option[String], user: UserIdentity) =
@@ -77,14 +97,4 @@ class PasskeyController(
         )
       )
       .toTry
-
-  private def handleErrors(exception: Throwable): Result =
-    exception match {
-      case exception: JanusException =>
-        logger.error(exception.engineerMessage, exception.causedBy.get)
-        Status(exception.httpCode)(exception.userMessage)
-      case NonFatal(exception) =>
-        logger.error(exception.getMessage, exception)
-        Status(INTERNAL_SERVER_ERROR)
-    }
 }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -1,19 +1,18 @@
 package controllers
 
 import aws.PasskeyChallengeDB.UserChallenge
-import aws.PasskeyDB.UserCredentialRecord
 import aws.{PasskeyChallengeDB, PasskeyDB}
 import com.gu.googleauth.{AuthAction, UserIdentity}
 import com.gu.janus.model.JanusData
-import com.webauthn4j.data.PublicKeyCredentialCreationOptions
-import com.webauthn4j.util.Base64UrlUtil
 import io.circe.syntax.EncoderOps
 import logic.Passkey
+import models.JanusException
 import models.Passkey._
-import models.{JanusException, JanusExceptionWithCause, NotFoundException}
 import play.api.mvc._
 import play.api.{Logging, Mode}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
+import scala.util.control.NonFatal
 
 /** Controller for handling passkey registration and authentication. */
 class PasskeyController(
@@ -29,64 +28,57 @@ class PasskeyController(
     * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
     */
   def registrationOptions: Action[AnyContent] = authAction { request =>
-    val outcome = for {
+    (for {
       options <- Passkey.registrationOptions(host, request.user)
       _ <- PasskeyChallengeDB.insert(
         UserChallenge(request.user, options.getChallenge)
       )
-    } yield options
-    handleErrors(
-      outcome,
-      successLogMessage =
-        s"Created registration options for user ${request.user.username}",
-      successResult = (options: PublicKeyCredentialCreationOptions) =>
-        Ok(options.asJson.noSpaces)
-    )
+    } yield {
+      logger.info(
+        s"Created registration options for user ${request.user.username}"
+      )
+      Ok(options.asJson.noSpaces)
+    }).fold(handleErrors, identity)
   }
 
   /** See
     * [[https://webauthn4j.github.io/webauthn4j/en/#registering-the-webauthn-public-key-credential-on-the-server]].
     */
   def register: Action[AnyContent] = authAction { request =>
-    val outcome = for {
+    (for {
       challenge <- PasskeyChallengeDB.load(request.user)
-      challengeStr = Base64UrlUtil.encodeToString(challenge.getValue)
       body <- extractRequestBody(request.body.asText, request.user)
-      credRecord <- Passkey.verifiedRegistration(host, challengeStr, body)
-      _ <- PasskeyDB.insert(UserCredentialRecord(request.user, credRecord))
+      credRecord <- Passkey.verifiedRegistration(host, challenge, body)
+      _ <- PasskeyDB.insert(request.user, credRecord)
       _ <- PasskeyChallengeDB.delete(request.user)
-    } yield ()
-    handleErrors(
-      outcome,
-      successLogMessage =
-        s"Registered passkey for user ${request.user.username}",
-      successResult = (_: Unit) => NoContent
-    )
+    } yield {
+      logger.info(
+        s"Registered passkey for user ${request.user.username}"
+      )
+      NoContent
+    }).fold(handleErrors, identity)
   }
 
   private def extractRequestBody(body: Option[String], user: UserIdentity) =
-    body.toRight(
-      NotFoundException(
-        "Missing body in registration request",
-        s"Missing body in registration request for user ${user.username}"
+    body
+      .toRight(
+        JanusException(
+          userMessage = "Missing body in registration request",
+          engineerMessage =
+            s"Missing body in registration request for user ${user.username}",
+          httpCode = BAD_REQUEST,
+          causedBy = None
+        )
       )
-    )
+      .toTry
 
-  private def handleErrors[A](
-      outcome: Either[JanusException, A],
-      successLogMessage: String,
-      successResult: A => Result
-  ): Result = {
-    outcome match {
-      case Left(exception: JanusExceptionWithCause) =>
-        logger.error(exception.engineerMessage, exception.cause)
+  private def handleErrors(exception: Throwable): Result =
+    exception match {
+      case exception: JanusException =>
+        logger.error(exception.engineerMessage, exception.causedBy.get)
         Status(exception.httpCode)(exception.userMessage)
-      case Left(exception: JanusException) =>
-        logger.error(exception.engineerMessage)
-        Status(exception.httpCode)(exception.userMessage)
-      case Right(success) =>
-        logger.info(successLogMessage)
-        successResult(success)
+      case NonFatal(exception) =>
+        logger.error(exception.getMessage, exception)
+        Status(INTERNAL_SERVER_ERROR)
     }
-  }
 }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -3,17 +3,16 @@ package controllers
 import aws.PasskeyChallengeDB.UserChallenge
 import aws.PasskeyDB.UserCredentialRecord
 import aws.{PasskeyChallengeDB, PasskeyDB}
-import com.gu.googleauth.AuthAction
+import com.gu.googleauth.{AuthAction, UserIdentity}
 import com.gu.janus.model.JanusData
 import com.webauthn4j.util.Base64UrlUtil
 import io.circe.syntax.EncoderOps
 import logic.Passkey
 import models.Passkey._
+import models.{JanusException, JanusExceptionWithCause, NotFoundException}
 import play.api.mvc._
 import play.api.{Logging, Mode}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
-
-import scala.util.{Failure, Success}
 
 /** Controller for handling passkey registration and authentication. */
 class PasskeyController(
@@ -30,37 +29,22 @@ class PasskeyController(
     */
   def registrationOptions: Action[AnyContent] = authAction { request =>
     val result = for {
-      options <- Passkey
-        .registrationOptions(host, request.user)
-        .toEither
-        .left
-        .map { exception =>
-          logger.error(
-            s"Failed to create registration options for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          BadRequest("Failed to create registration options")
-        }
-
-      _ <- PasskeyChallengeDB
-        .insert(UserChallenge(request.user, options.getChallenge))
-        .toEither
-        .left
-        .map { exception =>
-          logger.error(
-            s"Failed to store challenge for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          InternalServerError("Failed to store challenge")
-        }
-    } yield {
-      logger.info(
-        s"Created registration options for user ${request.user.username}"
+      options <- Passkey.registrationOptions(host, request.user)
+      _ <- PasskeyChallengeDB.insert(
+        UserChallenge(request.user, options.getChallenge)
       )
-      Ok(options.asJson.noSpaces)
-    }
+    } yield options
 
-    result.merge
+    result match {
+      case Left(exception) =>
+        logger.error(exception.engineerMessage, exception.getCause)
+        Status(exception.httpCode)(exception.userMessage)
+      case Right(options) =>
+        logger.info(
+          s"Created registration options for user ${request.user.username}"
+        )
+        Ok(options.asJson.noSpaces)
+    }
   }
 
   /** See
@@ -68,68 +52,34 @@ class PasskeyController(
     */
   def register: Action[AnyContent] = authAction { request =>
     val result = for {
-      challenge <- PasskeyChallengeDB.load(request.user) match {
-        case Failure(exception) =>
-          logger.error(
-            s"Failed to load challenge for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          Left(BadRequest("Registration session invalid"))
-        case Success(None) =>
-          logger.error(
-            s"Challenge not found for user ${request.user.username}"
-          )
-          Left(BadRequest("Registration session invalid"))
-        case Success(Some(challenge)) =>
-          Right(Base64UrlUtil.encodeToString(challenge.getValue))
-      }
+      challenge <- PasskeyChallengeDB.load(request.user)
+      challengeStr = Base64UrlUtil.encodeToString(challenge.getValue)
+      body <- extractBody(request.body.asText, request.user)
+      credRecord <- Passkey.verifiedRegistration(host, challengeStr, body)
+      _ <- PasskeyDB.insert(UserCredentialRecord(request.user, credRecord))
+      _ <- PasskeyChallengeDB.delete(request.user)
+    } yield ()
 
-      body <- request.body.asText.toRight {
-        logger.error(
-          s"Missing body in registration request for user ${request.user.username}"
+    result match {
+      case Left(exception: JanusExceptionWithCause) =>
+        logger.error(exception.engineerMessage, exception.cause)
+        Status(exception.httpCode)(exception.userMessage)
+      case Left(exception: JanusException) =>
+        logger.error(exception.engineerMessage)
+        Status(exception.httpCode)(exception.userMessage)
+      case Right(_) =>
+        logger.info(
+          s"Successfully registered passkey for user ${request.user.username}"
         )
-        BadRequest("Invalid request format")
-      }
-
-      credRecord <- Passkey
-        .verifiedRegistration(host, challenge, body)
-        .toEither
-        .left
-        .map { exception =>
-          logger.error(
-            s"Registration verification failed for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          BadRequest("Registration verification failed")
-        }
-
-      _ <- PasskeyChallengeDB.delete(request.user).toEither.left.map {
-        exception =>
-          logger.error(
-            s"Failed to delete challenge for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          InternalServerError("Failed to delete challenge")
-      }
-
-      _ <- PasskeyDB
-        .insert(UserCredentialRecord(request.user, credRecord))
-        .toEither
-        .left
-        .map { exception =>
-          logger.error(
-            s"Failed to store credential for user ${request.user.username}: ${exception.getMessage}",
-            exception
-          )
-          InternalServerError("Failed to store credential")
-        }
-    } yield {
-      logger.info(
-        s"Successfully registered passkey for user ${request.user.username}"
-      )
-      NoContent
+        NoContent
     }
-
-    result.merge
   }
+
+  private def extractBody(body: Option[String], user: UserIdentity) =
+    body.toRight(
+      NotFoundException(
+        "Missing body in registration request",
+        s"Missing body in registration request for user ${user.username}"
+      )
+    )
 }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -9,6 +9,7 @@ import logic.Passkey
 import models.Passkey._
 import play.api.mvc._
 import play.api.{Logging, Mode}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 /** Controller for handling passkey registration and authentication. */
 class PasskeyController(
@@ -16,11 +17,17 @@ class PasskeyController(
     authAction: AuthAction[AnyContent],
     host: String,
     janusData: JanusData
-)(implicit mode: Mode, assetsFinder: AssetsFinder)
+)(implicit dynamoDb: DynamoDbClient, mode: Mode, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
 
+  // TODO: Move to service config
   private val appName = "Janus"
+
+  def showRegistrationPage: Action[AnyContent] = authAction {
+    implicit request =>
+      Ok(views.html.passkeyRegistration(request.user, janusData))
+  }
 
   // TODO persist instead of using session - store with TTL
   private val challengeAttribName = "passkeyChallenge"

--- a/app/logic/Passkey.scala
+++ b/app/logic/Passkey.scala
@@ -1,7 +1,5 @@
 package logic
 
-import aws.PasskeyDB
-import aws.PasskeyDB.UserCredentialRecord
 import com.gu.googleauth.UserIdentity
 import com.webauthn4j.WebAuthnManager
 import com.webauthn4j.credential.{CredentialRecord, CredentialRecordImpl}
@@ -10,7 +8,6 @@ import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
 import com.webauthn4j.data.client.Origin
 import com.webauthn4j.data.client.challenge.{Challenge, DefaultChallenge}
 import com.webauthn4j.server.ServerProperty
-import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import java.net.URI
 import java.nio.charset.StandardCharsets.UTF_8
@@ -21,58 +18,41 @@ import scala.util.Try
 /** Logic for registration of passkeys and authentication using them. */
 object Passkey {
 
-  // TODO: move out
-  private object config {
-    /* When true, requires the user to verify their identity
-     * (with Touch ID or other authentication method)
-     * before completing the registration.
-     */
-    val userVerificationRequired = true
+  /* When true, requires the user to verify their identity
+   * (with Touch ID or other authentication method)
+   * before completing the registration.
+   */
+  private val userVerificationRequired = true
 
-    val publicKeyCredentialParameters
-        : util.List[PublicKeyCredentialParameters] = List(
-      // ES256 is widely supported and efficient
-      new PublicKeyCredentialParameters(
-        PublicKeyCredentialType.PUBLIC_KEY,
-        COSEAlgorithmIdentifier.ES256
-      ),
-      // RS256 for broader compatibility
-      new PublicKeyCredentialParameters(
-        PublicKeyCredentialType.PUBLIC_KEY,
-        COSEAlgorithmIdentifier.RS256
-      ),
-      // EdDSA for better security/performance in newer authenticators
-      new PublicKeyCredentialParameters(
-        PublicKeyCredentialType.PUBLIC_KEY,
-        COSEAlgorithmIdentifier.EdDSA
-      )
-    ).asJava
-  }
+  private val publicKeyCredentialParameters
+      : util.List[PublicKeyCredentialParameters] = List(
+    // ES256 is widely supported and efficient
+    new PublicKeyCredentialParameters(
+      PublicKeyCredentialType.PUBLIC_KEY,
+      COSEAlgorithmIdentifier.ES256
+    ),
+    // RS256 for broader compatibility
+    new PublicKeyCredentialParameters(
+      PublicKeyCredentialType.PUBLIC_KEY,
+      COSEAlgorithmIdentifier.RS256
+    ),
+    // EdDSA for better security/performance in newer authenticators
+    new PublicKeyCredentialParameters(
+      PublicKeyCredentialType.PUBLIC_KEY,
+      COSEAlgorithmIdentifier.EdDSA
+    )
+  ).asJava
 
-  sealed trait PasskeyFailure {
-    def details: String
+  private val appName = "Janus"
 
-    def cause: Throwable
-  }
-
-  case class InvalidInputFailure(details: String, cause: Throwable)
-      extends PasskeyFailure
-
-  case class VerificationFailure(details: String, cause: Throwable)
-      extends PasskeyFailure
-
-  case class StorageFailure(details: String, cause: Throwable)
-      extends PasskeyFailure
-
-  // TODO: look into how this is configured
   private val webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager()
 
   /** Creates registration options for a new passkey. This is required by a
     * browser to initiate the registration process.
     *
-    * @param appName
-    *   The name of the application the passkey will authenticate (the relying
-    *   party).
+    * See
+    * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
+    *
     * @param appHost
     *   The host of the application the passkey will authenticate (the relying
     *   party).
@@ -85,19 +65,14 @@ object Passkey {
     *   options.
     */
   def registrationOptions(
-      appName: String,
       appHost: String,
       user: UserIdentity,
       challenge: Challenge = new DefaultChallenge()
-  ): Either[InvalidInputFailure, PublicKeyCredentialCreationOptions] = {
+  ): Try[PublicKeyCredentialCreationOptions] = {
     for {
-      appDomain <- domainOf(appHost)
+      appDomain <- Try(URI.create(appHost).getHost)
 
-      relyingParty <- Try(
-        new PublicKeyCredentialRpEntity(appDomain, appName)
-      ).toEither.left.map(exception =>
-        InvalidInputFailure("Invalid relying party fields", exception)
-      )
+      relyingParty <- Try(new PublicKeyCredentialRpEntity(appDomain, appName))
 
       userInfo <- Try(
         new PublicKeyCredentialUserEntity(
@@ -105,8 +80,6 @@ object Passkey {
           user.username,
           user.fullName
         )
-      ).toEither.left.map(exception =>
-        InvalidInputFailure("Invalid user fields", exception)
       )
 
       options <- Try(
@@ -114,16 +87,17 @@ object Passkey {
           relyingParty,
           userInfo,
           challenge,
-          config.publicKeyCredentialParameters
+          publicKeyCredentialParameters
         )
-      ).toEither.left.map(exception =>
-        InvalidInputFailure("Failed to create registration options", exception)
       )
     } yield options
   }
 
   /** Verifies the registration response from the browser. This is called after
-    * the user has completed the registration process on the browser.
+    * the user has completed the passkey creation process on the browser.
+    *
+    * See
+    * [[https://webauthn4j.github.io/webauthn4j/en/#registering-the-webauthn-public-key-credential-on-the-server]].
     *
     * @param appHost
     *   The host of the application the passkey will authenticate (the relying
@@ -141,19 +115,15 @@ object Passkey {
       appHost: String,
       challenge: String,
       jsonResponse: String
-  ): Either[PasskeyFailure, CredentialRecord] = {
+  ): Try[CredentialRecord] = {
     for {
       regData <- Try(
         webAuthnManager.parseRegistrationResponseJSON(jsonResponse)
-      ).toEither.left.map(exception =>
-        InvalidInputFailure("Invalid registration response", exception)
       )
 
-      origin <- Try(Origin.create(appHost)).toEither.left.map(exception =>
-        InvalidInputFailure("Invalid origin", exception)
-      )
+      origin <- Try(Origin.create(appHost))
 
-      relyingPartyId <- domainOf(appHost)
+      relyingPartyId <- Try(URI.create(appHost).getHost)
 
       serverProps <- Try(
         new ServerProperty(
@@ -161,42 +131,20 @@ object Passkey {
           relyingPartyId,
           new DefaultChallenge(challenge)
         )
-      ).toEither.left.map(exception =>
-        InvalidInputFailure("Invalid server properties", exception)
       )
 
       regParams = new RegistrationParameters(
         serverProps,
-        config.publicKeyCredentialParameters,
-        config.userVerificationRequired
+        publicKeyCredentialParameters,
+        userVerificationRequired
       )
 
-      _ <- Try(webAuthnManager.verify(regData, regParams)).toEither.left.map(
-        exception =>
-          VerificationFailure("Registration verification failed", exception)
-      )
+      _ <- Try(webAuthnManager.verify(regData, regParams))
     } yield new CredentialRecordImpl(
       regData.getAttestationObject,
       regData.getCollectedClientData,
       regData.getClientExtensions,
       regData.getTransports
     )
-  }
-
-  private def domainOf(host: String) =
-    Try(URI.create(host).getHost).toEither.left.map(exception =>
-      InvalidInputFailure(s"Invalid host: $host", exception)
-    )
-
-  def store(user: UserIdentity, credentialRecord: CredentialRecord)(implicit
-      dynamoDb: DynamoDbClient
-  ): Either[StorageFailure, Unit] = {
-    PasskeyDB
-      .insert(UserCredentialRecord(user, credentialRecord))
-      .toEither
-      .left
-      .map { exception =>
-        StorageFailure("Failed to store credential", exception)
-      }
   }
 }

--- a/app/logic/Passkey.scala
+++ b/app/logic/Passkey.scala
@@ -44,8 +44,6 @@ object Passkey {
     )
   )
 
-  private val appName = "Janus"
-
   private val webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager()
 
   /** Creates registration options for a new passkey. This is required by a
@@ -54,6 +52,8 @@ object Passkey {
     * See
     * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
     *
+    * @param appName
+    *   Name of the app the passkey will authenticate (the relying party).
     * @param appHost
     *   The host of the application the passkey will authenticate (the relying
     *   party).
@@ -66,6 +66,7 @@ object Passkey {
     *   options.
     */
   def registrationOptions(
+      appName: String,
       appHost: String,
       user: UserIdentity,
       challenge: Challenge = new DefaultChallenge()

--- a/app/logic/Passkey.scala
+++ b/app/logic/Passkey.scala
@@ -107,8 +107,7 @@ object Passkey {
     *   The host of the application the passkey will authenticate (the relying
     *   party).
     * @param challenge
-    *   Must correspond
-    *   with the challenge passed in [[registrationOptions]]).
+    *   Must correspond with the challenge passed in [[registrationOptions]]).
     * @param jsonResponse
     *   The JSON response from the browser containing the registration data.
     * @return

--- a/app/logic/Passkey.scala
+++ b/app/logic/Passkey.scala
@@ -1,0 +1,198 @@
+package logic
+
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.WebAuthnManager
+import com.webauthn4j.credential.{CredentialRecord, CredentialRecordImpl}
+import com.webauthn4j.data._
+import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier
+import com.webauthn4j.data.client.Origin
+import com.webauthn4j.data.client.challenge.{Challenge, DefaultChallenge}
+import com.webauthn4j.server.ServerProperty
+
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+
+/** Logic for registration of passkeys and authentication using them. */
+object Passkey {
+
+  // TODO: move out
+  private object config {
+    /* When true, requires the user to verify their identity
+     * (with Touch ID or other authentication method)
+     * before completing the registration.
+     */
+    val userVerificationRequired = true
+
+    val publicKeyCredentialParameters
+        : util.List[PublicKeyCredentialParameters] = List(
+      // ES256 is widely supported and efficient
+      new PublicKeyCredentialParameters(
+        PublicKeyCredentialType.PUBLIC_KEY,
+        COSEAlgorithmIdentifier.ES256
+      ),
+      // RS256 for broader compatibility
+      new PublicKeyCredentialParameters(
+        PublicKeyCredentialType.PUBLIC_KEY,
+        COSEAlgorithmIdentifier.RS256
+      ),
+      // EdDSA for better security/performance in newer authenticators
+      new PublicKeyCredentialParameters(
+        PublicKeyCredentialType.PUBLIC_KEY,
+        COSEAlgorithmIdentifier.EdDSA
+      )
+    ).asJava
+  }
+
+  sealed trait PasskeyFailure {
+    def details: String
+
+    def cause: Throwable
+  }
+
+  case class InvalidInputFailure(details: String, cause: Throwable)
+      extends PasskeyFailure
+
+  case class VerificationFailure(details: String, cause: Throwable)
+      extends PasskeyFailure
+
+  case class StorageFailure(details: String, cause: Throwable)
+      extends PasskeyFailure
+
+  // TODO: look into how this is configured
+  private val webAuthnManager = WebAuthnManager.createNonStrictWebAuthnManager()
+
+  /** Creates registration options for a new passkey. This is required by a
+    * browser to initiate the registration process.
+    *
+    * @param appName
+    *   The name of the application the passkey will authenticate (the relying
+    *   party).
+    * @param appHost
+    *   The host of the application the passkey will authenticate (the relying
+    *   party).
+    * @param user
+    *   The user identity retrieved from Google auth.
+    * @param challenge
+    *   The challenge to be used for registration.
+    * @return
+    *   A PublicKeyCredentialCreationOptions object containing the registration
+    *   options.
+    */
+  def registrationOptions(
+      appName: String,
+      appHost: String,
+      user: UserIdentity,
+      challenge: Challenge = new DefaultChallenge()
+  ): Either[InvalidInputFailure, PublicKeyCredentialCreationOptions] = {
+    for {
+      appDomain <- domainOf(appHost)
+
+      relyingParty <- Try(
+        new PublicKeyCredentialRpEntity(appDomain, appName)
+      ).toEither.left.map(exception =>
+        InvalidInputFailure("Invalid relying party fields", exception)
+      )
+
+      userInfo <- Try(
+        new PublicKeyCredentialUserEntity(
+          user.username.getBytes(UTF_8),
+          user.username,
+          user.fullName
+        )
+      ).toEither.left.map(exception =>
+        InvalidInputFailure("Invalid user fields", exception)
+      )
+
+      options <- Try(
+        new PublicKeyCredentialCreationOptions(
+          relyingParty,
+          userInfo,
+          challenge,
+          config.publicKeyCredentialParameters
+        )
+      ).toEither.left.map(exception =>
+        InvalidInputFailure("Failed to create registration options", exception)
+      )
+    } yield options
+  }
+
+  /** Verifies the registration response from the browser. This is called after
+    * the user has completed the registration process on the browser.
+    *
+    * @param appHost
+    *   The host of the application the passkey will authenticate (the relying
+    *   party).
+    * @param challenge
+    *   Base 64 encoded challenge string used for registration (must correspond
+    *   with the challenge passed in [[registrationOptions]]).
+    * @param jsonResponse
+    *   The JSON response from the browser containing the registration data.
+    * @return
+    *   A CredentialRecord object containing the verified credential data or an
+    *   [[IllegalArgumentException]] if verification fails.
+    */
+  def verifiedRegistration(
+      appHost: String,
+      challenge: String,
+      jsonResponse: String
+  ): Either[PasskeyFailure, CredentialRecord] = {
+    for {
+      regData <- Try(
+        webAuthnManager.parseRegistrationResponseJSON(jsonResponse)
+      ).toEither.left.map(exception =>
+        InvalidInputFailure("Invalid registration response", exception)
+      )
+
+      origin <- Try(Origin.create(appHost)).toEither.left.map(exception =>
+        InvalidInputFailure("Invalid origin", exception)
+      )
+
+      relyingPartyId <- domainOf(appHost)
+
+      serverProps <- Try(
+        new ServerProperty(
+          origin,
+          relyingPartyId,
+          new DefaultChallenge(challenge)
+        )
+      ).toEither.left.map(exception =>
+        InvalidInputFailure("Invalid server properties", exception)
+      )
+
+      regParams = new RegistrationParameters(
+        serverProps,
+        config.publicKeyCredentialParameters,
+        config.userVerificationRequired
+      )
+
+      _ <- Try(webAuthnManager.verify(regData, regParams)).toEither.left.map(
+        exception =>
+          VerificationFailure("Registration verification failed", exception)
+      )
+    } yield new CredentialRecordImpl(
+      regData.getAttestationObject,
+      regData.getCollectedClientData,
+      regData.getClientExtensions,
+      regData.getTransports
+    )
+  }
+
+  private def domainOf(host: String) =
+    Try(URI.create(host).getHost).toEither.left.map(exception =>
+      InvalidInputFailure(s"Invalid host: $host", exception)
+    )
+
+  // TODO
+  def store(
+      user: UserIdentity,
+      credentialRecord: CredentialRecord
+  ): Either[StorageFailure, Unit] = {
+    println(
+      s"TODO: Store credential record: ${user.username}: $credentialRecord"
+    )
+    Right(())
+  }
+}

--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -1,0 +1,56 @@
+package models
+
+import com.webauthn4j.data._
+import com.webauthn4j.data.client.challenge.Challenge
+import com.webauthn4j.util.Base64UrlUtil
+import io.circe.syntax._
+import io.circe.{Encoder, Json}
+
+import scala.jdk.CollectionConverters._
+
+/** Encodings for the WebAuthn data types used in passkey registration and
+  * authentication. These can't be auto-encoded by Circe because they aren't
+  * case classes.
+  */
+object Passkey {
+
+  implicit val relyingPartyEncoder: Encoder[PublicKeyCredentialRpEntity] =
+    Encoder.forProduct2("id", "name")(rp => (rp.getId, rp.getName))
+
+  implicit val userInfoEncoder: Encoder[PublicKeyCredentialUserEntity] =
+    Encoder.forProduct3("id", "name", "displayName")(user =>
+      (
+        Base64UrlUtil.encodeToString(user.getId),
+        user.getName,
+        user.getDisplayName
+      )
+    )
+
+  implicit val publicKeyCredentialParametersEncoder
+      : Encoder[PublicKeyCredentialParameters] =
+    Encoder.forProduct2("type", "alg")(param =>
+      (param.getType.getValue, param.getAlg.getValue)
+    )
+
+  implicit val challengeEncoder: Encoder[Challenge] =
+    Encoder.instance(challenge =>
+      Json.fromString(Base64UrlUtil.encodeToString(challenge.getValue))
+    )
+
+  implicit val publicKeyCredentialParametersListEncoder
+      : Encoder[java.util.List[PublicKeyCredentialParameters]] =
+    Encoder.instance(paramsList =>
+      Json.fromValues(paramsList.asScala.map(_.asJson))
+    )
+
+  implicit val encoder: Encoder[PublicKeyCredentialCreationOptions] =
+    Encoder.forProduct4("challenge", "rp", "user", "pubKeyCredParams")(
+      options =>
+        (
+          options.getChallenge,
+          options.getRp,
+          options.getUser,
+          options.getPubKeyCredParams
+        )
+    )
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -1,5 +1,7 @@
 package models
 
+import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
+
 sealed trait AccountConfigStatus
 case class FederationConfigError(causedBy: Throwable)
     extends AccountConfigStatus
@@ -11,3 +13,37 @@ sealed trait DisplayMode
 object Normal extends DisplayMode
 object Spooky extends DisplayMode
 object Festive extends DisplayMode
+
+sealed trait JanusException extends Exception {
+  def userMessage: String
+  def engineerMessage: String
+  def httpCode: Int
+}
+sealed trait JanusExceptionWithCause extends JanusException {
+  def cause: Throwable
+}
+case class BadArgumentException(
+    userMessage: String,
+    engineerMessage: String,
+    cause: Throwable
+) extends JanusExceptionWithCause {
+  val httpCode: Int = BAD_REQUEST
+}
+case class AwsCallException(
+    userMessage: String,
+    engineerMessage: String,
+    cause: Throwable
+) extends JanusExceptionWithCause {
+  val httpCode: Int = INTERNAL_SERVER_ERROR
+}
+case class PasskeyVerificationException(
+    userMessage: String,
+    engineerMessage: String,
+    cause: Throwable
+) extends JanusExceptionWithCause {
+  val httpCode: Int = BAD_REQUEST
+}
+case class NotFoundException(userMessage: String, engineerMessage: String)
+    extends JanusException {
+  val httpCode: Int = BAD_REQUEST
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -14,36 +14,9 @@ object Normal extends DisplayMode
 object Spooky extends DisplayMode
 object Festive extends DisplayMode
 
-sealed trait JanusException extends Exception {
-  def userMessage: String
-  def engineerMessage: String
-  def httpCode: Int
-}
-sealed trait JanusExceptionWithCause extends JanusException {
-  def cause: Throwable
-}
-case class BadArgumentException(
+case class JanusException(
     userMessage: String,
     engineerMessage: String,
-    cause: Throwable
-) extends JanusExceptionWithCause {
-  val httpCode: Int = BAD_REQUEST
-}
-case class AwsCallException(
-    userMessage: String,
-    engineerMessage: String,
-    cause: Throwable
-) extends JanusExceptionWithCause {
-  val httpCode: Int = INTERNAL_SERVER_ERROR
-}
-case class PasskeyVerificationException(
-    userMessage: String,
-    engineerMessage: String,
-    cause: Throwable
-) extends JanusExceptionWithCause {
-  val httpCode: Int = BAD_REQUEST
-}
-case class NotFoundException(userMessage: String, engineerMessage: String)
-    extends JanusException {
-  val httpCode: Int = BAD_REQUEST
-}
+    httpCode: Int,
+    causedBy: Option[Throwable]
+) extends Exception(engineerMessage, causedBy.orNull)

--- a/build.sbt
+++ b/build.sbt
@@ -88,6 +88,7 @@ lazy val root: Project = (project in file("."))
       "software.amazon.awssdk" % "sts" % awsSdkVersion,
       "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3", // scala-steward:off
+      "com.webauthn4j" % "webauthn4j-core" % "0.28.6.RELEASE",
       "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % Test
     ) ++ jacksonDatabindOverrides
       ++ jacksonOverrides

--- a/conf/routes
+++ b/conf/routes
@@ -27,6 +27,9 @@ GET     /loginError                 controllers.AuthController.loginError
 GET     /oauthCallback              controllers.AuthController.oauthCallback
 GET     /logout                     controllers.AuthController.logout
 
+GET     /passkey/registration-options   controllers.PasskeyController.registrationOptions
+POST    /passkey/register               controllers.PasskeyController.register
+
 GET     /healthcheck                controllers.Utility.healthcheck
 GET     /accounts                   controllers.Utility.accounts
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -17,8 +17,12 @@ To make this table available for testing auditing functionality:
 2. Populate the table with some test data by running [Insertion test](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/test/aws/AuditTrailDBTest.scala#L16-L46).
 
 
-## Setting up Passkeys table
+## Setting up Passkeys tables
 
-We also host a table that holds passkey public keys for authentication.  
-To make this table available for testing Passkeys functionality:  
-Create the passkey table schema by running [create table test](/test/aws/PasskeyDBTest.scala).
+To test registration of passkeys and their use in authentication, you will need to have the tables to hold passkey
+public key data and challenges in your local database.  
+To make these tables available for testing passkeys functionality:    
+1. Create the passkey credentials table schema by running [create table test](/test/aws/PasskeyDBTest.scala).
+2. Create the passkey challenges table schema by running [create table test](/test/aws/PasskeyChallengeDBTest.scala).
+
+These tests are ignored by default.  To run them, just change `ignore` to `in`.

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -1,16 +1,24 @@
-# Setting up Audit Database
+# Setting up a local Dynamo DB service
 
-When running locally, the audit endpoints require a Dynamo DB service to be running on port 8000.
-
-The service hosts a database holding a table that stores audit logs.
-
-To make this table available for testing auditing functionality:
-
+You will need to have Docker installed to run the local Dynamo DB service.  
+Then:  
 1. Start Docker
 2. Start up a local Dynamo DB container:
 ```shell
 cd local-dev
 docker-compose up -d
 ```
-3. Create the audit table schema by running [Creation test](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/test/aws/AuditTrailDBTest.scala#L48-L50).
-4. Populate the table with some test data by running [Insertion test](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/test/aws/AuditTrailDBTest.scala#L16-L46).
+
+## Setting up Audit table
+
+The service hosts a database holding a table that stores audit logs.  
+To make this table available for testing auditing functionality:  
+1. Create the audit table schema by running [Creation test](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/test/aws/AuditTrailDBTest.scala#L48-L50).
+2. Populate the table with some test data by running [Insertion test](https://github.com/guardian/janus-app/blob/f522bca83d9d90657634b038c7734a9871974161/test/aws/AuditTrailDBTest.scala#L16-L46).
+
+
+## Setting up Passkeys table
+
+We also host a table that holds passkey public keys for authentication.  
+To make this table available for testing Passkeys functionality:  
+Create the passkey table schema by running [create table test](/test/aws/PasskeyDBTest.scala).

--- a/test/aws/PasskeyChallengeDBTest.scala
+++ b/test/aws/PasskeyChallengeDBTest.scala
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.dynamodb.model._
 import java.nio.charset.StandardCharsets.UTF_8
 import java.time.ZoneOffset.UTC
 import java.time.{Clock, Instant}
+import scala.util.{Failure, Success}
 
 class PasskeyChallengeDBTest extends AnyFreeSpec with Matchers {
 
@@ -36,26 +37,26 @@ class PasskeyChallengeDBTest extends AnyFreeSpec with Matchers {
 
       "insertion succeeds" ignore {
         PasskeyChallengeDB.insert(userChallenge) match {
-          case Left(e) =>
+          case Failure(e) =>
             fail(s"Failed to insert user challenge: ${e.getMessage}")
-          case Right(_) => succeed
+          case Success(_) => succeed
         }
       }
 
       "load succeeds" ignore {
         PasskeyChallengeDB.load(userChallenge.user) match {
-          case Left(e) =>
+          case Failure(e) =>
             fail(s"Failed to load user challenge: ${e.getMessage}")
-          case Right(challenge) =>
+          case Success(challenge) =>
             challenge.getValue shouldBe userChallenge.challenge.getValue
         }
       }
 
       "deletion succeeds" ignore {
         PasskeyChallengeDB.delete(userChallenge.user) match {
-          case Left(e) =>
+          case Failure(e) =>
             fail(s"Failed to delete user challenge: ${e.getMessage}")
-          case Right(_) => succeed
+          case Success(_) => succeed
         }
       }
     }

--- a/test/aws/PasskeyChallengeDBTest.scala
+++ b/test/aws/PasskeyChallengeDBTest.scala
@@ -1,0 +1,139 @@
+package aws
+
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.data.client.challenge.DefaultChallenge
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.KeyType.HASH
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.S
+import software.amazon.awssdk.services.dynamodb.model._
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.ZoneOffset.UTC
+import java.time.{Clock, Instant}
+import scala.util.{Failure, Success}
+
+class PasskeyChallengeDBTest extends AnyFreeSpec with Matchers {
+
+  "test db stuff - use this to test DynamoDB stuff locally during development" - {
+    implicit val dynamoDB: DynamoDbClient = Clients.localDb
+
+    "insertion and querying" - {
+      val clock = Clock.fixed(Instant.parse("2025-03-31T01:00:00Z"), UTC)
+
+      val userChallenge = PasskeyChallengeDB.UserChallenge(
+        UserIdentity(
+          sub = "",
+          email = "test.user@example.com",
+          firstName = "Test",
+          lastName = "User",
+          exp = 0,
+          avatarUrl = None
+        ),
+        new DefaultChallenge("challenge".getBytes(UTF_8)),
+        clock.instant.plusSeconds(60)
+      )
+
+      "insertion succeeds" ignore {
+        PasskeyChallengeDB.insert(userChallenge) match {
+          case Success(_) => succeed
+          case Failure(e) =>
+            fail(s"Failed to insert user challenge: ${e.getMessage}")
+        }
+      }
+
+      "load succeeds" ignore {
+        PasskeyChallengeDB.load(userChallenge.user) match {
+          case Success(Some(challenge)) =>
+            challenge.getValue shouldBe userChallenge.challenge.getValue
+          case Success(None) =>
+            fail("No challenge found for user")
+          case Failure(e) =>
+            fail(s"Failed to load user challenge: ${e.getMessage}")
+        }
+      }
+
+      "deletion succeeds" ignore {
+        PasskeyChallengeDB.delete(userChallenge.user) match {
+          case Success(_) => succeed
+          case Failure(e) =>
+            fail(s"Failed to delete user challenge: ${e.getMessage}")
+        }
+      }
+    }
+
+    "create table" ignore {
+      createTable()
+    }
+
+    "destroy table" ignore {
+      destroyTable()
+    }
+  }
+
+  /** NB: Only use these for local testing use the provided CloudFormation
+    * template to create table in AWS environments.
+    *
+    * If you update this then be sure to also update the CloudFormation
+    * template's definition.
+    */
+  private[aws] def createTable()(implicit
+      dynamoDB: DynamoDbClient
+  ): CreateTableResponse = {
+    val response = dynamoDB.createTable(
+      CreateTableRequest
+        .builder()
+        .tableName(PasskeyChallengeDB.tableName)
+        .keySchema(
+          KeySchemaElement
+            .builder()
+            .attributeName("userName")
+            .keyType(HASH)
+            .build()
+        )
+        .attributeDefinitions(
+          AttributeDefinition
+            .builder()
+            .attributeName("userName")
+            .attributeType(S)
+            .build()
+        )
+        .provisionedThroughput(
+          ProvisionedThroughput
+            .builder()
+            .readCapacityUnits(15L)
+            .writeCapacityUnits(15L)
+            .build()
+        )
+        .build()
+    )
+
+    // Enable TTL on the table after creation
+    dynamoDB.updateTimeToLive(
+      UpdateTimeToLiveRequest
+        .builder()
+        .tableName(PasskeyChallengeDB.tableName)
+        .timeToLiveSpecification(
+          TimeToLiveSpecification
+            .builder()
+            .attributeName("expiresAt")
+            .enabled(true)
+            .build()
+        )
+        .build()
+    )
+
+    response
+  }
+
+  private[aws] def destroyTable()(implicit
+      dynamoDb: DynamoDbClient
+  ): DeleteTableResponse =
+    dynamoDb.deleteTable(
+      DeleteTableRequest
+        .builder()
+        .tableName(PasskeyChallengeDB.tableName)
+        .build()
+    )
+}

--- a/test/aws/PasskeyDBTest.scala
+++ b/test/aws/PasskeyDBTest.scala
@@ -37,7 +37,7 @@ class PasskeyDBTest extends AnyFreeSpec with Matchers {
         .keySchema(
           KeySchemaElement
             .builder()
-            .attributeName("userName")
+            .attributeName("username")
             .keyType(HASH)
             .build(),
           KeySchemaElement
@@ -49,7 +49,7 @@ class PasskeyDBTest extends AnyFreeSpec with Matchers {
         .attributeDefinitions(
           AttributeDefinition
             .builder()
-            .attributeName("userName")
+            .attributeName("username")
             .attributeType(S)
             .build(),
           AttributeDefinition

--- a/test/aws/PasskeyDBTest.scala
+++ b/test/aws/PasskeyDBTest.scala
@@ -1,0 +1,77 @@
+package aws
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.KeyType.{HASH, RANGE}
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType.S
+import software.amazon.awssdk.services.dynamodb.model._
+
+class PasskeyDBTest extends AnyFreeSpec with Matchers {
+
+  "test db stuff - use this to test DynamoDB stuff locally during development" - {
+    implicit val dynamoDB: DynamoDbClient = Clients.localDb
+
+    "create table" ignore {
+      createTable()
+    }
+
+    "destroy table" ignore {
+      destroyTable()
+    }
+  }
+
+  /** NB: Only use these for local testing use the provided CloudFormation
+    * template to create table in AWS environments.
+    *
+    * If you update this then be sure to also update the CloudFormation
+    * template's definition.
+    */
+  private[aws] def createTable()(implicit
+      dynamoDB: DynamoDbClient
+  ): CreateTableResponse =
+    dynamoDB.createTable(
+      CreateTableRequest
+        .builder()
+        .tableName(PasskeyDB.tableName)
+        .keySchema(
+          KeySchemaElement
+            .builder()
+            .attributeName("userName")
+            .keyType(HASH)
+            .build(),
+          KeySchemaElement
+            .builder()
+            .attributeName("credentialId")
+            .keyType(RANGE)
+            .build()
+        )
+        .attributeDefinitions(
+          AttributeDefinition
+            .builder()
+            .attributeName("userName")
+            .attributeType(S)
+            .build(),
+          AttributeDefinition
+            .builder()
+            .attributeName("credentialId")
+            .attributeType(S)
+            .build()
+        )
+        .provisionedThroughput(
+          ProvisionedThroughput
+            .builder()
+            .readCapacityUnits(15L)
+            .writeCapacityUnits(15L)
+            .build()
+        )
+        .build()
+    )
+
+  private[aws] def destroyTable()(implicit
+      dynamoDb: DynamoDbClient
+  ): DeleteTableResponse =
+    dynamoDb.deleteTable(
+      DeleteTableRequest.builder().tableName(PasskeyDB.tableName).build()
+    )
+}

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -28,17 +28,16 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
       )
 
       val options = Passkey.registrationOptions(
-        appName,
         appHost,
         testUser,
         challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       )
-      options.value.asJson.spaces2 shouldBe
+      options.toEither.value.asJson.spaces2 shouldBe
         """{
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "rp" : {
         |    "id" : "test.example.com",
-        |    "name" : "Test App"
+        |    "name" : "Janus"
         |  },
         |  "user" : {
         |    "id" : "dGVzdC51c2Vy",
@@ -75,7 +74,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         invalidJson
       )
 
-      result.left.value.details shouldBe "Invalid registration response"
+      result.toEither.isLeft shouldBe true
     }
   }
 }

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -31,7 +31,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         testUser,
         challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       )
-      options.value.asJson.spaces2 shouldBe
+      options.toEither.value.asJson.spaces2 shouldBe
         """{
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "rp" : {
@@ -64,7 +64,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
   "verifiedRegistration" - {
     "rejects invalid registration response" in {
       val appHost = "https://test.example.com"
-      val challenge = Base64UrlUtil.encodeToString("challenge".getBytes(UTF_8))
+      val challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       val invalidJson = """{"type": "public-key", "id": "invalid"}"""
 
       val result = Passkey.verifiedRegistration(
@@ -73,7 +73,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         invalidJson
       )
 
-      result.isLeft shouldBe true
+      result.isFailure shouldBe true
     }
   }
 }

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -27,6 +27,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
       )
 
       val options = Passkey.registrationOptions(
+        appName = "Janus-Test",
         appHost,
         testUser,
         challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
@@ -36,7 +37,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "rp" : {
         |    "id" : "test.example.com",
-        |    "name" : "Janus"
+        |    "name" : "Janus-Test"
         |  },
         |  "user" : {
         |    "id" : "dGVzdC51c2Vy",

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -15,7 +15,6 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
 
   "registrationOptions" - {
     "creates valid registration options" in {
-      val appName = "Test App"
       val appHost = "https://test.example.com"
 
       val testUser = UserIdentity(
@@ -32,7 +31,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         testUser,
         challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       )
-      options.toEither.value.asJson.spaces2 shouldBe
+      options.value.asJson.spaces2 shouldBe
         """{
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "rp" : {
@@ -74,7 +73,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         invalidJson
       )
 
-      result.toEither.isLeft shouldBe true
+      result.isLeft shouldBe true
     }
   }
 }

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -1,0 +1,81 @@
+package logic
+
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.data.client.challenge.DefaultChallenge
+import com.webauthn4j.util.Base64UrlUtil
+import io.circe.syntax.EncoderOps
+import models.Passkey._
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
+
+  "registrationOptions" - {
+    "creates valid registration options" in {
+      val appName = "Test App"
+      val appHost = "https://test.example.com"
+
+      val testUser = UserIdentity(
+        sub = "sub",
+        email = "test.user@example.com",
+        firstName = "Test",
+        lastName = "User",
+        exp = 0,
+        avatarUrl = None
+      )
+
+      val options = Passkey.registrationOptions(
+        appName,
+        appHost,
+        testUser,
+        challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
+      )
+      options.value.asJson.spaces2 shouldBe
+        """{
+        |  "challenge" : "Y2hhbGxlbmdl",
+        |  "rp" : {
+        |    "id" : "test.example.com",
+        |    "name" : "Test App"
+        |  },
+        |  "user" : {
+        |    "id" : "dGVzdC51c2Vy",
+        |    "name" : "test.user",
+        |    "displayName" : "Test User"
+        |  },
+        |  "pubKeyCredParams" : [
+        |    {
+        |      "type" : "public-key",
+        |      "alg" : -7
+        |    },
+        |    {
+        |      "type" : "public-key",
+        |      "alg" : -257
+        |    },
+        |    {
+        |      "type" : "public-key",
+        |      "alg" : -8
+        |    }
+        |  ]
+        |}""".stripMargin
+    }
+  }
+
+  "verifiedRegistration" - {
+    "rejects invalid registration response" in {
+      val appHost = "https://test.example.com"
+      val challenge = Base64UrlUtil.encodeToString("challenge".getBytes(UTF_8))
+      val invalidJson = """{"type": "public-key", "id": "invalid"}"""
+
+      val result = Passkey.verifiedRegistration(
+        appHost,
+        challenge,
+        invalidJson
+      )
+
+      result.left.value.details shouldBe "Invalid registration response"
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.0"
+ThisBuild / version := "4.0.1-SNAPSHOT"


### PR DESCRIPTION
## What is the purpose of this change?
This adds two new endpoints to enable registration of passkeys for a new authentication feature:
* GET /passkey/registration-options
* POST /passkey/register 

## What is the value of this change and how do we measure success?
When the feature is complete it will improve the security of the app.
To test registration, it should be possible to hit these two endpoints in coordination with a browser that supports creation of passkey public key credentials, using the [navigator.credentials.create](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API#creating_a_key_pair_and_registering_a_user) call.

## Any additional notes?
The implementation uses the `webauthn4j` library and is heavily reliant on its excellent [docs](https://webauthn4j.github.io/webauthn4j/en/).  
The registration flow is described in detail there.

## Prerequisites

- [x] New DynamoDB tables have been cloudformed
