### PR TITLE
fix: Ensure wallclock option is removed only if it exists

### DIFF
--- a/frontend/janus.js
+++ b/frontend/janus.js
@@ -256,8 +256,10 @@ document.addEventListener('DOMContentLoaded', function() {
         // remove wallclock option if we're too far from 19:00
         if (msToEndOfWork > maxLongDuration) {
             const walltimeSelector = document.querySelector(".dropdown-time__link--walltime[data-length=standard]");
-            walltimeSelector.closest(".login-duration__header").querySelector(".dropdown-trigger").textContent = defaultLongDurationLink.textContent;
-            walltimeSelector.remove();
+            if (walltimeSelector) {
+                walltimeSelector.closest(".login-duration__header").querySelector(".dropdown-trigger").textContent = defaultLongDurationLink.textContent;
+                walltimeSelector.remove();
+            }
         }
 
         // remove admin control if there are no admin permissions available


### PR DESCRIPTION
## What is the purpose of this change?

There was a bug where the wallclock element was null if the time was before 9am. This was probably introduced when the Janus frontend project was converted from jQuery to Javascript.

## What is the value of this change and how do we measure success?

This remedies the bug by adding a null check for the element.