### PR TITLE
feat: enhance passkey name validation to prevent duplicates

### DIFF
--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -279,5 +279,5 @@ object PasskeyDB {
 
     val response = dynamoDB.query(request)
     response.hasItems && !response.items().isEmpty
-  }.adaptError(err => JanusException.failedToDeleteDbItem(user, tableName, err))
+  }.adaptError(err => JanusException.failedToLoadDbItem(user, tableName, err))
 }

--- a/app/controllers/Validation.scala
+++ b/app/controllers/Validation.scala
@@ -1,0 +1,19 @@
+package controllers
+
+import play.api.data.Form
+
+private[controllers] object Validation {
+
+  def formattedErrors[A](formWithErrors: Form[A]): String =
+    formWithErrors.errors
+      .map { error =>
+        val message = error.message match {
+          case "error.required"  => "missing value"
+          case "error.maxLength" => "too long"
+          case "error.pattern"   => "contains invalid characters"
+          case other             => other
+        }
+        s"${error.key}: $message"
+      }
+      .mkString(", ")
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -64,6 +64,17 @@ object JanusException {
     causedBy = Some(cause)
   )
 
+  def duplicatePasskeyNameFieldInRequest(
+      user: UserIdentity,
+      passkeyName: String
+  ): JanusException = JanusException(
+    userMessage = "passkeyName: already exists",
+    engineerMessage =
+      s"Passkey name '$passkeyName' already exists for user ${user.username}",
+    httpCode = BAD_REQUEST,
+    causedBy = None
+  )
+
   def failedToLoadDbItem(
       user: UserIdentity,
       tableName: String,


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

This pull request enhances the passkey management functionality by introducing duplicate name validation for passkeys and improving the structure of the HTML table to facilitate this validation. The most important changes include adding a data attribute to the passkey name table cells, implementing logic to fetch existing passkey names, and validating against duplicates during user input.


## What is the value of this change and how do we measure success?

### Enhancements to passkey management:

* [`app/views/userAccount.scala.html`](diffhunk://#diff-374d8384fc5549c89757384e7a301bd56c2701178a0ecda3457140b0b40cd9b0L40-R40): Added `data-passkey-name="true"` attribute to passkey name table cells to enable easier identification of passkey names in the DOM.

* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8R234-R249): Added logic to fetch existing passkey names from the HTML table and store them in a case-insensitive list for validation. This includes handling potential errors during DOM parsing.

### Validation improvements:

* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8R269-R277): Updated the passkey name validation logic to check for duplicate names (case-insensitive) and display an appropriate error message if a duplicate is detected.

* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8L266-R302): Refined the validation flow to ensure error messages are displayed consistently for invalid input, including duplicate names, excessive length, and disallowed characters.