### PR TITLE
feat: Improve passkey registration to prevent duplicate entries

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -41,7 +41,6 @@
                             <p>Type: @{passkey.aaguid}</p>
                             <p>Added: @{dateFormat(passkey.registrationTime)}</p>
                             <p>Last used: @{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</p>
-                            <p>Type: @{passkey.aaguid}</p>
                             <div><button class="btn delete-passkey-btn" csrf-token="@{CSRF.getToken.get.value}" data-passkey-id="@{passkey.id}" data-passkey-name="@{passkey.name}">Delete</button></div>
                         </div>
                     </div>

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -20,14 +20,19 @@ export async function registerPasskey(csrfToken) {
             passkeyName: passkeyName
         });
     } catch (err) {
-        console.error('Error during passkey registration:', err);
-        M.toast({ html: 'Failed to register passkey. Please try again.', classes: 'rounded red' });
+        if (err.name === 'InvalidStateError') {
+            console.warn('Passkey already registered:', err);
+            M.toast({html: 'This passkey has already been registered.', classes: 'rounded orange'});
+        } else {
+            console.error('Error during passkey registration:', err);
+            M.toast({html: 'Failed to register passkey. Please try again.', classes: 'rounded red'});
+        }
     }
 }
 
 export function setUpRegisterPasskeyButton(selector) {
     const registerButton = document.querySelector(selector);
-    if (!registerButton) { return };
+    if (!registerButton) { return }
 
     registerButton?.addEventListener('click', function (e) {
         e.preventDefault();

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -1,13 +1,15 @@
 package logic
 
 import com.gu.googleauth.UserIdentity
+import com.webauthn4j.data.attestation.authenticator.AAGUID
 import com.webauthn4j.data.client.challenge.DefaultChallenge
-import models.PasskeyEncodings
+import models.{PasskeyEncodings, PasskeyMetadata}
 import org.scalatest.EitherValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should
 
 import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
 
 class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
 
@@ -28,7 +30,16 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         appName = "Janus-Test",
         appHost,
         testUser,
-        challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
+        challenge = new DefaultChallenge("challenge".getBytes(UTF_8)),
+        existingPasskeys = Seq(
+          PasskeyMetadata(
+            id = "K9iphQ03JmTBqf-1pPGBXvpzfvt96ZAy51_BrKjibn0",
+            name = "Test",
+            registrationTime = Instant.parse("2025-05-21T09:30:00.000000Z"),
+            aaguid = new AAGUID("adce0002-35bc-c60a-648b-0b25f1f05503"),
+            lastUsedTime = None
+          )
+        )
       )
       val json = PasskeyEncodings.mapper
         .writerWithDefaultPrettyPrinter()
@@ -56,7 +67,11 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         |    "alg" : -257
         |  } ],
         |  "timeout" : 10000,
-        |  "excludeCredentials" : [ ],
+        |  "excludeCredentials" : [ {
+        |    "type" : "public-key",
+        |    "id" : "K9iphQ03JmTBqf-1pPGBXvpzfvt96ZAy51_BrKjibn0",
+        |    "transports" : [ ]
+        |  } ],
         |  "authenticatorSelection" : null,
         |  "hints" : [ ],
         |  "attestation" : "none",


### PR DESCRIPTION
## What is the purpose of this change?
We now send an [excludeCredentials](https://web.dev/articles/webauthn-exclude-credentials) attribute in our pre-registration options call, which contains details of the user's existing passkeys.  If they try to register a passkey of the same type twice they will get an `InvalidStateError`, which we trap with a warning toast.

## What is the value of this change and how do we measure success?
This will ensure that we don't end up with redundant and useless passkeys in the Janus database.  If a passkey of the same type is registered twice, the first one will be overwritten on the authenticator and therefore its record in the Janus database will be useless.  By intercepting the registration on the browser we avoid a new passkey of the same type being generated at all.
