### PR TITLE
chore: Update deprecated Play config (Attempt 2)

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -13,6 +13,7 @@ import play.api.mvc.{ActionBuilder, AnyContent, EssentialFilter}
 import play.api.routing.Router
 import play.api.{ApplicationLoader, BuiltInComponentsFromContext, Logging, Mode}
 import play.filters.HttpFiltersComponents
+import play.filters.csp.CSPComponents
 import router.Routes
 import software.amazon.awssdk.regions.Region.EU_WEST_1
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -24,11 +25,12 @@ class AppComponents(context: ApplicationLoader.Context)
     with AhcWSComponents
     with AssetsComponents
     with HttpFiltersComponents
+    with CSPComponents
     with RotatingSecretComponents
     with Logging {
 
   override def httpFilters: Seq[EssentialFilter] =
-    super.httpFilters :+ new HstsFilter
+    super.httpFilters :+ cspFilter :+ new HstsFilter
 
   // used by the template to detect development environment
   // in that situation, it'll load assets directly from npm vs production, where they'll come from the bundled files

--- a/app/views/accounts.scala.html
+++ b/app/views/accounts.scala.html
@@ -7,7 +7,7 @@
 @import scala.util.Failure
 @import scala.util.Success
 @import logic.ViewHelpers
-@(accountOwners: List[(AwsAccount, List[(String, Set[Permission])], Try[String])], user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(accountOwners: List[(AwsAccount, List[(String, Set[Permission])], Try[String])], user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Accounts", Some(user), janusData) {
     <div class="container" xmlns="http://www.w3.org/1999/html">

--- a/app/views/consoleUrl.scala.html
+++ b/app/views/consoleUrl.scala.html
@@ -3,7 +3,7 @@
 @import com.gu.janus.model.JanusData
 @import play.api.Mode
 
-@(url: String, accountName: String, credentials: Credentials, user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(url: String, accountName: String, credentials: Credentials, user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @import logic.Date
 

--- a/app/views/credentials.scala.html
+++ b/app/views/credentials.scala.html
@@ -4,7 +4,7 @@
 @import java.time.Instant
 @import play.api.Mode
 
-@(expiry: Instant, accountsCredentials: List[(AwsAccount, Credentials)], user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(expiry: Instant, accountsCredentials: List[(AwsAccount, Credentials)], user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @import logic.Date
 

--- a/app/views/error.scala.html
+++ b/app/views/error.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.JanusData
 @import play.api.Mode
 
-@(error: String, user: Option[UserIdentity], janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(error: String, user: Option[UserIdentity], janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Home", user, janusData) {
     <div class="container">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,8 +4,9 @@
 @import logic.Customisation.displayColour
 @import play.api.Mode
 @import java.time.Instant
+@import views.html.helper.CSPNonce
 
-@(title: String, userOpt: Option[UserIdentity], janusData: JanusData, displayMode: DisplayMode = Normal)(content: Html)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(title: String, userOpt: Option[UserIdentity], janusData: JanusData, displayMode: DisplayMode = Normal)(content: Html)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -83,16 +84,16 @@
         </footer>
 
         @if(mode == Mode.Dev) {
-            <script src="https://janus-frontend.local.dev-gutools.co.uk/janus.js"></script>
+            <script src="https://janus-frontend.local.dev-gutools.co.uk/janus.js" @{CSPNonce.attr}></script>
         } else {
-            <script src="@assetsFinder.path("frontend/janus.js")"></script>
+            <script src="@assetsFinder.path("frontend/janus.js")" @{CSPNonce.attr}></script>
         }
 
         @if(displayMode == Festive) {
             @if(mode == Mode.Dev) {
-                <script src="https://janus-frontend.local.dev-gutools.co.uk/snow.js"></script>
+                <script src="https://janus-frontend.local.dev-gutools.co.uk/snow.js" @{CSPNonce.attr}></script>
             } else {
-                <script src="@assetsFinder.path("frontend/snow.js")"></script>
+                <script src="@assetsFinder.path("frontend/snow.js")" @{CSPNonce.attr}></script>
             }
         }
 

--- a/app/views/noPermissions.scala.html
+++ b/app/views/noPermissions.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.JanusData
 @import play.api.Mode
 
-@(user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Home", Some(user), janusData) {
     <div class="container">

--- a/app/views/permissionDenied.scala.html
+++ b/app/views/permissionDenied.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.JanusData
 @import play.api.Mode
 
-@(user: UserIdentity, janusData: JanusData)(implicit mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Home", Some(user), janusData) {
     <div class="container">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,7 +3,7 @@
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.i18n.langs=["en"]
 
 play.application.loader = AppLoader
 
@@ -55,7 +55,14 @@ play {
 
   filters {
     hosts.allowed = [ "." ]  # allow all hosts because we're behind an ELB with a dynamic hostname
-    headers.contentSecurityPolicy="default-src 'self'; font-src 'self' data:; style-src 'self' 'unsafe-inline'"
+    csp {
+      directives {
+        base-uri="'self'"
+        default-src="'self'"
+        font-src="'self' data:"
+        style-src="'self' 'unsafe-inline'"
+      }
+    }
   }
 
   # Trust all proxies (the internet can't reach us directly so this is safe)


### PR DESCRIPTION
## What is the purpose of this change?
This is another attempt at #603 - to update config to improve content security policy (CSP) and resolve deprecated config warnings.
On that occasion it gave us error:

> Refused to load the script ... because it violates the following Content Security Policy directive: "script-src 'nonce-...' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"

The difference in this PR is that nonce attributes have been added to HTML script elements to enable scripts to be loaded in browser with reduced risk of XSS injection, following the [Play CSP filter documentation](https://www.playframework.com/documentation/3.0.x/CspFilter#Using-CSP-in-Page-Templates).

## What is the value of this change and how do we measure success?
Will stop broken functionality in future upgrades of Play.

This should be a no-op change.

## Any additional notes?
Reproduced problem seen in Production by selectively applying same CSP locally.
