### PR TITLE
refactor: migrate from Circe to Play Json for passkey data encoding

### DIFF
--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -8,8 +8,8 @@ import play.api.libs.json._
 import scala.jdk.CollectionConverters._
 
 /** Encodings for the WebAuthn data types used in passkey registration and
-  * authentication. These can't be auto-encoded because they aren't
-  * case classes.
+  * authentication. These can't be auto-encoded because they aren't case
+  * classes.
   */
 object Passkey {
 
@@ -30,7 +30,8 @@ object Passkey {
       )
     }
 
-  implicit val publicKeyCredentialParametersWrites: Writes[PublicKeyCredentialParameters] =
+  implicit val publicKeyCredentialParametersWrites
+      : Writes[PublicKeyCredentialParameters] =
     Writes { param =>
       Json.obj(
         "type" -> param.getType.getValue,
@@ -43,12 +44,14 @@ object Passkey {
       JsString(Base64UrlUtil.encodeToString(challenge.getValue))
     }
 
-  implicit val publicKeyCredentialParametersListWrites: Writes[java.util.List[PublicKeyCredentialParameters]] =
+  implicit val publicKeyCredentialParametersListWrites
+      : Writes[java.util.List[PublicKeyCredentialParameters]] =
     Writes { paramsList =>
       JsArray(paramsList.asScala.map(Json.toJson(_)).toSeq)
     }
 
-  implicit val creationOptionsWrites: Writes[PublicKeyCredentialCreationOptions] =
+  implicit val creationOptionsWrites
+      : Writes[PublicKeyCredentialCreationOptions] =
     Writes { options =>
       Json.obj(
         "challenge" -> options.getChallenge,

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -1,6 +1,5 @@
 package models
-
-import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR}
+import play.api.libs.json.{Json, Writes}
 
 sealed trait AccountConfigStatus
 case class FederationConfigError(causedBy: Throwable)
@@ -20,3 +19,21 @@ case class JanusException(
     httpCode: Int,
     causedBy: Option[Throwable]
 ) extends Exception(engineerMessage, causedBy.orNull)
+
+object JanusException {
+  implicit val janusExceptionWrites: Writes[JanusException] = Writes {
+    exception =>
+      Json.obj(
+        "status" -> "error",
+        "message" -> exception.userMessage,
+        "httpCode" -> exception.httpCode
+      )
+  }
+
+  implicit val throwableWrites: Writes[Throwable] = Writes { throwable =>
+    Json.obj(
+      "status" -> "error",
+      "message" -> throwable.getClass.getSimpleName
+    )
+  }
+}

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -7,7 +7,7 @@ export async function registerPasskey(csrfToken) {
     await fetch('/passkey/register', {
         method: 'POST',
         headers: {
-            'Content-Type': 'text/plain',
+            'Content-Type': 'application/json',
             'Csrf-Token': csrfToken
         },
         body: JSON.stringify(registrationResponseJSON)

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -2,12 +2,12 @@ package logic
 
 import com.gu.googleauth.UserIdentity
 import com.webauthn4j.data.client.challenge.DefaultChallenge
-import com.webauthn4j.util.Base64UrlUtil
-import io.circe.syntax.EncoderOps
 import models.Passkey._
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should
+import play.api.libs.json.Json.toJson
+import play.api.libs.json._
 
 import java.nio.charset.StandardCharsets.UTF_8
 
@@ -32,7 +32,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         testUser,
         challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       )
-      options.toEither.value.asJson.spaces2 shouldBe
+      Json.prettyPrint(toJson(options.toEither.value)) shouldBe
         """{
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "rp" : {
@@ -44,20 +44,16 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         |    "name" : "test.user",
         |    "displayName" : "Test User"
         |  },
-        |  "pubKeyCredParams" : [
-        |    {
-        |      "type" : "public-key",
-        |      "alg" : -7
-        |    },
-        |    {
-        |      "type" : "public-key",
-        |      "alg" : -257
-        |    },
-        |    {
-        |      "type" : "public-key",
-        |      "alg" : -8
-        |    }
-        |  ]
+        |  "pubKeyCredParams" : [ {
+        |    "type" : "public-key",
+        |    "alg" : -7
+        |  }, {
+        |    "type" : "public-key",
+        |    "alg" : -257
+        |  }, {
+        |    "type" : "public-key",
+        |    "alg" : -8
+        |  } ]
         |}""".stripMargin
     }
   }


### PR DESCRIPTION
## What is the purpose of this change?
We're using Circe for Json handling of the passkey responses largely because we were using it in the configTools subproject and then over-generalised.  It's easier to use Play-json in a Play app as it slightly simplifies the handling of json request bodies and gives us consistent handling of Json throughout the app.

## What is the value of this change and how do we measure success?
As we're working in the Play framework it makes sense to use its features unless there's a reason not to.
