### PR TITLE
feat: Enable bypassing of passkey authentication for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ crashlytics-build.properties
 .metals/
 .vscode/
 .bloop/
+/project/metals.sbt

--- a/app/views/passkeymock/awsAccounts.scala.html
+++ b/app/views/passkeymock/awsAccounts.scala.html
@@ -41,17 +41,26 @@
                         <div class="card-action-group__row row">
                             <div class="card-action-group col m6 s12">
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-redirect?"
-                                    class="@if(passkeysEnabled) {passkey-protected }waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(permission.shortTerm) {short} else {standard} card-action-link--spaced">
+                                    class="waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(permission.shortTerm) {short} else {standard} card-action-link--spaced"
+                                    data-passkey-protected = "true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                >
                                     <i class="material-icons">cloud</i>
                                 </a>
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-credentials-page?"
-                                    class="@if(passkeysEnabled) {passkey-protected }right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(permission.shortTerm) {short} else {standard}">
+                                    class="right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(permission.shortTerm) {short} else {standard}"
+                                    data-passkey-protected = "true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                >
                                     <i class="material-icons black-text">link</i>
                                 </a>
                             </div>
                             <div class="card-action-group card-action-group--divider col m6 s12">
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-credentials-page?"
-                                    class="@if(passkeysEnabled) {passkey-protected }waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(permission.shortTerm) {short} else {standard}">
+                                    class="waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(permission.shortTerm) {short} else {standard}"
+                                    data-passkey-protected = "true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                >
                                     <i class="material-icons">vpn_key</i>
                                 </a>
                                 @if(!permission.shortTerm) {

--- a/app/views/passkeymock/awsAccounts.scala.html
+++ b/app/views/passkeymock/awsAccounts.scala.html
@@ -42,15 +42,15 @@
                             <div class="card-action-group col m6 s12">
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-redirect?"
                                     class="waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(permission.shortTerm) {short} else {standard} card-action-link--spaced"
-                                    data-passkey-protected = "true"
-                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                    data-passkey-protected="true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed="true"}
                                 >
                                     <i class="material-icons">cloud</i>
                                 </a>
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-credentials-page?"
                                     class="right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(permission.shortTerm) {short} else {standard}"
-                                    data-passkey-protected = "true"
-                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                    data-passkey-protected="true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed="true"}
                                 >
                                     <i class="material-icons black-text">link</i>
                                 </a>
@@ -58,8 +58,8 @@
                             <div class="card-action-group card-action-group--divider col m6 s12">
                                 <a csrf-token="@{CSRF.getToken.get.value}" href="/passkey/protected-credentials-page?"
                                     class="waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(permission.shortTerm) {short} else {standard}"
-                                    data-passkey-protected = "true"
-                                    @if(!passkeysEnabled) {data-passkey-bypassed = "true"}
+                                    data-passkey-protected="true"
+                                    @if(!passkeysEnabled) {data-passkey-bypassed="true"}
                                 >
                                     <i class="material-icons">vpn_key</i>
                                 </a>

--- a/frontend/janus.js
+++ b/frontend/janus.js
@@ -296,8 +296,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     setUpRegisterPasskeyButton('#register-passkey');
     setUpDeletePasskeyButtons('.delete-passkey-btn');
-    // setupAuthButtons('.auth-button');
-    const protectedLinks = document.querySelectorAll('.passkey-protected');
+    const protectedLinks = document.querySelectorAll('[data-passkey-protected]');
     setUpProtectedLinks(protectedLinks);
     
     const flashMessage = document.getElementById('flash-message');

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -80,6 +80,16 @@ export async function authenticatePasskey(targetHref, csrfToken) {
     }
 }
 
+export async function bypassPasskeyAuthentication(targetHref, csrfToken) {
+    try {
+        createAndSubmitForm(targetHref, {
+            csrfToken: csrfToken
+        });
+    } catch (err) {
+        console.error('Error during bypass of passkey authentication:', err);
+    }
+}
+
 /**
  * Deletes a passkey from the user's account
  * @param {string} passkeyId - ID of the passkey to delete
@@ -170,9 +180,15 @@ export function setUpProtectedLinks(links) {
             e.preventDefault();
             const csrfToken = link.getAttribute('csrf-token');
             const targetHref = link.href;
-            authenticatePasskey(targetHref, csrfToken).catch(function (err) {
-                console.error('Error setting up protected link:', err);
-            });
+            if (link.dataset.passkeyBypassed) {
+                bypassPasskeyAuthentication(targetHref, csrfToken).catch(function (err) {
+                    console.error('Error setting up bypass of protected link:', err);
+                });
+            } else {
+                authenticatePasskey(targetHref, csrfToken).catch(function (err) {
+                    console.error('Error setting up protected link:', err);
+                });
+            }
         });
     });
 }


### PR DESCRIPTION
## What is the purpose of this change?
This change makes the bypass of passkeys consistent with the use of passkeys so that protected links are now POSTs instead of GETs in both cases.

## What is the value of this change and how do we measure success?
This fixes an error introduced in #585 where, if passkeys were being bypassed, the link would do a GET but there was no corresponding GET route available on the server.

## Any additional notes?
We can now do the same thing with the live links so that they can be tested with and without passkey authentication.
