### PR TITLE
refactor: remove redundant date-time decoder from Loader

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/config/Loader.scala
+++ b/configTools/src/main/scala/com/gu/janus/config/Loader.scala
@@ -195,17 +195,4 @@ object Loader {
       }
     } yield SupportACL.create(rota.toMap, supportAccess.toSet, period)
   }
-
-  private implicit val decodeDateTime: Decoder[Instant] =
-    Decoder.decodeString.emap { s =>
-      try {
-        Right(
-          ZonedDateTime
-            .parse(s, format.DateTimeFormatter.ISO_DATE_TIME)
-            .toInstant
-        )
-      } catch {
-        case NonFatal(e) => Left(e.getMessage)
-      }
-    }
 }


### PR DESCRIPTION
## What is the purpose of this change?
This removes a custom Circe decoder that isn't used.  
Circe decodes strings in ISO 8601 format to `Instant`s automatically so this decoder isn't being used.

## What is the value of this change and how do we measure success?
Removes redundant code, which is always good.
