### PR TITLE
feat: add registration timestamp to passkey data

### DIFF
--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -5,13 +5,16 @@ import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.util.Base64UrlUtil
 import play.api.libs.json._
 
+import java.time.Instant
 import scala.jdk.CollectionConverters._
+
+case class Passkey(id: String, name: String, registrationTime: Instant)
 
 /** Encodings for the WebAuthn data types used in passkey registration and
   * authentication. These can't be auto-encoded because they aren't case
   * classes.
   */
-object Passkey {
+object PasskeyEncodings {
 
   implicit val relyingPartyWrites: Writes[PublicKeyCredentialRpEntity] =
     Writes { rp =>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -51,24 +51,5 @@
                 </div>
             }
         </div>
-
-        <div class="row">
-            @if(passkeys.nonEmpty) {
-                @for(passkey <- passkeys) {
-                    <div class="col s12 m12 l6">
-                        <div class="card-panel">
-                            <p>Passkey: @{passkey}</p>
-                            <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@passkey">Delete</button></div>
-                        </div>
-                    </div>
-                }
-            } else {
-                <div class="col s12">
-                    <div class="card-panel">
-                        <p>You haven't registered any passkeys yet.</p>
-                    </div>
-                </div>
-            }
-        </div>
     </div>
 }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -2,8 +2,10 @@
 @import com.gu.janus.model.JanusData
 @import logic.UserAccess.username
 @import play.api.Mode
-@(user: UserIdentity, janusData: JanusData, passkeys: Seq[String])(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 @import play.filters.csrf.CSRF
+@import java.time.Instant
+
+@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.Passkey], dateFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("User account", Some(user), janusData) {
 
@@ -14,10 +16,10 @@
             <div class="col s12 m12 l3">
                 <div class="card-panel">
                         <p>You are logged in as @username(user).</p><div><a href="/logout"><button class="btn">Log out</button></a></div>
-                </div>  
+                </div>
             </div>
         </div>
-        
+
         <h3 class="header orange-text">Passkeys</h3>
 
         <div class="row">
@@ -28,6 +30,26 @@
                     <div><button id="register-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}">Register a new passkey</button></div>
                 </div>
             </div>
+        </div>
+
+        <div class="row">
+            @if(passkeys.nonEmpty) {
+                @for(passkey <- passkeys) {
+                    <div class="col s12 m12 l6">
+                        <div class="card-panel">
+                            <p>Passkey: @{passkey.name}</p>
+                            <p>Added: @{dateFormat(passkey.registrationTime)}</p>
+                            <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@{passkey.id}">Delete</button></div>
+                        </div>
+                    </div>
+                }
+            } else {
+                <div class="col s12">
+                    <div class="card-panel">
+                        <p>You haven't registered any passkeys yet.</p>
+                    </div>
+                </div>
+            }
         </div>
 
         <div class="row">

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -101,11 +101,11 @@ function getPasskeyNameFromUser() {
                 <a href="#!" id="submit-button" class="waves-effect waves-light btn orange">Save</a>
             </div>
         </div>`;
-        
+
         document.body.insertAdjacentHTML('beforeend', modalHtml);
-        
+
         const modalElement = document.getElementById(modalId);
-        
+
         // Initialize Materialize modal
         const modalInstance = M.Modal.init(modalElement, {
             dismissible: false, // User must use buttons to close
@@ -114,17 +114,17 @@ function getPasskeyNameFromUser() {
                 modalElement.remove();
             }
         });
-        
+
         // Set up event listeners
         const submitButton = modalElement.querySelector('#submit-button');
         const cancelButton = modalElement.querySelector('#cancel-button');
         const input = modalElement.querySelector('#passkey-name');
         const errorMessage = modalElement.querySelector('#passkey-name-error');
-        
+
         // Focus the input when modal opens
         modalInstance.open();
         setTimeout(() => input.focus(), 100); // Small delay to ensure modal is visible
-        
+
         // Clear error when typing
         input.addEventListener('input', () => {
             if (input.value.trim()) {
@@ -132,31 +132,31 @@ function getPasskeyNameFromUser() {
                 errorMessage.style.display = 'none';
             }
         });
-        
+
         // Handle form submission
         submitButton.addEventListener('click', (e) => {
             e.preventDefault();
             const passkeyName = input.value.trim();
-            
+
             if (!passkeyName) {
                 // Show validation error
                 input.classList.add('invalid');
                 errorMessage.style.display = 'block';
                 return;
             }
-            
+
             // Close modal and resolve with the passkey name
             modalInstance.close();
             resolve(passkeyName);
         });
-        
+
         // Handle cancel button
         cancelButton.addEventListener('click', (e) => {
             e.preventDefault();
             modalInstance.close();
             reject(new Error('Passkey registration cancelled'));
         });
-        
+
         // Handle Enter key for form submission
         input.addEventListener('keypress', (e) => {
             if (e.key === 'Enter') {

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -2,7 +2,7 @@ package logic
 
 import com.gu.googleauth.UserIdentity
 import com.webauthn4j.data.client.challenge.DefaultChallenge
-import models.Passkey._
+import models.PasskeyEncodings._
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should


### PR DESCRIPTION
## What is the purpose of this change?
It adds the time that a passkey was created and registered in Janus to the database and shows it in the UI.

## What is the value of this change and how do we measure success?
We can see when a passkey was created and use this data for troubleshooting or for sorting and filtering.

## Any additional notes?
See also #566 

