### PR TITLE
feat: Add lastUsedTime to Passkey model

### DIFF
--- a/app/controllers/PasskeyAuthFilter.scala
+++ b/app/controllers/PasskeyAuthFilter.scala
@@ -57,6 +57,7 @@ class PasskeyAuthFilter(host: String)(implicit
           )
           _ <- PasskeyChallengeDB.delete(request.user)
           _ <- PasskeyDB.updateCounter(request.user, verifiedAuthData)
+          _ <- PasskeyDB.updateLastUsedTime(request.user, verifiedAuthData)
           _ = logger.info(
             s"Authenticated passkey for user ${request.user.username}"
           )

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -182,9 +182,15 @@ class PasskeyController(
   // TODO: move to Janus or account controller
   def showUserAccountPage: Action[AnyContent] = authAction { implicit request =>
     apiResponse {
-      val dateFormatter = DateTimeFormatter.ofPattern("d MMM yyyy")
+      def dateTimeFormat(instant: Instant, formatter: DateTimeFormatter) =
+        instant.atZone(ZoneId.of("Europe/London")).format(formatter)
       def dateFormat(instant: Instant) =
-        instant.atZone(ZoneId.of("Europe/London")).format(dateFormatter)
+        dateTimeFormat(instant, DateTimeFormatter.ofPattern("d MMM yyyy"))
+      def timeFormat(instant: Instant) =
+        dateTimeFormat(
+          instant,
+          DateTimeFormatter.ofPattern("d MMM yyyy HH:mm:ss XXXXX")
+        )
       for {
         queryResponse <- PasskeyDB.loadCredentials(request.user)
         passkeys = PasskeyDB.extractMetadata(queryResponse)
@@ -192,7 +198,8 @@ class PasskeyController(
         request.user,
         janusData,
         passkeys,
-        dateFormat
+        dateFormat,
+        timeFormat
       )
     }
   }

--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -14,7 +14,8 @@ case class PasskeyMetadata(
     name: String,
     registrationTime: Instant,
     // Identifies the model of the authenticator device that created the passkey
-    aaguid: AAGUID
+    aaguid: AAGUID,
+    lastUsedTime: Option[Instant]
 )
 
 /** Encodings for the WebAuthn data types used in passkey registration and

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -5,7 +5,7 @@
 @import play.filters.csrf.CSRF
 @import java.time.Instant
 
-@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.PasskeyMetadata], dateFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.PasskeyMetadata], dateFormat: Instant => String, timeFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("User account", Some(user), janusData) {
 
@@ -38,8 +38,9 @@
                     <div class="col s12 m12 l6">
                         <div class="card-panel">
                             <p>Passkey: @{passkey.name}</p>
-                            <p>Added: @{dateFormat(passkey.registrationTime)}</p>
                             <p>Type: @{passkey.aaguid}</p>
+                            <p>Added: @{dateFormat(passkey.registrationTime)}</p>
+                            <p>Last used: @{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</p>
                             <div><button id="delete-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey="@{passkey.id}">Delete</button></div>
                         </div>
                     </div>


### PR DESCRIPTION
## What is the purpose of this change?
This adds a timestamp for the last time the passkey was used to authenticate an action to the database.
We then show the timestamp on the passkey section of the user account page.

## What is the value of this change and how do we measure success?
Can be used for troubleshooting and to give user confidence.

## Images
<img width="1129" alt="Screenshot 2025-05-14 at 13 19 55" src="https://github.com/user-attachments/assets/6238a095-8e72-44a4-bc5f-4ff84aa39882" />
