### PR TITLE
Add a play run hook that starts the DynamoDB container

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,16 +131,22 @@ do some setup in Google as well.
 This will likely involve DNS or a hosts entry as well as a webserver
 (or container configuration) that forwards requests to port 9000.
 
+#### Start docker
+
+Janus uses docker to provide a local version of DynamoDB.
+
 #### Run Janus
 
 Use sbt to run Janus in development mode. 
 
     sbt -Dconfig.file=<PATH>/janus.local.conf run
 
-The Node bundle is built using a [`PlayRunHook`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/project/RunClientHook.scala#L1) which is [configured in `build.sbt`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/build.sbt#L80).
-
+The Node bundle is built using a [PlayRunHook](https://www.playframework.com/documentation/3.0.x/sbtCookbook), [`RunClientHook`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/project/RunClientHook.scala#L1).
 The frontend dev-server will automatically recompile and reload when changes are made.
 
+The application database is started using another Play run-hook, [DockerComposeHook](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/project/DockerComposeHook.scala)
+
+These hooks [configured in `build.sbt`](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/build.sbt#L80-L83), which makes sure that these dependencies are started and stopped automatically when Play's dev server starts and stops.
 
 #### Local audit log support
 

--- a/README.md
+++ b/README.md
@@ -141,12 +141,13 @@ Use sbt to run Janus in development mode.
 
     sbt -Dconfig.file=<PATH>/janus.local.conf run
 
-The Node bundle is built using a [PlayRunHook](https://www.playframework.com/documentation/3.0.x/sbtCookbook), [`RunClientHook`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/project/RunClientHook.scala#L1).
+The dev server uses [PlayRunHooks](https://www.playframework.com/documentation/3.0.x/sbtCookbook#Hooking-into-Plays-dev-mode) to start and stop dependent services.
+These hooks are [configured in `build.sbt`](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/build.sbt#L80-L83), which makes sure that these dependencies are started and stopped automatically when Play's dev server starts and stops.
+
+The Node bundle is built and started by the [`RunClientHook`](https://github.com/guardian/janus-app/blob/d2b7553d26f2dc52706fb053a7e138fce745710b/project/RunClientHook.scala#L1).
 The frontend dev-server will automatically recompile and reload when changes are made.
 
-The application database is started using another Play run-hook, [DockerComposeHook](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/project/DockerComposeHook.scala)
-
-These hooks [configured in `build.sbt`](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/build.sbt#L80-L83), which makes sure that these dependencies are started and stopped automatically when Play's dev server starts and stops.
+The application's database is started by the [DockerComposeHook](https://github.com/guardian/janus-app/blob/6ce4579bc49e15753bc8f4f3a61c91f90e785940/project/DockerComposeHook.scala).
 
 #### Local audit log support
 

--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,7 @@ lazy val root: Project = (project in file("."))
     // allows us to kick off the frontend dev-server when the API is run
     playRunHooks ++= Seq(
       RunClientHook(root.base),
-      DockerComposeHook(root.base),
+      DockerComposeHook(root.base)
     ),
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,10 @@ lazy val root: Project = (project in file("."))
       "-J-Xmx1g"
     ),
     // allows us to kick off the frontend dev-server when the API is run
-    playRunHooks += RunClientHook(root.base),
+    playRunHooks ++= Seq(
+      RunClientHook(root.base),
+      DockerComposeHook(root.base),
+    ),
     libraryDependencies ++= commonDependencies ++ Seq(
       ws,
       filters,

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -1,12 +1,12 @@
 # Setting up a local Dynamo DB service
 
-You will need to have Docker installed to run the local Dynamo DB service.  
-Then:  
-1. Start Docker
-2. Start up a local Dynamo DB container:
+You will need to have Docker installed and running to use the local Dynamo DB service.
+
+The local database container will be automatically started when Janus' webapp runs, but if you need to run it yourself you can use the following:
+
 ```shell
 cd local-dev
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Setting up Audit table

--- a/project/DockerComposeHook.scala
+++ b/project/DockerComposeHook.scala
@@ -1,0 +1,28 @@
+import play.sbt.PlayRunHook
+import sbt._
+
+import scala.sys.process.Process
+
+object DockerComposeHook {
+  def apply(base: File): PlayRunHook = {
+    object DockerComposeHook extends PlayRunHook {
+      var process: Option[Process] = None
+
+      val up = "docker compose up -d"
+      val down = "docker compose down"
+
+      override def afterStarted(): Unit = {
+        process = Some(
+          Process(up, base / "local-dev").run
+        )
+      }
+
+      override def afterStopped(): Unit = {
+        Process(down, base / "local-dev").!
+        process.foreach(p => p.destroy())
+        process = None
+      }
+    }
+    DockerComposeHook
+  }
+}


### PR DESCRIPTION
Adds a play run hook that starts the DynamoDB via `docker compose`. This automates an essential manual step in getting this application running locally.

This saves a step that is a bit tedious, and that is hard to discover for users coming to janus-app for the first time.