### PR TITLE
fix (passkeys): Add custom encoding for PublicKeyCredentialUserEntity

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -20,7 +20,6 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, ZoneId, ZonedDateTime}
 import scala.concurrent.ExecutionContext
-import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 /** Controller for handling passkey registration and authentication. */

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -17,9 +17,9 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
 
       val testUser = UserIdentity(
         sub = "sub",
-        email = "test.user@example.com",
-        firstName = "Test",
-        lastName = "User",
+        email = "a.solver@example.com",
+        firstName = "A",
+        lastName = "Solver",
         exp = 0,
         avatarUrl = None
       )
@@ -40,9 +40,9 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         |    "name" : "Janus-Test"
         |  },
         |  "user" : {
-        |    "id" : "dGVzdC51c2Vy",
-        |    "name" : "test.user",
-        |    "displayName" : "Test User"
+        |    "id" : "YS5zb2x2ZXI",
+        |    "name" : "a.solver",
+        |    "displayName" : "A Solver"
         |  },
         |  "challenge" : "Y2hhbGxlbmdl",
         |  "pubKeyCredParams" : [ {


### PR DESCRIPTION
## What is the purpose of this change?
This change ensures that the user ID is base64url encoded when it's presented to [PublicKeyCredential.parseCreationOptionsFromJSON](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static) in the browser.

## What is the value of this change and how do we measure success?
Without this change, certain users whose names are encoded in a way that doesn't produce a base64url encoded string will be rejected in some browsers, at least Chrome.
We see error:
> Error during passkey registration: Error during passkey registration: EncodingError: Failed to execute 'parseCreationOptionsFromJSON' on 'PublicKeyCredential': 'user.id' contains invalid base64url data
