### PR TITLE
feat: Improve passkey validation and add server-side validation

### DIFF
--- a/app/constants/ValidationConstants.scala
+++ b/app/constants/ValidationConstants.scala
@@ -1,21 +1,19 @@
 package constants
 
-/**
- * Shared validation constants used across the application
- * These constants are used by both server-side code and exposed to client-side JavaScript
- */
+/** Shared validation constants used across the application These constants are
+  * used by both server-side code and exposed to client-side JavaScript
+  */
 object ValidationConstants {
   // Passkey validation constants
   object PasskeyName {
     val REGEX_PATTERN = "^[a-zA-Z0-9 _-]*$"
     val MAX_LENGTH = 50
   }
-  
-  /**
-   * Convert constants to JavaScript
-   * This creates a JavaScript object that can be included in the page
-   */
-  def toJavaScript: String = 
+
+  /** Convert constants to JavaScript This creates a JavaScript object that can
+    * be included in the page
+    */
+  def toJavaScript: String =
     s"""window.ValidationConstants = {
        |  PASSKEY_NAME: {
        |    REGEX_PATTERN: "${PasskeyName.REGEX_PATTERN}",

--- a/app/constants/ValidationConstants.scala
+++ b/app/constants/ValidationConstants.scala
@@ -1,0 +1,26 @@
+package constants
+
+/**
+ * Shared validation constants used across the application
+ * These constants are used by both server-side code and exposed to client-side JavaScript
+ */
+object ValidationConstants {
+  // Passkey validation constants
+  object PasskeyName {
+    val REGEX_PATTERN = "^[a-zA-Z0-9 _-]*$"
+    val MAX_LENGTH = 50
+  }
+  
+  /**
+   * Convert constants to JavaScript
+   * This creates a JavaScript object that can be included in the page
+   */
+  def toJavaScript: String = 
+    s"""window.ValidationConstants = {
+       |  PASSKEY_NAME: {
+       |    REGEX_PATTERN: "${PasskeyName.REGEX_PATTERN}",
+       |    MAX_LENGTH: ${PasskeyName.MAX_LENGTH}
+       |  }
+       |};
+       |""".stripMargin
+}

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -40,17 +40,19 @@ class PasskeyController(
     with Logging {
 
   // Use the constants directly from Scala
-  private val validPasskeyNameRegex = ValidationConstants.PasskeyName.REGEX_PATTERN.r
+  private val validPasskeyNameRegex =
+    ValidationConstants.PasskeyName.REGEX_PATTERN.r
   private val maxPasskeyNameLength = ValidationConstants.PasskeyName.MAX_LENGTH
 
-  /**
-   * Validates a passkey name against format and length requirements
-   * @param name The passkey name to validate
-   * @return True if the name is valid, false otherwise
-   */
+  /** Validates a passkey name against format and length requirements
+    * @param name
+    *   The passkey name to validate
+    * @return
+    *   True if the name is valid, false otherwise
+    */
   private def isValidPasskeyName(name: String): Boolean = {
-    name.nonEmpty && 
-    name.length <= maxPasskeyNameLength && 
+    name.nonEmpty &&
+    name.length <= maxPasskeyNameLength &&
     validPasskeyNameRegex.matches(name)
   }
 
@@ -130,26 +132,40 @@ class PasskeyController(
               JanusException.missingFieldInRequest(request.user, "passkeyName")
             )
         }
-        
+
         // Validate the passkey name format
-        _ <- if (!isValidPasskeyName(passkeyName)) {
-          Failure(JanusException.invalidFieldInRequest(
-            request.user,
-            "passkeyName",
-            new IllegalArgumentException("Passkey name must contain only letters, numbers, spaces, underscores, and hyphens, and be under 50 characters")
-          ))
-        } else Success(())
-        
+        _ <-
+          if (!isValidPasskeyName(passkeyName)) {
+            Failure(
+              JanusException.invalidFieldInRequest(
+                request.user,
+                "passkeyName",
+                new IllegalArgumentException(
+                  "Passkey name must contain only letters, numbers, spaces, underscores, and hyphens, and be under 50 characters"
+                )
+              )
+            )
+          } else Success(())
+
         // Check for duplicate passkey names
         existingPasskeys <- PasskeyDB.loadCredentials(request.user)
-        _ <- if (PasskeyDB.extractMetadata(existingPasskeys).exists(_.name.equalsIgnoreCase(passkeyName))) {
-          Failure(JanusException.invalidFieldInRequest(
-            request.user,
-            "passkeyName",
-            new IllegalArgumentException(s"A passkey with name '$passkeyName' already exists for this user")
-          ))
-        } else Success(())
-        
+        _ <-
+          if (
+            PasskeyDB
+              .extractMetadata(existingPasskeys)
+              .exists(_.name.equalsIgnoreCase(passkeyName))
+          ) {
+            Failure(
+              JanusException.invalidFieldInRequest(
+                request.user,
+                "passkeyName",
+                new IllegalArgumentException(
+                  s"A passkey with name '$passkeyName' already exists for this user"
+                )
+              )
+            )
+          } else Success(())
+
         credRecord <- Passkey.verifiedRegistration(
           host,
           request.user,
@@ -158,7 +174,9 @@ class PasskeyController(
         )
         _ <- PasskeyDB.insert(request.user, credRecord, passkeyName)
         _ <- PasskeyChallengeDB.delete(request.user)
-        _ = logger.info(s"Registered passkey '$passkeyName' for user ${request.user.username}")
+        _ = logger.info(
+          s"Registered passkey '$passkeyName' for user ${request.user.username}"
+        )
       } yield Redirect("/user-account")
     )
   }

--- a/app/views/fragments/validationConstants.scala.html
+++ b/app/views/fragments/validationConstants.scala.html
@@ -1,0 +1,12 @@
+@import constants.ValidationConstants
+
+@()
+
+<script type="text/javascript">
+window.ValidationConstants = {
+  PASSKEY_NAME: {
+    REGEX_PATTERN: "@{ValidationConstants.PasskeyName.REGEX_PATTERN}",
+    MAX_LENGTH: "@{ValidationConstants.PasskeyName.MAX_LENGTH}"
+  }
+};
+</script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -20,6 +20,7 @@
             <link href="@assetsFinder.path("frontend/main.css")" type="text/css" rel="stylesheet" media="screen,projection"/>
         }
         <link rel="icon" href="@assetsFinder.path("images/favicon.ico")"/>
+        @fragments.validationConstants()
     </head>
     <body>
         <header>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -16,58 +16,58 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <div class="row">
+        <p>Passkeys are a secure way to log in without a password. They are stored on your device and are used to authenticate you when you access Janus credentials or the AWS console.</p>
+        <p>You can register up to two passkeys. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).</p>
+
+        <div class="row">           
+            <h4 class="header orange-text">Registered passkeys</h4>
             <div class="col s12">
                 <div class="card-panel">
-                    <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
-                    </p>
-                    <div><button id="register-passkey" class="btn" csrf-token="@{CSRF.getToken.get.value}">Register a new passkey</button></div>
+                    @if(passkeys.nonEmpty) {
+                        <table class="striped responsive-table">
+                            <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th>Type</th>
+                                    <th>Added</th>
+                                    <th>Last used</th>
+                                    <th>Delete</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for(passkey <- passkeys) {
+                                    <tr>
+                                        <td>@{passkey.name}</td>
+                                        <td>@{passkey.aaguid}</td>
+                                        <td>@{dateFormat(passkey.registrationTime)}</td>
+                                        <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
+                                        <td>
+                                            <button class="btn delete-passkey-btn" 
+                                                    csrf-token="@{CSRF.getToken.get.value}" 
+                                                    data-passkey-id="@{passkey.id}" 
+                                                    data-passkey-name="@{passkey.name}">
+                                                <i class="material-icons">delete</i>
+                                            </button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    } else {                                 
+                        <p>You haven't registered any passkeys yet.</p>
+                    }                    
+                    
+                    @if(passkeys.size < 2) {
+                        <div class="section">
+                            <button id="register-passkey" 
+                                    class="btn" 
+                                    csrf-token="@{CSRF.getToken.get.value}">
+                                Register a new passkey
+                            </button>
+                        </div>
+                    }
                 </div>
             </div>
-        </div>
-
-        <div class="row">
-            @if(passkeys.nonEmpty) {
-                    <h4 class="header orange-text">Your passkeys</h4>
-                    <div class="col s12">
-                        <div class="card-panel">
-                            <table class="striped responsive-table">
-                                <thead>
-                                    <tr>
-                                        <th>Name</th>
-                                        <th>Type</th>
-                                        <th>Added</th>
-                                        <th>Last used</th>
-                                        <th>Delete</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @for(passkey <- passkeys) {
-                                        <tr>
-                                            <td>@{passkey.name}</td>
-                                            <td>@{passkey.aaguid}</td>
-                                            <td>@{dateFormat(passkey.registrationTime)}</td>
-                                            <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
-                                            <td>
-                                                <button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" 
-                                                        data-passkey-id="@{passkey.id}" 
-                                                        data-passkey-name="@{passkey.name}">
-                                                    <i class="material-icons">delete</i>
-                                                </button>
-                                            </td>
-                                        </tr>
-                                    }
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-            } else {
-                <div class="col s12">
-                    <div class="card-panel">
-                        <p>You haven't registered any passkeys yet.</p>
-                    </div>
-                </div>
-            }
         </div>
     </div>
     <div id="passkey-name-modal" class="modal">

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -17,7 +17,7 @@
         <h3 class="header orange-text">Passkeys</h3>
 
         <div class="row">
-            <div class="col s12 m12 l9">
+            <div class="col s12">
                 <div class="card-panel">
                     <p>You can have up to two passkeys to log in to Janus. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).
                     </p>
@@ -28,18 +28,39 @@
 
         <div class="row">
             @if(passkeys.nonEmpty) {
-                @for(passkey <- passkeys) {
-                    <div class="col s12 m12 l6">
+                    <h4 class="header orange-text">Your passkeys</h4>
+                    <div class="col s12">
                         <div class="card-panel">
-                            <p>Passkey: @{passkey.name}</p>
-                            <p>Type: @{passkey.aaguid}</p>
-                            <p>Added: @{dateFormat(passkey.registrationTime)}</p>
-                            <p>Last used: @{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</p>
-                            <p>Type: @{passkey.aaguid}</p>
-                            <div><button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey-id="@{passkey.id}" data-passkey-name="@{passkey.name}">Delete</button></div>
+                            <table class="striped responsive-table">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Type</th>
+                                        <th>Added</th>
+                                        <th>Last used</th>
+                                        <th>Delete</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @for(passkey <- passkeys) {
+                                        <tr>
+                                            <td>@{passkey.name}</td>
+                                            <td>@{passkey.aaguid}</td>
+                                            <td>@{dateFormat(passkey.registrationTime)}</td>
+                                            <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>
+                                            <td>
+                                                <button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" 
+                                                        data-passkey-id="@{passkey.id}" 
+                                                        data-passkey-name="@{passkey.name}">
+                                                    <i class="material-icons">delete</i>
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
                         </div>
                     </div>
-                }
             } else {
                 <div class="col s12">
                     <div class="card-panel">

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -61,7 +61,8 @@
                         <div class="section">
                             <button id="register-passkey" 
                                     class="btn" 
-                                    csrf-token="@{CSRF.getToken.get.value}">
+                                    csrf-token="@{CSRF.getToken.get.value}"
+                                    data-existing-names="@{passkeys.map(_.name).mkString("|")}">
                                 Register a new passkey
                             </button>
                         </div>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -12,13 +12,7 @@
     <div class="container">
         <h1 class="header orange-text">Account</h1>
 
-        <div class="row">
-            <div class="col s12 m12 l3">
-                <div class="card-panel">
-                        <p>You are logged in as @username(user).</p><div><a href="/logout"><button class="btn">Log out</button></a></div>
-                </div>
-            </div>
-        </div>
+        <p>You are logged in as <strong>@username(user)</strong>.</p>
 
         <h3 class="header orange-text">Passkeys</h3>
 


### PR DESCRIPTION
## What is the purpose of this change?

Follows #578 

This pull request introduces validation improvements for passkey names, ensuring consistency across server-side and client-side code. It centralizes validation logic in a shared constants file, enhances duplicate name checking, and improves the user experience by providing real-time validation feedback in the UI.

## What is the value of this change and how do we measure success?


### Validation Enhancements

* **Centralized Validation Constants**: Added `ValidationConstants` in `app/constants/ValidationConstants.scala` to define shared constants for passkey name validation, including a regex pattern and maximum length. These constants are exposed to the client-side via a JavaScript object.
* **Server-Side Validation**: Integrated the centralized constants into `PasskeyController` for server-side validation of passkey names, including format and duplicate checks.
### Client-Side Validation Improvements

* **Dynamic Validation Logic**: Updated `frontend/passkeys.js` to use the shared constants from `window.ValidationConstants` for real-time validation of passkey names. Added functions to check for format compliance and duplicate names, with detailed error messages. 
* **Duplicate Name Handling**: Modified the passkey registration button to include existing passkey names as a data attribute, enabling client-side duplicate name checks before submission.
### UI Enhancements

* **Validation Feedback**: Improved the passkey naming modal to provide immediate feedback on format and duplicate name issues, enhancing the user experience.
* **JavaScript Injection**: Included the validation constants script in the main HTML layout to ensure availability across pages.

## Images
### Error message displayed and saving blocked when user tries to enter same passkey name
![image](https://github.com/user-attachments/assets/481c021a-0e4f-4531-8b9f-1521488e9d57)

## Any additional notes?

