### PR TITLE
fix(passkeys): Use correct method for options calls

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -27,8 +27,8 @@ GET     /loginError                 controllers.AuthController.loginError
 GET     /oauthCallback              controllers.AuthController.oauthCallback
 GET     /logout                     controllers.AuthController.logout
 
-GET     /passkey/registration-options   controllers.PasskeyController.registrationOptions
-GET     /passkey/auth-options           controllers.PasskeyController.authenticationOptions
+POST    /passkey/registration-options   controllers.PasskeyController.registrationOptions
+POST    /passkey/auth-options           controllers.PasskeyController.authenticationOptions
 POST    /passkey/register               controllers.PasskeyController.register
 POST    /passkey/delete                 controllers.PasskeyController.deletePasskey
 

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -9,9 +9,10 @@ import M from 'materialize-css';
 export async function registerPasskey(csrfToken) {
     try {
         const regOptionsResponse = await fetch('/passkey/registration-options', {
-            method: 'GET',
+            method: 'POST',
             headers: {
-                'X-CSRF-Token': csrfToken // Securely include CSRF token in headers
+                'CSRF-Token': csrfToken, // Securely include CSRF token in headers
+                'Content-Type': 'application/x-www-form-urlencoded', // To satisfy Play CSRF filter
             }
         });
         const regOptionsResponseJson = await regOptionsResponse.json();
@@ -61,9 +62,10 @@ export function setUpRegisterPasskeyButton(selector) {
 export async function authenticatePasskey(targetHref, csrfToken) {
     try {
         const authOptionsResponse = await fetch('/passkey/auth-options', {
-            method: 'GET',
+            method: 'POST',
             headers: {
-                'X-CSRF-Token': csrfToken // Securely include CSRF token in headers
+                'CSRF-Token': csrfToken, // Securely include CSRF token in headers,
+                'Content-Type': 'application/x-www-form-urlencoded', // To satisfy Play CSRF filter
             }
         });
         const authOptionsResponseJson = await authOptionsResponse.json();


### PR DESCRIPTION
## What is the purpose of this change?
It changes the HTTP method of the pre-registration and pre-authentication passkey options requests to use a POST instead of a GET.

## What is the value of this change and how do we measure success?
These calls write challenges to the database and have unique content per call so they shouldn't be GETs.
A GET call is meant to be idempotent and cacheable, which these are not.
