### PR TITLE
feat(passkeys): Restrict authentication options to registered credentials

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -132,7 +132,13 @@ class PasskeyController(
   def authenticationOptions: Action[Unit] = authAction(parse.empty) { request =>
     apiResponse(
       for {
-        options <- Passkey.authenticationOptions(host, request.user)
+        loadCredentialsResponse <- PasskeyDB.loadCredentials(request.user)
+        options <- Passkey.authenticationOptions(
+          appHost = host,
+          user = request.user,
+          challenge = new DefaultChallenge(),
+          existingPasskeys = PasskeyDB.extractMetadata(loadCredentialsResponse)
+        )
         _ <- PasskeyChallengeDB.insert(
           UserChallenge(request.user, options.getChallenge)
         )

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -133,4 +133,14 @@ object JanusException {
       httpCode = UNAUTHORIZED,
       causedBy = Some(cause)
     )
+
+  def noPasskeysRegistered(user: UserIdentity): JanusException =
+    JanusException(
+      userMessage =
+        "No passkeys registered. Please register a passkey before attempting to authenticate.",
+      engineerMessage =
+        s"User ${user.username} attempted to authenticate but has no registered passkeys",
+      httpCode = BAD_REQUEST,
+      causedBy = None
+    )
 }

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -66,6 +66,23 @@ export async function authenticatePasskey(targetHref, csrfToken) {
                 'X-CSRF-Token': csrfToken // Securely include CSRF token in headers
             }
         });
+        
+        if (authOptionsResponse.status !== 200) {
+            console.error('Authentication options request failed:', authOptionsResponse.body);
+            if (authOptionsResponse.status === 400) {
+                M.toast({
+                    html: 'Please register a passkey before attempting to authenticate.',
+                    classes: 'rounded red'
+                });
+            } else {
+                M.toast({
+                    html: 'Failed to get authentication options from server. Please try again.',
+                    classes: 'rounded red'
+                });
+            }
+            return;
+        }
+
         const authOptionsResponseJson = await authOptionsResponse.json();
         const credentialGetOptions = PublicKeyCredential.parseRequestOptionsFromJSON(authOptionsResponseJson);
         const publicKeyCredential = await navigator.credentials.get({ publicKey: credentialGetOptions });


### PR DESCRIPTION
## What is the purpose of this change?
Currently if a user hasn't registered a passkey they can still go through the authentication flow even though it is bound to fail.  This change gives a 400 response to the pre-authentication options call and then responds to that in a user-friendly way in the browser.

## What is the value of this change and how do we measure success?
Avoids unnecessary confusion.
