### PR TITLE
feat: add delete passkey functionality

### DIFF
--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -264,27 +264,6 @@ object PasskeyDB {
     )
   )
 
-  def loadCredentialByName(
-      user: UserIdentity,
-      passkeyName: String
-  )(implicit dynamoDB: DynamoDbClient): Try[QueryResponse] =
-    Try {
-      val expressionValues = Map(
-        ":username" -> AttributeValue.fromS(user.username),
-        ":passkeyName" -> AttributeValue.fromS(passkeyName)
-      )
-      val request = QueryRequest
-        .builder()
-        .tableName(tableName)
-        .keyConditionExpression("username = :username")
-        .filterExpression("passkeyName = :passkeyName")
-        .expressionAttributeValues(expressionValues.asJava)
-        .build()
-      dynamoDB.query(request)
-    }.recoverWith(err =>
-      Failure(JanusException.failedToLoadDbItem(user, tableName, err))
-    )
-
   def deleteById(
       user: UserIdentity,
       credentialId: String

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -150,14 +150,14 @@ class PasskeyController(
   ) { implicit request =>
     apiResponse(
       for {
-        passkeyName <- request.body.get("passkeyName") match {
+        passkeyId <- request.body.get("passkeyId") match {
           case Some(values) => Success(values.head)
           case None =>
             Failure(
-              JanusException.missingFieldInRequest(request.user, "passkeyName")
+              JanusException.missingFieldInRequest(request.user, "passkeyId")
             )
         }
-        _ <- PasskeyDB.delete(request.user, passkeyName)
+        _ <- PasskeyDB.deleteById(request.user, passkeyId)
         _ = logger.info(s"Deleted passkey for user ${request.user.username}")
       } yield Redirect("/user-account")
     )

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -144,6 +144,25 @@ class PasskeyController(
     )
   }
 
+  /** Deletes a passkey for a user */
+  def deletePasskey: Action[Map[String, Seq[String]]] = authAction(
+    parse.formUrlEncoded
+  ) { implicit request =>
+    apiResponse(
+      for {
+        passkeyName <- request.body.get("passkeyName") match {
+          case Some(values) => Success(values.head)
+          case None =>
+            Failure(
+              JanusException.missingFieldInRequest(request.user, "passkeyName")
+            )
+        }
+        _ <- PasskeyDB.delete(request.user, passkeyName)
+        _ = logger.info(s"Deleted passkey for user ${request.user.username}")
+      } yield Redirect("/user-account")
+    )
+  }
+
   // To be removed when passkeyAuthAction has been applied to real endpoints
   def protectedCredentialsPage: Action[AnyContent] = passkeyAuthAction { _ =>
     Ok("This is the protected page you're authorised to see.")

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -41,7 +41,8 @@
                             <p>Type: @{passkey.aaguid}</p>
                             <p>Added: @{dateFormat(passkey.registrationTime)}</p>
                             <p>Last used: @{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</p>
-                            <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@{passkey.id}">Delete</button></div>
+                            <p>Type: @{passkey.aaguid}</p>
+                            <div><button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey-id="@{passkey.id}" data-passkey-name="@{passkey.name}">Delete</button></div>
                         </div>
                     </div>
                 }

--- a/conf/routes
+++ b/conf/routes
@@ -30,6 +30,7 @@ GET     /logout                     controllers.AuthController.logout
 GET     /passkey/registration-options   controllers.PasskeyController.registrationOptions
 GET     /passkey/auth-options           controllers.PasskeyController.authenticationOptions
 POST    /passkey/register               controllers.PasskeyController.register
+POST    /passkey/delete                 controllers.PasskeyController.deletePasskey
 
 # Temporary endpoints for testing passkey auth
 POST    /passkey/protected-credentials-page controllers.PasskeyController.protectedCredentialsPage

--- a/frontend/janus.js
+++ b/frontend/janus.js
@@ -1,6 +1,6 @@
 import DOMPurify from 'dompurify';
 import M from 'materialize-css';
-import {setUpProtectedLinks, setUpRegisterPasskeyButton} from './passkeys.js';
+import {setUpDeletePasskeyButtons, setUpProtectedLinks, setUpRegisterPasskeyButton} from './passkeys.js';
 
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -296,6 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     setUpRegisterPasskeyButton('#register-passkey');
+    setUpDeletePasskeyButtons('#delete-passkey');
     // setupAuthButtons('.auth-button');
     const protectedLinks = document.querySelectorAll('.passkey-protected');
     setUpProtectedLinks(protectedLinks);

--- a/frontend/janus.js
+++ b/frontend/janus.js
@@ -296,7 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     setUpRegisterPasskeyButton('#register-passkey');
-    setUpDeletePasskeyButtons('#delete-passkey');
+    setUpDeletePasskeyButtons('.delete-passkey-btn');
     // setupAuthButtons('.auth-button');
     const protectedLinks = document.querySelectorAll('.passkey-protected');
     setUpProtectedLinks(protectedLinks);

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -25,9 +25,11 @@ export async function registerPasskey(csrfToken) {
     }
 }
 
-export function setUpRegisterPasskeyButton(buttonSelector) {
-    const registerPasskeyButton = document.querySelector(buttonSelector);
-    registerPasskeyButton?.addEventListener('click', function (e) {
+export function setUpRegisterPasskeyButton(selector) {
+    const registerButton = document.querySelector(selector);
+    if (!registerButton) { return };
+
+    registerButton?.addEventListener('click', function (e) {
         e.preventDefault();
         const csrfToken = this.getAttribute('csrf-token');
         registerPasskey(csrfToken).catch(function (err) {
@@ -72,16 +74,35 @@ export function deletePasskey(passkeyName, csrfToken) {
     }
 }
 
-export function setUpDeletePasskeyButtons(buttonSelector) {
-    const deleteButtons = document.querySelectorAll(buttonSelector);
+export function setUpDeletePasskeyButtons(selector) {
+    const deleteButtons = document.querySelectorAll(selector);
+    if (!deleteButtons.length) return;
+
     deleteButtons.forEach(button => {
-        button.addEventListener('click', function(e) {
-            e.preventDefault();
-            const csrfToken = this.getAttribute('csrf-token');
-            const passkeyName = this.getAttribute('data-passkey');
-            deletePasskey(passkeyName, csrfToken).catch(function(err) {
-                console.error('Error setting up delete passkey button:', err);
-            });
+        button.addEventListener('click', async () => {
+            const passkeyName = button.getAttribute('data-passkey-name');
+            const passkeyId = button.getAttribute('data-passkey-id');
+            
+            if (!passkeyId) {
+                console.error('No passkey ID found');
+                alert('Error: Passkey ID not found');
+                return;
+            }
+            
+            if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
+                try {
+                    const csrfToken = button.getAttribute('csrf-token');
+                    
+                    // Use the createAndSubmitForm function with passkeyId
+                    createAndSubmitForm('/passkey/delete', {
+                        passkeyId: passkeyId,
+                        csrfToken: csrfToken
+                    });
+                } catch (error) {
+                    console.error('Error deleting passkey:', error);
+                    alert('An error occurred while deleting the passkey');
+                }
+            }
         });
     });
 }
@@ -104,6 +125,8 @@ function createAndSubmitForm(targetHref, formData) {
 }
 
 export function setUpProtectedLinks(links) {
+    if (!links.length) return;
+
     links.forEach((link) => {
         link.addEventListener('click', function (e) {
             e.preventDefault();

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -58,6 +58,34 @@ export async function authenticatePasskey(targetHref, csrfToken) {
     }
 }
 
+export function deletePasskey(passkeyName, csrfToken) {
+    try {
+        if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
+            createAndSubmitForm('/passkey/delete', {
+                passkeyName: passkeyName,
+                csrfToken: csrfToken
+            });
+        }
+    } catch (err) {
+        console.error('Error during passkey deletion:', err);
+        M.toast({ html: 'Failed to delete passkey. Please try again.', classes: 'rounded red' });
+    }
+}
+
+export function setUpDeletePasskeyButtons(buttonSelector) {
+    const deleteButtons = document.querySelectorAll(buttonSelector);
+    deleteButtons.forEach(button => {
+        button.addEventListener('click', function(e) {
+            e.preventDefault();
+            const csrfToken = this.getAttribute('csrf-token');
+            const passkeyName = this.getAttribute('data-passkey');
+            deletePasskey(passkeyName, csrfToken).catch(function(err) {
+                console.error('Error setting up delete passkey button:', err);
+            });
+        });
+    });
+}
+
 function createAndSubmitForm(targetHref, formData) {
     const form = document.createElement('form');
     form.setAttribute('method', 'post');

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -76,7 +76,9 @@ export function deletePasskey(passkeyName, csrfToken) {
 
 export function setUpDeletePasskeyButtons(selector) {
     const deleteButtons = document.querySelectorAll(selector);
-    if (!deleteButtons.length) return;
+    if (!deleteButtons.length) {
+        return;
+    }
 
     deleteButtons.forEach(button => {
         button.addEventListener('click', async () => {
@@ -85,7 +87,7 @@ export function setUpDeletePasskeyButtons(selector) {
             
             if (!passkeyId) {
                 console.error('No passkey ID found');
-                alert('Error: Passkey ID not found');
+                M.toast({ html: 'Error: Passkey ID not found', classes: 'rounded red' });
                 return;
             }
             
@@ -100,7 +102,7 @@ export function setUpDeletePasskeyButtons(selector) {
                     });
                 } catch (error) {
                     console.error('Error deleting passkey:', error);
-                    alert('An error occurred while deleting the passkey');
+                    M.toast({ html: 'An error occurred while deleting the passkey', classes: 'rounded red' });
                 }
             }
         });
@@ -125,7 +127,9 @@ function createAndSubmitForm(targetHref, formData) {
 }
 
 export function setUpProtectedLinks(links) {
-    if (!links.length) return;
+    if (!links.length) {
+        return;
+    }
 
     links.forEach((link) => {
         link.addEventListener('click', function (e) {

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -90,9 +90,14 @@ export function setUpDeletePasskeyButtons(selector) {
                 return;
             }
             
+            if (!csrfToken) {
+                console.error('No CSRF token found');
+                M.toast({ html: 'Error: Security token not found', classes: 'rounded red' });
+                return;
+            }
+            
             if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
                 deletePasskey(passkeyId, csrfToken);
-                
             }
         });
     });

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -60,19 +60,17 @@ export async function authenticatePasskey(targetHref, csrfToken) {
     }
 }
 
-export function deletePasskey(passkeyName, csrfToken) {
-    try {
-        if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
-            createAndSubmitForm('/passkey/delete', {
-                passkeyName: passkeyName,
-                csrfToken: csrfToken
-            });
-        }
-    } catch (err) {
-        console.error('Error during passkey deletion:', err);
-        M.toast({ html: 'Failed to delete passkey. Please try again.', classes: 'rounded red' });
+export function deletePasskey(passkeyId, csrfToken) {
+    try {   
+        createAndSubmitForm('/passkey/delete', {
+            passkeyId,
+            csrfToken
+        }); 
+    } catch (error) {
+        console.error('Error deleting passkey:', error);
+        M.toast({ html: 'An error occurred while deleting the passkey', classes: 'rounded red' });
     }
-}
+}   
 
 export function setUpDeletePasskeyButtons(selector) {
     const deleteButtons = document.querySelectorAll(selector);
@@ -84,6 +82,7 @@ export function setUpDeletePasskeyButtons(selector) {
         button.addEventListener('click', async () => {
             const passkeyName = button.getAttribute('data-passkey-name');
             const passkeyId = button.getAttribute('data-passkey-id');
+            const csrfToken = button.getAttribute('csrf-token');
             
             if (!passkeyId) {
                 console.error('No passkey ID found');
@@ -92,18 +91,8 @@ export function setUpDeletePasskeyButtons(selector) {
             }
             
             if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
-                try {
-                    const csrfToken = button.getAttribute('csrf-token');
-                    
-                    // Use the createAndSubmitForm function with passkeyId
-                    createAndSubmitForm('/passkey/delete', {
-                        passkeyId: passkeyId,
-                        csrfToken: csrfToken
-                    });
-                } catch (error) {
-                    console.error('Error deleting passkey:', error);
-                    M.toast({ html: 'An error occurred while deleting the passkey', classes: 'rounded red' });
-                }
+                deletePasskey(passkeyId, csrfToken);
+                
             }
         });
     });


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

This pull request introduces functionality for deleting passkeys, including backend, frontend, and UI changes. The most important changes include adding new methods for deleting passkeys in the database, creating a corresponding API endpoint, updating the UI to include delete buttons, and implementing frontend logic to handle passkey deletion.

### Backend Changes:
* **Database Methods**: Added `loadCredentialByName` and `deleteById` methods to the `PasskeyDB` object to query and delete passkeys from the DynamoDB table. These methods handle exceptions and provide meaningful error messages.
* **Controller Endpoint**: Introduced a `deletePasskey` method in `PasskeyController` to handle HTTP requests for deleting passkeys. It validates the request, deletes the passkey using `PasskeyDB`, and redirects the user upon success.
* **Routes**: Added a new route (`POST /passkey/delete`) to map the delete passkey API endpoint to the `deletePasskey` controller method.

### Frontend Changes:
* **UI Updates**: Updated the delete button in the `userAccount.scala.html` file to include `data-passkey-id` and `data-passkey-name` attributes for easier identification of the passkey being deleted.
* **JavaScript Logic**: 
  - Added `deletePasskey` and `setUpDeletePasskeyButtons` functions in `passkeys.js` to handle the deletion process, including confirmation dialogs and form submission.
  - Integrated the new delete button setup in `janus.js` to initialize event listeners on page load. [[1]](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8R63-R109) [[2]](diffhunk://#diff-88cc93f042de9edc2d7dcae4d80e117f44c66f39596c94ed1fe7810574937367R299)
## Testing

To test this locally, run this branch and try to create and then delete a passkey.