### PR TITLE
fix: Update janusProfileName for local testing

### DIFF
--- a/app/aws/Clients.scala
+++ b/app/aws/Clients.scala
@@ -13,7 +13,7 @@ object Clients {
   /** This profile is specifically to give access to the assumeRole permission
     * in the Dev stage
     */
-  private val janusProfileName = "developerPlayground"
+  private val janusProfileName = "janus"
 
   /** In the Dev stage, the security profile is used to access the Play secret
     * stored in parameter store


### PR DESCRIPTION
This is associated with reverting to the use of a permanent IAM user's credentials for local testing, introduced in guardian/janus#4809.