### PR TITLE
fix: Update CSP to allow inline data images

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -55,7 +55,7 @@ play {
 
   filters {
     hosts.allowed = [ "." ]  # allow all hosts because we're behind an ELB with a dynamic hostname
-    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'"
+    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
   }
 
   # Trust all proxies (the internet can't reach us directly so this is safe)


### PR DESCRIPTION
We show inline Base64 PNG images against passkeys.  This change updates the CSP to allow these to be shown.