### PR TITLE
Add a user-defined passkey name to the passkey data

### DIFF
--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -35,7 +35,8 @@ object PasskeyDB {
     */
   def toDynamoItem(
       user: UserIdentity,
-      credentialRecord: CredentialRecord
+      credentialRecord: CredentialRecord,
+      passkeyName: String
   ): Map[String, AttributeValue] =
     Map(
       "username" -> AttributeValue.fromS(user.username),
@@ -66,14 +67,16 @@ object PasskeyDB {
         )
       ),
       // see https://www.w3.org/TR/webauthn-1/#sign-counter
-      "authCounter" -> AttributeValue.fromN("0")
+      "authCounter" -> AttributeValue.fromN("0"),
+      "passkeyName" -> AttributeValue.fromS(passkeyName)
     )
 
   def insert(
       user: UserIdentity,
-      credentialRecord: CredentialRecord
+      credentialRecord: CredentialRecord,
+      passkeyName: String
   )(implicit dynamoDB: DynamoDbClient): Try[Unit] = Try {
-    val item = toDynamoItem(user, credentialRecord)
+    val item = toDynamoItem(user, credentialRecord, passkeyName)
     val request =
       PutItemRequest.builder().tableName(tableName).item(item.asJava).build()
     dynamoDB.putItem(request)

--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -217,4 +217,44 @@ object PasskeyDB {
       )
     )
   )
+
+  def fetchByUser(user: UserIdentity)(implicit dynamoDB: DynamoDbClient): Try[GetItemResponse] = {
+    Try {
+      val key = Map("username" -> AttributeValue.fromS(user.username))
+      val request =
+        GetItemRequest.builder().tableName(tableName).key(key.asJava).build()
+      dynamoDB.getItem(request)
+    }.recoverWith(err =>
+      Failure(
+        JanusException(
+          userMessage = "Failed to load user passkeys",
+          engineerMessage =
+            s"Failed to load user passkeys for ${user.username}: ${err.getMessage}",
+          httpCode = INTERNAL_SERVER_ERROR,
+          causedBy = Some(err)
+        )
+      )
+    )
+  }
+
+}
+
+def extractPasskeys(response: GetRecordsResponse): Try[Seq[String]] = {
+  if (response.hasItem) {
+    Try {
+      val item = response.
+      val passkeys =
+        Base64UrlUtil.decode(item.get("passkey").s().getBytes(UTF_8))
+      new DefaultChallenge(challenge)
+    }
+  } else {
+    Failure(
+      JanusException(
+        userMessage = "Challenge not found",
+        engineerMessage = s"Challenge not found for user ${user.username}",
+        httpCode = INTERNAL_SERVER_ERROR,
+        causedBy = None
+      )
+    )
+  }
 }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -11,6 +11,7 @@ import logic.{Date, Favourites, Passkey}
 import models.JanusException
 import models.JanusException.throwableWrites
 import models.Passkey._
+import play.api.http.Writeable
 import play.api.libs.json.Json.toJson
 import play.api.libs.json._
 import play.api.mvc._
@@ -19,6 +20,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import java.time.{ZoneId, ZonedDateTime}
 import scala.concurrent.ExecutionContext
