### PR TITLE
fix: Exclude htmlunit dependency to resolve security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,11 @@ lazy val root: Project = (project in file("."))
       ++ jacksonOverrides
       ++ pekkoSerializationJacksonOverrides,
     dependencyOverrides += "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2", // Avoid binary incompatibility error.
+    // See https://github.com/guardian/janus-app/security/dependabot/19
+    excludeDependencies += ExclusionRule(
+      organization = "net.sourceforge.htmlunit",
+      name = "htmlunit"
+    ),
 
     // local development
     playDefaultPort := 9100,


### PR DESCRIPTION
## What is the purpose of this change?
Excludes a transitive test dependency that we don't currently use.

## What is the value of this change and how do we measure success?
Resolves a critical vulnerability alert: https://github.com/guardian/janus-app/security/dependabot/19
