### PR TITLE
feat: Improve UX of user account page

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -17,7 +17,7 @@
         <h3 class="header orange-text">Passkeys</h3>
 
         <div class="row">
-            <div class="col s12 m12 l9">
+            <div class="col s12">
                 <div class="card-panel">
                     <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
                     </p>
@@ -28,17 +28,39 @@
 
         <div class="row">
             @if(passkeys.nonEmpty) {
-                @for(passkey <- passkeys) {
-                    <div class="col s12 m12 l6">
+                    <h4 class="header orange-text">Your passkeys</h4>
+                    <div class="col s12">
                         <div class="card-panel">
-                            <p>Passkey: @{passkey.name}</p>
-                            <p>Type: @{passkey.aaguid}</p>
-                            <p>Added: @{dateFormat(passkey.registrationTime)}</p>
-                            <p>Last used: @{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</p>
-                            <div><button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey-id="@{passkey.id}" data-passkey-name="@{passkey.name}">Delete</button></div>
+                            <table class="striped responsive-table">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Type</th>
+                                        <th>Added</th>
+                                        <th>Last used</th>
+                                        <th>Delete</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for(passkey <- passkeys) {
+                                        <tr>
+                                            <td>@{passkey.name}</td>
+                                            <td>@{passkey.aaguid}</td>
+                                            <td>@{dateFormat(passkey.registrationTime)}</td>
+                                            <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
+                                            <td>
+                                                <button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" 
+                                                        data-passkey-id="@{passkey.id}" 
+                                                        data-passkey-name="@{passkey.name}">
+                                                    <i class="material-icons">delete</i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
                         </div>
                     </div>
-                }
             } else {
                 <div class="col s12">
                     <div class="card-panel">

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -16,58 +16,58 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <div class="row">
+        <p>Passkeys are a secure way to log in without a password. They are stored on your device and are used to authenticate you when you access Janus credentials or the AWS console.</p>
+        <p>You can register up to two passkeys. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).</p>
+
+        <div class="row">           
+            <h4 class="header orange-text">Registered passkeys</h4>
             <div class="col s12">
                 <div class="card-panel">
-                    <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
-                    </p>
-                    <div><button id="register-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}">Register a new passkey</button></div>
+                    @if(passkeys.nonEmpty) {
+                        <table class="striped responsive-table">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Type</th>
+                                    <th>Added</th>
+                                    <th>Last used</th>
+                                    <th>Delete</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for(passkey <- passkeys) {
+                                    <tr>
+                                        <td>@{passkey.name}</td>
+                                        <td>@{passkey.aaguid}</td>
+                                        <td>@{dateFormat(passkey.registrationTime)}</td>
+                                        <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
+                                        <td>
+                                            <button class="btn delete-passkey-btn" 
+                                                    csrf-token="@{CSRF.getToken.get.value}" 
+                                                    data-passkey-id="@{passkey.id}" 
+                                                    data-passkey-name="@{passkey.name}">
+                                                <i class="material-icons">delete</i>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    } else {                                 
+                        <p>You haven't registered any passkeys yet.</p>
+                    }                    
+                    
+                    @if(passkeys.size < 2) {
+                        <div class="section">
+                            <button id="register-passkey" 
+                                    class="btn" 
+                                    csrf-token="@{CSRF.getToken.get.value}">
+                                Register a new passkey
+                            </button>
+                        </div>
+                    }
                 </div>
             </div>
-        </div>
-
-        <div class="row">
-            @if(passkeys.nonEmpty) {
-                    <h4 class="header orange-text">Your passkeys</h4>
-                    <div class="col s12">
-                        <div class="card-panel">
-                            <table class="striped responsive-table">
-                                <thead>
-                                    <tr>
-                                        <th>Name</th>
-                                        <th>Type</th>
-                                        <th>Added</th>
-                                        <th>Last used</th>
-                                        <th>Delete</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @for(passkey <- passkeys) {
-                                        <tr>
-                                            <td>@{passkey.name}</td>
-                                            <td>@{passkey.aaguid}</td>
-                                            <td>@{dateFormat(passkey.registrationTime)}</td>
-                                            <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
-                                            <td>
-                                                <button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" 
-                                                        data-passkey-id="@{passkey.id}" 
-                                                        data-passkey-name="@{passkey.name}">
-                                                    <i class="material-icons">delete</i>
-                                                </button>
-                                            </td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-            } else {
-                <div class="col s12">
-                    <div class="card-panel">
-                        <p>You haven't registered any passkeys yet.</p>
-                    </div>
-                </div>
-            }
         </div>
     </div>
     <div id="passkey-name-modal" class="modal">

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -56,16 +56,13 @@
                     } else {                                 
                         <p>You haven't registered any passkeys yet.</p>
                     }                    
-                    
-                    @if(passkeys.size < 2) {
-                        <div class="section">
-                            <button id="register-passkey" 
-                                    class="btn" 
-                                    csrf-token="@{CSRF.getToken.get.value}">
-                                Register a new passkey
-                            </button>
-                        </div>
-                    }
+                    <div class="section">
+                        <button id="register-passkey" 
+                                class="btn" 
+                                csrf-token="@{CSRF.getToken.get.value}">
+                            Register a new passkey
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -12,13 +12,7 @@
     <div class="container">
         <h1 class="header orange-text">Account</h1>
 
-        <div class="row">
-            <div class="col s12 m12 l3">
-                <div class="card-panel">
-                        <p>You are logged in as @username(user).</p><div><a href="/logout"><button class="btn">Log out</button></a></div>
-                </div>
-            </div>
-        </div>
+        <p>You are logged in as <strong>@username(user)</strong>.</p>
 
         <h3 class="header orange-text">Passkeys</h3>
 

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -16,8 +16,8 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <p>Passkeys are a secure way to log in without a password. They are stored on your device and are used to authenticate you when you access Janus credentials or the AWS console.</p>
-        <p>You can register up to two passkeys. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).</p>
+        <p>Passkeys are a secure way to log in without a password. They are used to authenticate you when you access Janus credentials or the AWS console.</p>
+        <p>We recommend you register at least two passkeys. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).</p>
 
         <div class="row">           
             <h4 class="header orange-text">Registered passkeys</h4>


### PR DESCRIPTION
## What is the purpose of this change?
## Images

### Before - no passkeys

![image](https://github.com/user-attachments/assets/1c7f87fc-d0fa-4f87-8239-9f826527fb2f)

## Before - one or more passkeys

![image](https://github.com/user-attachments/assets/c43fa66d-8629-4a67-b4bb-1c0ba3060604)


### After - no passkeys

![image](https://github.com/user-attachments/assets/d8b3ea7f-c14d-4ead-bc0b-01f1ec772246)


### One or more passkeys

![image](https://github.com/user-attachments/assets/f2c5ecf0-0d87-4f9d-a031-281b0e359dac)

## Any additional notes?

I have reverted the two-passkey limit as this was not required.

I have also changed this PR remove the error messaging and fetch api use from this PR as I will use Play session flash messages rather than client-side toast messages in a separate PR.