### PR TITLE
chore: Cross-compile the config-tools project

### DIFF
--- a/.github/workflows/trigger-private-janus-build.yml
+++ b/.github/workflows/trigger-private-janus-build.yml
@@ -41,7 +41,13 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      - run: sbt clean compile scalafmtCheckAll scalafmtSbtCheck test
+      - run: >
+          sbt 
+          +compile 
+          +Test/compile 
+          scalafmtCheckAll 
+          scalafmtSbtCheck 
+          +test
 
       - name: Test Report for Janus-App
         uses: dorny/test-reporter@890a17cecf52a379fc869ab770a71657660be727 # v2.1.0


### PR DESCRIPTION
## What is the purpose of this change?
Compile config-tools to Scala 2.13 and in Scala 3.

## What is the value of this change and how do we measure success?
Now that we are publishing two versions of the config-tools library, we need to make sure that the project is always able to compile to both.