### PR TITLE
fix: update roleSessionName for account revocation

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -172,7 +172,11 @@ object Federation {
       creds.sessionToken
     )
     val provider = StaticCredentialsProvider.create(sessionCredentials)
-    val iamClient = IamClient.builder().region(EU_WEST_1).credentialsProvider(provider).build()
+    val iamClient = IamClient
+      .builder()
+      .region(EU_WEST_1)
+      .credentialsProvider(provider)
+      .build()
 
     // remove access from assumed role
     val roleName = getRoleName(roleArn)

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -3,6 +3,8 @@ package aws
 import com.gu.janus.model.{AwsAccount, Permission}
 import data.Policies
 import logic.Date
+import play.api.Mode
+import play.api.Mode.Prod
 import play.api.libs.json.Json
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.services.iam.IamClient
@@ -147,12 +149,17 @@ object Federation {
       after: Instant,
       roleArn: String,
       stsClient: StsClient
-  ): Unit = {
+  )(implicit mode: Mode): Unit = {
     val revocationPolicyDocument = denyOlderSessionsPolicyDocument(after)
+
+    val username = mode match {
+      case Prod => "janus"
+      case _    => "janus-dev"
+    }
 
     // assume role in the target account to authenticate the revocation
     val creds = Federation.assumeRole(
-      "janus",
+      username,
       roleArn,
       Policies.revokeAccessPermission(account),
       stsClient,

--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -7,6 +7,7 @@ import play.api.Mode
 import play.api.Mode.Prod
 import play.api.libs.json.Json
 import software.amazon.awssdk.auth.credentials._
+import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.iam.IamClient
 import software.amazon.awssdk.services.iam.model.PutRolePolicyRequest
 import software.amazon.awssdk.services.sts.StsClient
@@ -171,7 +172,7 @@ object Federation {
       creds.sessionToken
     )
     val provider = StaticCredentialsProvider.create(sessionCredentials)
-    val iamClient = IamClient.builder().credentialsProvider(provider).build()
+    val iamClient = IamClient.builder().region(EU_WEST_1).credentialsProvider(provider).build()
 
     // remove access from assumed role
     val roleName = getRoleName(roleArn)


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
The configuration of privileges is slightly different in Prod and Dev environments.  This changes the username that can revoke access to accounts to reflect this difference.

## What is the value of this change and how do we measure success?
We will be able to test revocation of all current access to an AWS account locally in a dev environment.

## Any additional notes?
See guardian/janus#4737 for configuration of Guardian's resources for local testing.
