### PR TITLE
fix: Update CSP policy to resolve Firefox warnings

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,11 @@ play {
         font-src="'self' data:"
         style-src="'self' 'unsafe-inline'"
         img-src="'self' data:"
+
+        # This is Play default policy (see https://www.playframework.com/documentation/3.0.x/CspFilter#Default-CSP-Policy)
+        # but without 'unsafe-inline' and schemas, which are ignored by browsers if 'strict-dynamic' is supported.
+        # And all modern browsers support 'strict-dynamic': https://caniuse.com/?search=strict-dynamic
+        script-src = ${play.filters.csp.nonce.pattern} "'strict-dynamic'"
       }
     }
   }


### PR DESCRIPTION
## What is the purpose of this change?
This is to resolve warnings in the Firefox dev console:
> Content-Security-Policy: Ignoring “'unsafe-inline'” within script-src: ‘strict-dynamic’ specified

Modern browsers support the [strict-dynamic](https://content-security-policy.com/strict-dynamic/) policy, which makes the `unsafe-inline` and schema policies redundant.

## What is the value of this change and how do we measure success?
More secure policy and no warnings in Firefox.
Tested locally in Chrome, Firefox and Safari.
