### PR TITLE
feat: name validation UX tweaks

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -37,7 +37,7 @@
                             <tbody>
                                 @for(passkey <- passkeys) {
                                     <tr>
-                                        <td>@{passkey.name}</td>
+                                        <td data-passkey-name="true">@{passkey.name}</td>
                                         <td>
                                             @passkey.authenticator.flatMap(_.icon).map { icon =>
                                                 <img class="passkey-authenticator-icon" src="@icon" alt="@{passkey.authenticator.map(_.description).getOrElse("Unknown authenticator")} icon" />

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -37,7 +37,7 @@
                             <tbody>
                                 @for(passkey <- passkeys) {
                                     <tr>
-                                        <td data-passkey-name="true">@{passkey.name}</td>
+                                        <td data-passkey-name="@{passkey.name}">@{passkey.name}</td>
                                         <td>
                                             @passkey.authenticator.flatMap(_.icon).map { icon =>
                                                 <img class="passkey-authenticator-icon" src="@icon" alt="@{passkey.authenticator.map(_.description).getOrElse("Unknown authenticator")} icon" />

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -319,7 +319,7 @@ function getPasskeyNameFromUser() {
             document.querySelectorAll('[data-passkey-name="true"]')
         ).map(td => td.textContent.trim().toLowerCase());
 
-        const existingPasskeyNameMessage = `A passkey with this name already exists, please choose a different name`;
+        const existingPasskeyNameMessage = 'A passkey with this name already exists, please choose a different name';
 
         // Helper function to update submit button state
         const updateSubmitButtonState = (isValid) => {

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -325,8 +325,10 @@ function getPasskeyNameFromUser() {
         const updateSubmitButtonState = (isValid) => {
             if (isValid) {
                 submitButton.classList.remove('disabled');
+                submitButton.disabled = false;
             } else {
                 submitButton.classList.add('disabled');
+                submitButton.disabled = true;
             }
         };
 

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -314,10 +314,10 @@ function getPasskeyNameFromUser() {
         const alphanumericRegex = /^[a-zA-Z0-9 _-]*$/;
         const maxLength = 50; // Maximum character limit
         
-        // Get existing passkey names from the DOM
+        // Get existing passkey names from the DOM - using attribute values directly
         const existingPasskeyNames = Array.from(
-            document.querySelectorAll('[data-passkey-name="true"]')
-        ).map(td => td.textContent.trim().toLowerCase());
+            document.querySelectorAll('[data-passkey-name]')
+        ).map(element => element.getAttribute('data-passkey-name').trim().toLowerCase());
 
         const existingPasskeyNameMessage = 'A passkey with this name already exists, please choose a different name';
 

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -313,6 +313,13 @@ function getPasskeyNameFromUser() {
         // Regex to allow letters, numbers, spaces, underscores and hyphens
         const alphanumericRegex = /^[a-zA-Z0-9 _-]*$/;
         const maxLength = 50; // Maximum character limit
+        
+        // Get existing passkey names from the DOM
+        const existingPasskeyNames = Array.from(
+            document.querySelectorAll('[data-passkey-name="true"]')
+        ).map(td => td.textContent.trim().toLowerCase());
+
+        const existingPasskeyNameMessage = `A passkey with this name already exists, please choose a different name`;
 
         // Reset the input field and error message when opening the modal
         input.value = '';
@@ -326,13 +333,21 @@ function getPasskeyNameFromUser() {
         // Define named handler functions so they can be properly removed later
         const handleInput = () => {
             const input_value = input.value;
+            const trimmedValue = input_value.trim();
             
             // Check if input is approaching the limit
             if (input_value.length > maxLength) {
                 input.classList.add('invalid');
                 errorMessage.style.display = 'block';
                 errorMessage.textContent = `Name is too long: ${input_value.length}/${maxLength} characters`;
-            } else if (input_value.trim() && alphanumericRegex.test(input_value)) {
+            } 
+            // Check if the name already exists
+            else if (trimmedValue && existingPasskeyNames.includes(trimmedValue.toLowerCase())) {
+                input.classList.add('invalid');
+                errorMessage.style.display = 'block';
+                errorMessage.textContent = existingPasskeyNameMessage;
+            }
+            else if (trimmedValue && alphanumericRegex.test(input_value)) {
                 input.classList.remove('invalid');
                 errorMessage.style.display = 'none';
             } else {
@@ -354,8 +369,15 @@ function getPasskeyNameFromUser() {
                     errorMessage.textContent = `Passkey name too long: maximum ${maxLength} characters allowed`;
                 } else {
                     errorMessage.textContent = 'Cannot save passkey name: only letters, numbers, spaces, underscores and hyphens are allowed';
-                   
                 }
+                return;
+            }
+            
+            // Check for duplicate names before submitting
+            if (existingPasskeyNames.includes(passkeyName.toLowerCase())) {
+                input.classList.add('invalid');
+                errorMessage.style.display = 'block';
+                errorMessage.textContent = existingPasskeyNameMessage;
                 return;
             }
 

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -334,15 +334,15 @@ function getPasskeyNameFromUser() {
 
         // Helper function to validate input and update UI accordingly
         const validateInput = () => {
-            const input_value = input.value;
-            const trimmedValue = input_value.trim();
+            const inputValue = input.value;
+            const trimmedValue = inputValue.trim();
             let isValid = false;
             
             // Check if input is approaching the limit
-            if (input_value.length > maxLength) {
+            if (inputValue.length > maxLength) {
                 input.classList.add('invalid');
                 errorMessage.style.display = 'block';
-                errorMessage.textContent = `Name is too long: ${input_value.length}/${maxLength} characters`;
+                errorMessage.textContent = `Name is too long: ${inputValue.length}/${maxLength} characters`;
             } 
             // Check if the name already exists
             else if (trimmedValue && existingPasskeyNames.includes(trimmedValue.toLowerCase())) {
@@ -350,7 +350,7 @@ function getPasskeyNameFromUser() {
                 errorMessage.style.display = 'block';
                 errorMessage.textContent = existingPasskeyNameMessage;
             }
-            else if (trimmedValue && alphanumericRegex.test(input_value)) {
+            else if (trimmedValue && alphanumericRegex.test(trimmedValue)) {
                 input.classList.remove('invalid');
                 errorMessage.style.display = 'none';
                 isValid = true; // Valid input


### PR DESCRIPTION
## What is the purpose of this change?

- Based on #615.

- Improves the user experience for managing passkeys by introducing stricter validation for passkey names and enhancing the frontend logic to prevent duplicate names.

### Enhancements to passkey validation and user feedback:

* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8L302-R383): Implemented logic to check for duplicate passkey names by retrieving existing names from the DOM and validating against them. Added error messages for duplicate names and improved validation feedback for invalid inputs.

* [`app/views/userAccount.scala.html`](diffhunk://#diff-374d8384fc5549c89757384e7a301bd56c2701178a0ecda3457140b0b40cd9b0L40-R40): Added a `data-passkey-name` attribute to the table cell displaying passkey names, enabling the frontend to identify and validate existing passkey names.
> [!NOTE]  
> This could also be done using classes, but using a data attribute makes it explicit that this element contains a passkey name, rather than just being styled as one. The HTML5 specification introduced data attributes specifically to solve the problem of storing custom data without overloading attributes meant for other purposes, like classes.

### Improvements to modal interaction:

* [`frontend/passkeys.js`](diffhunk://#diff-157d328996ad7679d704789ae8346a8f08d8aa777aab1f412acc445879b352f8L302-R383): Enhanced the modal behavior by disabling the submit button until the input is valid and adding safeguards to prevent submission of invalid or duplicate names.

## What is the value of this change and how do we measure success?

- Ensuring we test for duplicate names in the frontend means that the user doesn't have to submit the name form before finding out that it was a duplicate. 
- Disabling the submit button when the name is invalid ensures that the user doesn't try to click submit, which won't work when the name is invalid.

## Images

### Invalid state before
<img width="834" alt="image" src="https://github.com/user-attachments/assets/7ea8841b-301e-47f4-bf3f-a42123fa6b59" />


### Invalid state after - note disabled submit button
<img width="834" alt="image" src="https://github.com/user-attachments/assets/857500da-920d-4341-849b-055e5d6b1974" />