### PR TITLE
feat: use DELETE method instead of POST for passkey deletion

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -6,14 +6,13 @@ import com.gu.googleauth.AuthAction
 import com.gu.googleauth.AuthAction.UserIdentityRequest
 import com.gu.janus.model.JanusData
 import com.webauthn4j.data.client.challenge.DefaultChallenge
-import com.webauthn4j.util.Base64UrlUtil
 import logic.AccountOrdering.orderedAccountAccess
 import logic.UserAccess.{userAccess, username}
 import logic.{Date, Favourites, Passkey}
 import models.JanusException.throwableWrites
 import models.{JanusException, PasskeyEncodings}
 import play.api.http.MimeTypes
-import play.api.libs.json.{Json, JsObject}
+import play.api.libs.json.{Json}
 import play.api.libs.json.Json.toJson
 import play.api.mvc._
 import play.api.{Logging, Mode}

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -156,17 +156,7 @@ class PasskeyController(
             .find(_.id == passkeyId)
             .map(_.name)
             .toRight(
-              JanusException(
-                userMessage = "Passkey not found",
-                engineerMessage =
-                  s"Passkey with ID $passkeyId not found for user ${request.user.username}",
-                httpCode = NOT_FOUND,
-                causedBy = Some(
-                  new NoSuchElementException(
-                    s"Passkey ID $passkeyId does not exist in user's passkey collection"
-                  )
-                )
-              )
+              JanusException.missingItemInDb(request.user, "Passkeys")
             )
             .toTry
           _ <- PasskeyDB.deleteById(request.user, passkeyId)

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -146,8 +146,8 @@ class PasskeyController(
   }
 
   /** Deletes a passkey from the user's account */
-  def deletePasskey(passkeyId: String): Action[AnyContent] = authAction {
-    implicit request =>
+  def deletePasskey(passkeyId: String): Action[Unit] = authAction(parse.empty) {
+    implicit request: UserIdentityRequest[Unit] =>
       apiResponse(
         for {
           // Look up the passkey before deleting to include the name in the success message

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -37,7 +37,7 @@
                             <tbody>
                                 @for(passkey <- passkeys) {
                                     <tr>
-                                        <td data-passkey-name="true">@{passkey.name}</td>
+                                        <td>@{passkey.name}</td>
                                         <td>@{passkey.aaguid}</td>
                                         <td>@{dateFormat(passkey.registrationTime)}</td>
                                         <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -37,7 +37,7 @@
                             <tbody>
                                 @for(passkey <- passkeys) {
                                     <tr>
-                                        <td>@{passkey.name}</td>
+                                        <td data-passkey-name="true">@{passkey.name}</td>
                                         <td>@{passkey.aaguid}</td>
                                         <td>@{dateFormat(passkey.registrationTime)}</td>
                                         <td>@{passkey.lastUsedTime.map(timeFormat).getOrElse("Never")}</td>

--- a/conf/routes
+++ b/conf/routes
@@ -30,7 +30,7 @@ GET     /logout                     controllers.AuthController.logout
 GET     /passkey/registration-options   controllers.PasskeyController.registrationOptions
 GET     /passkey/auth-options           controllers.PasskeyController.authenticationOptions
 POST    /passkey/register               controllers.PasskeyController.register
-POST    /passkey/delete                 controllers.PasskeyController.deletePasskey
+DELETE  /passkey/delete/:passkeyId      controllers.PasskeyController.deletePasskey(passkeyId: String)
 
 # Temporary endpoints for testing passkey auth
 POST    /passkey/protected-credentials-page controllers.PasskeyController.protectedCredentialsPage

--- a/conf/routes
+++ b/conf/routes
@@ -30,7 +30,7 @@ GET     /logout                     controllers.AuthController.logout
 GET     /passkey/registration-options   controllers.PasskeyController.registrationOptions
 GET     /passkey/auth-options           controllers.PasskeyController.authenticationOptions
 POST    /passkey/register               controllers.PasskeyController.register
-DELETE  /passkey/delete/:passkeyId      controllers.PasskeyController.deletePasskey(passkeyId: String)
+DELETE  /passkey/:passkeyId      controllers.PasskeyController.deletePasskey(passkeyId: String)
 
 # Temporary endpoints for testing passkey auth
 POST    /passkey/protected-credentials-page controllers.PasskeyController.protectedCredentialsPage

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -94,7 +94,7 @@ export async function bypassPasskeyAuthentication(targetHref, csrfToken) {
  * Deletes a passkey from the user's account
  * @param {string} passkeyId - ID of the passkey to delete
  * @param {string} csrfToken - CSRF token for security verification
- * @returns {Promise<Response>} The fetch response
+ * @returns {Promise<Object>} A promise that resolves with the JSON response data
  */
 export async function deletePasskey(passkeyId, csrfToken) {
     try {

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -167,7 +167,7 @@ export function setUpDeletePasskeyButtons(selector) {
                     } else {
                         window.location.reload();
                     }
-                } catch (error) {
+                } catch {
                     // Error is already handled in deletePasskey function
                 }
             } else {
@@ -322,7 +322,7 @@ function getPasskeyNameFromUser() {
                     errorMessage.textContent = 'Cannot save passkey name: only letters, numbers, spaces, underscores and hyphens are allowed';
                    
                 }
-                 return;
+                return;
             }
 
             // Close modal and resolve with the passkey name

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -102,7 +102,6 @@ export async function deletePasskey(passkeyId, csrfToken) {
             method: 'DELETE',
             headers: {
                 'Csrf-Token': csrfToken, 
-                'Content-Type': 'application/json'
             },
             credentials: 'same-origin'
         });

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -94,16 +94,39 @@ export async function bypassPasskeyAuthentication(targetHref, csrfToken) {
  * Deletes a passkey from the user's account
  * @param {string} passkeyId - ID of the passkey to delete
  * @param {string} csrfToken - CSRF token for security verification
+ * @returns {Promise<Response>} The fetch response
  */
-export function deletePasskey(passkeyId, csrfToken) {
-    try {   
-        createAndSubmitForm('/passkey/delete', {
-            passkeyId,
-            csrfToken
-        }); 
+export async function deletePasskey(passkeyId, csrfToken) {
+    try {
+        const response = await fetch(`/passkey/delete/${passkeyId}`, {
+            method: 'DELETE',
+            headers: {
+                'Csrf-Token': csrfToken, 
+                'Content-Type': 'application/json'
+            },
+            credentials: 'same-origin'
+        });
+        
+        if (!response.ok) {
+            let errorMessage = `Server returned ${response.status}`;
+            try {
+                const errorData = await response.json();
+                if (errorData && errorData.message) {
+                    errorMessage = errorData.message;
+                }
+            } catch (e) {
+                console.warn('Could not parse error response as JSON:', e);
+            }
+            throw new Error(errorMessage);
+        }
+        
+        const responseData = await response.json();
+        
+        return responseData;
     } catch (error) {
         console.error('Error deleting passkey:', error);
-        M.toast({ html: 'An error occurred while deleting the passkey', classes: 'rounded red' });
+        M.toast({ html: `Error deleting passkey: ${error.message}`, classes: 'rounded red' });
+        throw error;
     }
 }   
 
@@ -136,7 +159,18 @@ export function setUpDeletePasskeyButtons(selector) {
             }
             
             if (confirm(`Are you sure you want to delete the passkey "${passkeyName}"?`)) {
-                deletePasskey(passkeyId, csrfToken);
+                try {
+                    const result = await deletePasskey(passkeyId, csrfToken);
+                    // Immediately redirect to the user-account page
+                    // The flash message will be displayed after the redirect
+                    if (result.redirect) {
+                        window.location.href = result.redirect;
+                    } else {
+                        window.location.reload();
+                    }
+                } catch (error) {
+                    // Error is already handled in deletePasskey function
+                }
             } else {
                 M.toast({ html: 'Passkey deletion cancelled', classes: 'rounded orange' });
             }

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -280,22 +280,6 @@ function getPasskeyNameFromUser() {
         const alphanumericRegex = /^[a-zA-Z0-9 _-]*$/;
         const maxLength = 50; // Maximum character limit
 
-        // Get existing passkey names
-        let existingPasskeyNames = [];
-        try {
-            const passkeysTable = document.querySelector('.card-panel table');
-            if (passkeysTable) {
-                const nameElements = passkeysTable.querySelectorAll('td[data-passkey-name="true"]');
-                nameElements.forEach(nameCell => {
-                    if (nameCell && nameCell.textContent) {
-                        existingPasskeyNames.push(nameCell.textContent.trim().toLowerCase());
-                    }
-                });
-            }
-        } catch (err) {
-            console.error('Error fetching existing passkey names:', err);
-        }
-
         // Reset the input field and error message when opening the modal
         input.value = '';
         input.classList.remove('invalid');
@@ -315,15 +299,8 @@ function getPasskeyNameFromUser() {
                 errorMessage.style.display = 'block';
                 errorMessage.textContent = `Name is too long: ${input_value.length}/${maxLength} characters`;
             } else if (input_value.trim() && alphanumericRegex.test(input_value)) {
-                // Check for duplicate names (case-insensitive)
-                if (existingPasskeyNames.includes(input_value.trim().toLowerCase())) {
-                    input.classList.add('invalid');
-                    errorMessage.style.display = 'block';
-                    errorMessage.textContent = `A passkey with the name "${input_value.trim()}" already exists. Please use a different name.`;
-                } else {
-                    input.classList.remove('invalid');
-                    errorMessage.style.display = 'none';
-                }
+                input.classList.remove('invalid');
+                errorMessage.style.display = 'none';
             } else {
                 input.classList.add('invalid');
                 errorMessage.style.display = 'block';
@@ -335,21 +312,17 @@ function getPasskeyNameFromUser() {
             e.preventDefault();
             const passkeyName = input.value.trim();
 
-            if (!passkeyName || !alphanumericRegex.test(passkeyName)) {
+            if (!passkeyName || !alphanumericRegex.test(passkeyName) || passkeyName.length > maxLength) {
+                // Show validation error
                 input.classList.add('invalid');
                 errorMessage.style.display = 'block';
-                errorMessage.textContent = 'Cannot save passkey name: only letters, numbers, spaces, underscores and hyphens are allowed';
-                return;
-            } else if (passkeyName.length > maxLength) {
-                input.classList.add('invalid');
-                errorMessage.style.display = 'block';
-                errorMessage.textContent = `Passkey name too long: maximum ${maxLength} characters allowed`;
-                return;
-            } else if (existingPasskeyNames.includes(passkeyName.toLowerCase())) {
-                input.classList.add('invalid');
-                errorMessage.style.display = 'block';
-                errorMessage.textContent = `A passkey with the name "${passkeyName}" already exists. Please use a different name.`;
-                return;
+                if (passkeyName.length > maxLength) {
+                    errorMessage.textContent = `Passkey name too long: maximum ${maxLength} characters allowed`;
+                } else {
+                    errorMessage.textContent = 'Cannot save passkey name: only letters, numbers, spaces, underscores and hyphens are allowed';
+                   
+                }
+                 return;
             }
 
             // Close modal and resolve with the passkey name

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -98,7 +98,7 @@ export async function bypassPasskeyAuthentication(targetHref, csrfToken) {
  */
 export async function deletePasskey(passkeyId, csrfToken) {
     try {
-        const response = await fetch(`/passkey/delete/${passkeyId}`, {
+        const response = await fetch(`/passkey/${passkeyId}`, {
             method: 'DELETE',
             headers: {
                 'Csrf-Token': csrfToken, 


### PR DESCRIPTION
## What is the purpose of this change?

Follows: #588 

This pull request introduces several updates to the passkey deletion functionality, including improvements to the backend API, frontend integration, and routing. The changes enhance user experience by providing better error handling, JSON responses, and immediate redirection upon successful deletion.

### Backend API updates:
* [`app/controllers/PasskeyController.scala`](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fL146-R182): Refactored the `deletePasskey` method to accept a `passkeyId` as a parameter, retrieve passkey metadata for better success messages, and return a JSON response with success, message, and redirection details.

### Routing updates:
* [`conf/routes`](diffhunk://#diff-3668dd1c5d74e6d728b59d45112f57372248fbbcde03767f2fe38499aceef443L33-R33): Changed the HTTP method for the passkey deletion endpoint from `POST` to `DELETE` and updated the route to include a `passkeyId` parameter.

### Frontend integration updates:
* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8R87-R119): Updated the `deletePasskey` function to use `fetch` with the `DELETE` method, handle server responses, and provide detailed error messages.
* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8L129-R163): Modified the `setUpDeletePasskeyButtons` function to handle the new JSON response, enabling immediate redirection or page reload upon successful deletion.

### Dependency updates:
* [`app/controllers/PasskeyController.scala`](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fR9-R16): Added imports for `Base64UrlUtil` and `JsObject` to support new functionality.

## What is the value of this change and how do we measure success?

Better alignment with modern RESTful practices.