### PR TITLE
feat(passkeys): Add check for duplicate passkey name

### DIFF
--- a/app/controllers/Validation.scala
+++ b/app/controllers/Validation.scala
@@ -1,0 +1,19 @@
+package controllers
+
+import play.api.data.Form
+
+private[controllers] object Validation {
+
+  def formattedErrors[A](formWithErrors: Form[A]): String =
+    formWithErrors.errors
+      .map { error =>
+        val message = error.message match {
+          case "error.required"  => "missing value"
+          case "error.maxLength" => "too long"
+          case "error.pattern"   => "contains invalid characters"
+          case other             => other
+        }
+        s"${error.key}: $message"
+      }
+      .mkString(", ")
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -64,6 +64,17 @@ object JanusException {
     causedBy = Some(cause)
   )
 
+  def duplicatePasskeyNameFieldInRequest(
+      user: UserIdentity,
+      passkeyName: String
+  ): JanusException = JanusException(
+    userMessage = "passkeyName: already exists",
+    engineerMessage =
+      s"Passkey name '$passkeyName' already exists for user ${user.username}",
+    httpCode = BAD_REQUEST,
+    causedBy = None
+  )
+
   def failedToLoadDbItem(
       user: UserIdentity,
       tableName: String,


### PR DESCRIPTION
## What is the purpose of this change?

This pull request introduces enhancements to the `PasskeyDB` and `PasskeyController` classes to improve passkey registration validation and error handling. It also refactors the codebase by moving the `formattedErrors` function to a new `Validation` object for better modularity. The most important changes include adding a validation method to check for duplicate passkey names, creating a helper method for handling errors during redirection, and refactoring error formatting logic.

### Enhancements to passkey registration validation:

* **Added `passkeyNameExists` method in `PasskeyDB`:** This method checks if a passkey name already exists for a given user in the database, helping prevent duplicate passkey names during registration.
* **Introduced `validateRegistrationData` in `PasskeyController`:** Validates registration data by ensuring the passkey name does not already exist in the database before proceeding with registration. 
* **Added `duplicatePasskeyNameFieldInRequest` exception:** A new exception type was added to handle duplicate passkey name scenarios with clear user and engineer messages.

### Improvements to error handling:

* **Created `redirectResponseOnError` helper method in `PasskeyController`:** Simplifies error handling by redirecting users to a specified path with appropriate flash messages on failure.

### Code refactoring:

* **Moved `formattedErrors` to a new `Validation` object:** The error formatting logic was extracted from `PasskeyController` into a dedicated `Validation` object for better modularity and reuse. (`app/controllers/Validation.scala`, [app/controllers/Validation.scalaR1-R19](diffhunk://#diff-435df286632280651e369f7379c69f74466e7cad069344b0b4165e477099977fR1-R19))

## What is the value of this change and how do we measure success?

Better experience as reduces the confusion of having two passkeys with the same name.
