### PR TITLE
feat(passkeys): Discourage discoverable passkeys

### DIFF
--- a/app/logic/Passkey.scala
+++ b/app/logic/Passkey.scala
@@ -108,7 +108,7 @@ object Passkey {
       val excludeCredentials = existingPasskeys.map(toDescriptor)
       val authenticatorSelection = new AuthenticatorSelectionCriteria(
         AuthenticatorAttachment.PLATFORM, // Prefer platform authenticators (TouchID, FaceID, Windows Hello)
-        ResidentKeyRequirement.PREFERRED, // Store credentials on the authenticator when possible
+        ResidentKeyRequirement.DISCOURAGED, // Don't allow passkeys unknown to the server to be discovered at authentication time
         UserVerificationRequirement.REQUIRED // Always require user verification
       )
       val hints: Seq[PublicKeyCredentialHints] = Nil

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -76,7 +76,7 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
         |  "authenticatorSelection" : {
         |    "authenticatorAttachment" : "platform",
         |    "requireResidentKey" : false,
-        |    "residentKey" : "preferred",
+        |    "residentKey" : "discouraged",
         |    "userVerification" : "required"
         |  },
         |  "hints" : [ ],


### PR DESCRIPTION
## What is the purpose of this change?
This pull request updates the `Passkey` config in `app/logic/Passkey.scala` to modify the handling of resident (discoverable) keys during authentication.  It now 'discourages' resident keys.

## What is the value of this change and how do we measure success?
Passkeys can't be discovered at authentication time unless they're referenced in the pre-authentication options call, which keeps the choice of passkeys under the control of the Janus server.

## Any additional notes?
See https://www.corbado.com/glossary/resident-key#resident-key-vs-non-resident-keys-whats-the-difference
Resident keys are designed to make the flow smoother when the user is unknown.
In our case, there's always an identifiable signed-in user and we know their credential IDs so we don't need to be able to 'discover' passkeys.