### PR TITLE
feat: Add AAGUID to Passkey metadata

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -187,7 +187,7 @@ class PasskeyController(
         instant.atZone(ZoneId.of("Europe/London")).format(dateFormatter)
       for {
         queryResponse <- PasskeyDB.loadCredentials(request.user)
-        passkeys = PasskeyDB.extractCredentials(queryResponse)
+        passkeys = PasskeyDB.extractMetadata(queryResponse)
       } yield views.html.userAccount(
         request.user,
         janusData,

--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -1,6 +1,7 @@
 package models
 
 import com.webauthn4j.data._
+import com.webauthn4j.data.attestation.authenticator.AAGUID
 import com.webauthn4j.data.client.challenge.Challenge
 import com.webauthn4j.util.Base64UrlUtil
 import play.api.libs.json._
@@ -8,7 +9,13 @@ import play.api.libs.json._
 import java.time.Instant
 import scala.jdk.CollectionConverters._
 
-case class Passkey(id: String, name: String, registrationTime: Instant)
+case class PasskeyMetadata(
+    id: String,
+    name: String,
+    registrationTime: Instant,
+    // Identifies the model of the authenticator device that created the passkey
+    aaguid: AAGUID
+)
 
 /** Encodings for the WebAuthn data types used in passkey registration and
   * authentication. These can't be auto-encoded because they aren't case

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -5,7 +5,7 @@
 @import play.filters.csrf.CSRF
 @import java.time.Instant
 
-@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.Passkey], dateFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.PasskeyMetadata], dateFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("User account", Some(user), janusData) {
 
@@ -39,6 +39,7 @@
                         <div class="card-panel">
                             <p>Passkey: @{passkey.name}</p>
                             <p>Added: @{dateFormat(passkey.registrationTime)}</p>
+                            <p>Type: @{passkey.aaguid}</p>
                             <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@{passkey.id}">Delete</button></div>
                         </div>
                     </div>


### PR DESCRIPTION
## What is the purpose of this change?
This change adds the passkey's [AAGUID](https://web.dev/articles/webauthn-aaguid) (Authenticator Attestation Global Unique Identifier) to our passkey metadata model.

## What is the value of this change and how do we measure success?
We can use the AAGUID to identify the type of authenticator that generated the passkey.

## Any additional notes?
A further step is required to get the authenticator type from the AAGUID.  We need to look it up in a data feed that is published monthly by the [Fido Alliance](https://fidoalliance.org/metadata/).  The further step is described in [this Trello card](https://trello.com/c/22xJM3hH).
