### PR TITLE
feat: enable https on the frontend app when running locally

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -15,7 +15,7 @@
         <title>@title - Janus</title>
 
          @if(mode == Mode.Dev) {
-            <link href="http://localhost:1234/main.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+            <link href="https://janus-frontend.local.dev-gutools.co.uk/main.css" type="text/css" rel="stylesheet" media="screen,projection"/>
         } else {
             <link href="@assetsFinder.path("frontend/main.css")" type="text/css" rel="stylesheet" media="screen,projection"/>
         }
@@ -83,14 +83,14 @@
         </footer>
 
         @if(mode == Mode.Dev) {
-            <script src="http://localhost:1234/janus.js"></script>
+            <script src="https://janus-frontend.local.dev-gutools.co.uk/janus.js"></script>
         } else {
             <script src="@assetsFinder.path("frontend/janus.js")"></script>
         }
 
         @if(displayMode == Festive) {
             @if(mode == Mode.Dev) {
-                <script src="http://localhost:1234/snow.js"></script>
+                <script src="https://janus-frontend.local.dev-gutools.co.uk/snow.js"></script>
             } else {
                 <script src="@assetsFinder.path("frontend/snow.js")"></script>
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Use Google Authentication to provide audited temporary access to AWS resources",
   "scripts": {
-    "start": "parcel --port 1234 --hmr-host localhost:1234",
+    "start": "parcel --port 1234 --no-hmr",
     "build": "parcel build --dist-dir ../public/frontend"
   },
   "source": [


### PR DESCRIPTION
## What is the purpose of this change?

To enable https on the frontend app when running locally. 

Also removes the 'hot module reloading' option from parcel as this feature is currently not working. We can revisit this in the future.

## What is the value of this change and how do we measure success?

We are able to run the app locally in Safari as well as Firefox and Chrome.

There is an associated PR in the [`janus` repo](https://github.com/guardian/janus/pull/4728) to create the nginx mapping.