+import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 /** Controller for handling passkey registration and authentication. */
@@ -35,10 +37,6 @@ class PasskeyController(
 ) extends AbstractController(controllerComponents)
     with Logging {
 
-  // To handle API responses with no return value
-  implicit val unitWrites: Writes[Unit] =
-    Writes(_ => Json.obj("status" -> "success"))
-
   private def passkeyAuthAction
       : ActionBuilder[UserIdentityRequest, AnyContent] =
     authAction.andThen(new PasskeyAuthFilter(host))
@@ -51,7 +49,7 @@ class PasskeyController(
 
   private def apiResponse[A](
       action: => Try[A]
-  )(implicit writes: Writes[A]): Result =
+  )(implicit resultConverter: A => Result): Result =
     action match {
       case Failure(err: JanusException) =>
         logger.error(err.engineerMessage, err.causedBy.orNull)
@@ -59,8 +57,17 @@ class PasskeyController(
       case Failure(err) =>
         logger.error(err.getMessage, err)
         Status(INTERNAL_SERVER_ERROR)(toJson(err))
-      case Success(a) => Ok(toJson(a))
+      case Success(a) => resultConverter(a)
     }
+
+  implicit def jsonToResult[A](a: A)(implicit writes: Writes[A]): Result = Ok(
+    toJson(a)
+  )
+
+  implicit def htmlToResult[A](a: A)(implicit writeable: Writeable[A]): Result =
+    Ok(a)
+
+  implicit def resultToResult(r: Result): Result = r
 
   /** See
     * [[https://webauthn4j.github.io/webauthn4j/en/#generating-a-webauthn-credential-key-pair]].
@@ -93,34 +100,29 @@ class PasskeyController(
           request.user
         )
         passkey <- request.body.get("passkey") match {
-          case Some(a) => Success(a.head)
+          case Some(values) => Success(values.head)
           case None =>
             Failure(
-              JanusException(
-                "Missing passkey",
-                "Missing passkey in request body",
-                400,
-                None
-              )
+              JanusException.missingFieldInRequest(request.user, "passkey")
             )
         }
         passkeyName <- request.body.get("passkeyName") match {
-          case Some(a) => Success(a.head)
+          case Some(values) => Success(values.head)
           case None =>
             Failure(
-              JanusException(
-                "Missing passkey name",
-                "Missing passkey name in request body",
-                400,
-                None
-              )
+              JanusException.missingFieldInRequest(request.user, "passkeyName")
             )
         }
-        credRecord <- Passkey.verifiedRegistration(host, challenge, passkey)
+        credRecord <- Passkey.verifiedRegistration(
+          host,
+          request.user,
+          challenge,
+          passkey
+        )
         _ <- PasskeyDB.insert(request.user, credRecord, passkeyName)
         _ <- PasskeyChallengeDB.delete(request.user)
         _ = logger.info(s"Registered passkey for user ${request.user.username}")
-      } yield ()
+      } yield Redirect("/user-account")
     )
   }
 
@@ -176,21 +178,11 @@ class PasskeyController(
     }).getOrElse(Ok(views.html.noPermissions(request.user, janusData)))
   }
 
+  // TODO: move to Janus or account controller
   def showUserAccountPage: Action[AnyContent] = authAction { implicit request =>
-    val passkeysResult = for {
+    apiResponse(for {
       queryResponse <- PasskeyDB.loadCredentials(request.user)
       passkeys = PasskeyDB.extractCredentials(queryResponse)
-    } yield passkeys
-
-    passkeysResult match {
-      case Success(passkeys) =>
-        Ok(views.html.userAccount(request.user, janusData, passkeys))
-      case Failure(e) =>
-        logger.error(
-          s"Failed to load passkeys for user ${request.user.username}",
-          e
-        )
-        Ok(views.html.userAccount(request.user, janusData, Nil))
-    }
+    } yield views.html.userAccount(request.user, janusData, passkeys))
   }
 }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -91,8 +91,11 @@ class PasskeyController(
           request.user
         )
         body = request.body.toString()
+        // TODO: parse request.body.asText to JSON
+        // part goes to verifiedRegistration
+        // and part goes to passkeyName
         credRecord <- Passkey.verifiedRegistration(host, challenge, body)
-        _ <- PasskeyDB.insert(request.user, credRecord)
+        _ <- PasskeyDB.insert(request.user, credRecord, "TODO")
         _ <- PasskeyChallengeDB.delete(request.user)
         _ = logger.info(s"Registered passkey for user ${request.user.username}")
       } yield ()

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -177,6 +177,7 @@ class PasskeyController(
   }
 
   def showUserAccountPage: Action[AnyContent] = authAction { implicit request =>
-    Ok(views.html.userAccount(request.user, janusData))
+    val passkeysForUser = PasskeyDB.fetchByUser(request.user)
+    Ok(views.html.userAccount(request.user, janusData, passkeysForUser))
   }
 }

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -1,4 +1,7 @@
 package models
+
+import com.gu.googleauth.UserIdentity
+import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, UNAUTHORIZED}
 import play.api.libs.json.{Json, Writes}
 
 sealed trait AccountConfigStatus
@@ -21,6 +24,7 @@ case class JanusException(
 ) extends Exception(engineerMessage, causedBy.orNull)
 
 object JanusException {
+
   implicit val janusExceptionWrites: Writes[JanusException] = Writes {
     exception =>
       Json.obj(
@@ -36,4 +40,97 @@ object JanusException {
       "message" -> throwable.getClass.getSimpleName
     )
   }
+
+  def missingFieldInRequest(
+      user: UserIdentity,
+      fieldName: String
+  ): JanusException = JanusException(
+    userMessage = s"Missing $fieldName field",
+    engineerMessage =
+      s"Missing $fieldName in request body for user ${user.username}",
+    httpCode = BAD_REQUEST,
+    causedBy = None
+  )
+
+  def invalidFieldInRequest(
+      user: UserIdentity,
+      fieldName: String,
+      cause: Throwable
+  ): JanusException = JanusException(
+    userMessage = s"Invalid $fieldName field",
+    engineerMessage =
+      s"Invalid $fieldName field in request body for user ${user.username}: ${cause.getMessage}",
+    httpCode = BAD_REQUEST,
+    causedBy = Some(cause)
+  )
+
+  def failedToLoadDbItem(
+      user: UserIdentity,
+      tableName: String,
+      cause: Throwable
+  ): JanusException = JanusException(
+    userMessage = s"Failed to load item from $tableName table",
+    engineerMessage =
+      s"Failed to load item from $tableName table for user ${user.username}: ${cause.getMessage}",
+    httpCode = INTERNAL_SERVER_ERROR,
+    causedBy = Some(cause)
+  )
+
+  def failedToCreateDbItem(
+      user: UserIdentity,
+      tableName: String,
+      cause: Throwable
+  ): JanusException = JanusException(
+    userMessage = s"Failed to store item in $tableName table",
+    engineerMessage =
+      s"Failed to store item in $tableName table for user ${user.username}: ${cause.getMessage}",
+    httpCode = INTERNAL_SERVER_ERROR,
+    causedBy = Some(cause)
+  )
+
+  def failedToUpdateDbItem(
+      user: UserIdentity,
+      tableName: String,
+      attribName: String,
+      cause: Throwable
+  ): JanusException = JanusException(
+    userMessage = s"Failed to update $tableName.$attribName",
+    engineerMessage =
+      s"Failed to update $tableName.$attribName for user ${user.username}: ${cause.getMessage}",
+    httpCode = INTERNAL_SERVER_ERROR,
+    causedBy = Some(cause)
+  )
+
+  def failedToDeleteDbItem(
+      user: UserIdentity,
+      tableName: String,
+      cause: Throwable
+  ): JanusException = JanusException(
+    userMessage = s"Failed to delete from $tableName table",
+    engineerMessage =
+      s"Failed to delete from $tableName table for user ${user.username}: ${cause.getMessage}",
+    httpCode = INTERNAL_SERVER_ERROR,
+    causedBy = Some(cause)
+  )
+
+  def missingItemInDb(user: UserIdentity, tableName: String): JanusException =
+    JanusException(
+      userMessage = s"Item missing in $tableName table",
+      engineerMessage =
+        s"Item not found in $tableName table for user ${user.username}",
+      httpCode = INTERNAL_SERVER_ERROR,
+      causedBy = None
+    )
+
+  def authenticationFailure(
+      user: UserIdentity,
+      cause: Throwable
+  ): JanusException =
+    JanusException(
+      userMessage = "Authentication failed",
+      engineerMessage =
+        s"Authentication failed for user ${user.username}: ${cause.getMessage}",
+      httpCode = UNAUTHORIZED,
+      causedBy = Some(cause)
+    )
 }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -11,13 +11,6 @@
         <h1 class="header orange-text">Account</h1>
 
         <div class="row">
-            <div class="col s12 m12 l9">    
-                <div class="card-panel">          
-                    <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
-                    </p>
-                    <div><button id="register-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}">Register a new passkey</button></div>
-                </div>
-            </div>
             <div class="col s12 m12 l3">
                 <div class="card-panel">
                         <p>You are logged in as @username(user).</p><div><a href="/logout"><button class="btn">Log out</button></a></div>
@@ -25,7 +18,18 @@
             </div>
         </div>
         
-        <h2 class="header orange-text">Passkeys</h2>
+        <h3 class="header orange-text">Passkeys</h3>
+
+        <div class="row">
+            <div class="col s12 m12 l9">
+                <div class="card-panel">
+                    <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
+                    </p>
+                    <div><button id="register-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}">Register a new passkey</button></div>
+                </div>
+            </div>
+        </div>
+
         <div class="row">
             @if(passkeys.nonEmpty) {
                 @for(passkey <- passkeys) {
@@ -39,7 +43,7 @@
             } else {
                 <div class="col s12">
                     <div class="card-panel">
-                        <p>You don't have any passkeys registered yet.</p>
+                        <p>You haven't registered any passkeys yet.</p>
                     </div>
                 </div>
             }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -24,12 +24,22 @@
                 </div>  
             </div>
         </div>
+        
+        <h2 class="header orange-text">Passkeys</h2>
         <div class="row">
-            @for(passkey <- passkeys) {
-                <div class="col s12 m12 l6">
+            @if(passkeys.nonEmpty) {
+                @for(passkey <- passkeys) {
+                    <div class="col s12 m12 l6">
+                        <div class="card-panel">
+                            <p>Passkey: @{passkey}</p>
+                            <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@passkey">Delete</button></div>
+                        </div>
+                    </div>
+                }
+            } else {
+                <div class="col s12">
                     <div class="card-panel">
-                        <p>Passkey: @{passkey}</p>
-                        <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@passkey">Delete</button></div>
+                        <p>You don't have any passkeys registered yet.</p>
                     </div>
                 </div>
             }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.JanusData
 @import logic.UserAccess.username
 @import play.api.Mode
-@(user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeysForUser: Seq[String])(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 @import play.filters.csrf.CSRF
 
 @main("User account", Some(user), janusData) {
@@ -23,7 +23,15 @@
                         <p>You are logged in as @username(user).</p><div><a href="/logout"><button class="btn">Log out</button></a></div>
                 </div>  
             </div>
-        </div>               
+        </div>
+        <div class="row">
+            @for(passkey <- passkeysForUser) {
+                <div class="col s12 m12 l6">
+                    <div class="card-panel>">
+                        <p>Passkey: @{passkey}</p>
+                        <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@passkey">Delete</button></div>
+            }
+        </div>
     </div>
 
 }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.JanusData
 @import logic.UserAccess.username
 @import play.api.Mode
-@(user: UserIdentity, janusData: JanusData, passkeysForUser: Seq[String])(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeys: Seq[String])(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 @import play.filters.csrf.CSRF
 
 @main("User account", Some(user), janusData) {
@@ -25,13 +25,14 @@
             </div>
         </div>
         <div class="row">
-            @for(passkey <- passkeysForUser) {
+            @for(passkey <- passkeys) {
                 <div class="col s12 m12 l6">
-                    <div class="card-panel>">
+                    <div class="card-panel">
                         <p>Passkey: @{passkey}</p>
                         <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@passkey">Delete</button></div>
+                    </div>
+                </div>
             }
         </div>
     </div>
-
 }

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -1,15 +1,21 @@
-export async function registerPasskey(csrfToken) {
-    const regOptionsResponse = await fetch('/passkey/registration-options');
-    const regOptionsResponseJson = await regOptionsResponse.json();
-    const credentialCreationOptions = PublicKeyCredential.parseCreationOptionsFromJSON(regOptionsResponseJson);
-    const publicKeyCredential = await navigator.credentials.create({ publicKey: credentialCreationOptions });
-    const passkeyName = await getPasskeyNameFromUser();
+import M from 'materialize-css';
 
-    createAndSubmitForm('/passkey/register', {
-        passkey: JSON.stringify(publicKeyCredential.toJSON()),
-        csrfToken: csrfToken,
-        passkeyName: passkeyName
-    });
+export async function registerPasskey(csrfToken) {
+    try {
+        const regOptionsResponse = await fetch('/passkey/registration-options');
+        const regOptionsResponseJson = await regOptionsResponse.json();
+        const credentialCreationOptions = PublicKeyCredential.parseCreationOptionsFromJSON(regOptionsResponseJson);
+        const publicKeyCredential = await navigator.credentials.create({publicKey: credentialCreationOptions});
+        const passkeyName = await getPasskeyNameFromUser();
+
+        createAndSubmitForm('/passkey/register', {
+            passkey: JSON.stringify(publicKeyCredential.toJSON()),
+            csrfToken: csrfToken,
+            passkeyName: passkeyName
+        });
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 export function setUpRegisterPasskeyButton(buttonSelector) {
@@ -24,15 +30,19 @@ export function setUpRegisterPasskeyButton(buttonSelector) {
 }
 
 export async function authenticatePasskey(targetHref, csrfToken)  {
-    const authOptionsResponse = await fetch("/passkey/auth-options");
-    const authOptionsResponseJson = await authOptionsResponse.json();
-    const credentialGetOptions = PublicKeyCredential.parseRequestOptionsFromJSON(authOptionsResponseJson);
-    const publicKeyCredential = await navigator.credentials.get({ publicKey: credentialGetOptions});
+    try {
+        const authOptionsResponse = await fetch('/passkey/auth-options');
+        const authOptionsResponseJson = await authOptionsResponse.json();
+        const credentialGetOptions = PublicKeyCredential.parseRequestOptionsFromJSON(authOptionsResponseJson);
+        const publicKeyCredential = await navigator.credentials.get({publicKey: credentialGetOptions});
 
-    createAndSubmitForm(targetHref, {
-        credentials: JSON.stringify(publicKeyCredential.toJSON()),
-        csrfToken: csrfToken
-    });
+        createAndSubmitForm(targetHref, {
+            credentials: JSON.stringify(publicKeyCredential.toJSON()),
+            csrfToken: csrfToken
+        });
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 function createAndSubmitForm(targetHref, formData) {
@@ -48,7 +58,7 @@ function createAndSubmitForm(targetHref, formData) {
         form.appendChild(input);
     });
 
-    document.getElementsByTagName('body')[0].appendChild(form);
+    document.body.append(form);
     form.submit();
 }
 
@@ -77,11 +87,10 @@ function getPasskeyNameFromUser() {
         const modalHtml = `
         <div id="${modalId}" class="modal">
             <div class="modal-content">
-                <h4 class="orange-text">Name Your Passkey</h4>
+                <h4 class="orange-text">Passkey Name</h4>
                 <p>Give this passkey a name to help you recognize it later.</p>
                 <div class="input-field">
                     <input type="text" id="passkey-name" class="validate" placeholder="e.g. Macbook, Phone" required>
-                    <label for="passkey-name">Passkey Name</label>
                 </div>
             </div>
             <div class="modal-footer">
@@ -90,7 +99,6 @@ function getPasskeyNameFromUser() {
             </div>
         </div>`;
         
-        // Add modal to document
         document.body.insertAdjacentHTML('beforeend', modalHtml);
         
         const modalElement = document.getElementById(modalId);

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -12,7 +12,7 @@ export async function registerPasskey(csrfToken) {
     const credsInput = document.createElement('input');
     credsInput.setAttribute('type','hidden');
     credsInput.setAttribute('name','passkey');
-    credsInput.setAttribute('value', registrationResponseJSON);
+    credsInput.setAttribute('value', JSON.stringify(registrationResponseJSON));
     const csrfTokenInput = document.createElement('input');
     csrfTokenInput.setAttribute('type','hidden');
     csrfTokenInput.setAttribute('name','csrfToken');

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -10,7 +10,9 @@ export async function registerPasskey(csrfToken) {
             'Content-Type': 'application/json',
             'Csrf-Token': csrfToken
         },
-        body: JSON.stringify(registrationResponseJSON)
+        body: {
+            "passkeyName": "TODO",
+            "passkey": JSON.stringify(registrationResponseJSON)}
     });
 }
 

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -4,16 +4,28 @@ export async function registerPasskey(csrfToken) {
     const credentialCreationOptions = PublicKeyCredential.parseCreationOptionsFromJSON(publicKeyCredentialCreationOptionsJSON);
     const publicKeyCredential = await navigator.credentials.create({ publicKey: credentialCreationOptions });
     const registrationResponseJSON = publicKeyCredential.toJSON();
-    await fetch('/passkey/register', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'Csrf-Token': csrfToken
-        },
-        body: {
-            "passkeyName": "TODO",
-            "passkey": JSON.stringify(registrationResponseJSON)}
-    });
+    // Add a form to the DOM so that it can be submitted at page level
+    const targetHref = '/passkey/register';
+    const form = document.createElement('form');
+    form.setAttribute('method', 'post');
+    form.setAttribute('action', targetHref);
+    const credsInput = document.createElement('input');
+    credsInput.setAttribute('type','hidden');
+    credsInput.setAttribute('name','passkey');
+    credsInput.setAttribute('value', registrationResponseJSON);
+    const csrfTokenInput = document.createElement('input');
+    csrfTokenInput.setAttribute('type','hidden');
+    csrfTokenInput.setAttribute('name','csrfToken');
+    csrfTokenInput.setAttribute('value', csrfToken);
+    const passkeyNameInput = document.createElement('input');
+    passkeyNameInput.setAttribute('type','hidden');
+    passkeyNameInput.setAttribute('name','passkeyName');
+    passkeyNameInput.setAttribute('value', 'hello again passkeyName');
+    form.appendChild(credsInput);
+    form.appendChild(passkeyNameInput);
+    form.appendChild(csrfTokenInput);
+    document.getElementsByTagName('body')[0].appendChild(form);
+    form.submit();
 }
 
 export function setUpRegisterPasskeyButton(buttonSelector) {

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -15,6 +15,7 @@ export async function registerPasskey(csrfToken) {
         });
     } catch (err) {
         console.error(err);
+        M.toast({html: err.message, classes: 'rounded red'});
     }
 }
 
@@ -42,6 +43,7 @@ export async function authenticatePasskey(targetHref, csrfToken)  {
         });
     } catch (err) {
         console.error(err);
+        M.toast({html: err.message, classes: 'rounded red'});
     }
 }
 
@@ -91,6 +93,7 @@ function getPasskeyNameFromUser() {
                 <p>Give this passkey a name to help you recognize it later.</p>
                 <div class="input-field">
                     <input type="text" id="passkey-name" class="validate" placeholder="e.g. Macbook, Phone" required>
+                    <div id="passkey-name-error" class="error-message red-text" style="display: none;">Please enter a name for your passkey</div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -116,10 +119,19 @@ function getPasskeyNameFromUser() {
         const submitButton = modalElement.querySelector('#submit-button');
         const cancelButton = modalElement.querySelector('#cancel-button');
         const input = modalElement.querySelector('#passkey-name');
+        const errorMessage = modalElement.querySelector('#passkey-name-error');
         
         // Focus the input when modal opens
         modalInstance.open();
         setTimeout(() => input.focus(), 100); // Small delay to ensure modal is visible
+        
+        // Clear error when typing
+        input.addEventListener('input', () => {
+            if (input.value.trim()) {
+                input.classList.remove('invalid');
+                errorMessage.style.display = 'none';
+            }
+        });
         
         // Handle form submission
         submitButton.addEventListener('click', (e) => {
@@ -129,6 +141,7 @@ function getPasskeyNameFromUser() {
             if (!passkeyName) {
                 // Show validation error
                 input.classList.add('invalid');
+                errorMessage.style.display = 'block';
                 return;
             }
             
@@ -141,7 +154,7 @@ function getPasskeyNameFromUser() {
         cancelButton.addEventListener('click', (e) => {
             e.preventDefault();
             modalInstance.close();
-            reject(new Error('User cancelled passkey naming'));
+            reject(new Error('Passkey registration cancelled'));
         });
         
         // Handle Enter key for form submission

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -61,11 +61,20 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
   "verifiedRegistration" - {
     "rejects invalid registration response" in {
       val appHost = "https://test.example.com"
+      val testUser = UserIdentity(
+        sub = "sub",
+        email = "test.user@example.com",
+        firstName = "Test",
+        lastName = "User",
+        exp = 0,
+        avatarUrl = None
+      )
       val challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       val invalidJson = """{"type": "public-key", "id": "invalid"}"""
 
       val result = Passkey.verifiedRegistration(
         appHost,
+        testUser,
         challenge,
         invalidJson
       )


### PR DESCRIPTION
## What is the purpose of this change?
This adds a mechanism to the frontend to set a passkey name during the registration process.  The name is added to the data stored in the Dynamo passkeys table.  This change also uses the names to list passkeys on the user account page.

## What is the value of this change and how do we measure success?
Users are allowed up to two passkeys so this change enables them to identify the passkeys they have already registered.  In the future it will allow them to choose which one to delete if they want to.

Co-authored-by: @tjsilver
