### PR TITLE
feat(passkeys): Redirect to user account page if no passkeys

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -21,7 +21,8 @@
             AWS credentials or the AWS console.</p>
         <p>We recommend that you <strong>register at least two passkeys</strong> to ensure you have access to
             your AWS accounts.
-            One should be on-device (e.g. Mac Touch ID) and the other off-device (e.g. security key or phone).</p>
+            One should be on-device (e.g. Mac Touch ID or Windows Hello)
+            and the other off-device (e.g. security key or phone).</p>
 
         <div class="row">           
             <h4 class="header orange-text">Registered passkeys</h4>
@@ -87,7 +88,7 @@
             <h4 class="orange-text">Passkey name</h4>
             <p>Give this passkey a name to help you recognise it later.</p>
             <div class="input-field">
-                <input type="text" id="passkey-name" class="validate" placeholder="e.g. Macbook, Phone" required>
+                <input type="text" id="passkey-name" class="validate" placeholder="e.g. Macbook Chrome, Phone" required>
                 <div id="passkey-name-error" class="error-message red-text hidden">Please enter a name for your passkey</div>
             </div>
         </div>

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -63,7 +63,13 @@
                             </tbody>
                         </table>
                     } else {                                 
-                        <p>You haven't registered any passkeys yet.</p>
+                        <div class="center-align">
+                            <div class="alert-box">
+                                <i class="material-icons medium red-text">error</i>
+                                <h5>No Passkeys Registered</h5>
+                                <p>Before you can access AWS credentials or console you must register at least one passkey.</p>
+                            </div>
+                        </div>
                     }                    
                     <div class="section">
                         <button id="register-passkey" 

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -16,8 +16,12 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <p>Passkeys are a secure way to log in without a password. They are used to authenticate you when you access Janus credentials or the AWS console.</p>
-        <p>We recommend you register at least two passkeys. One should be on-device (e.g. Touch ID) and the other off-device (e.g. security key or authenticator app).</p>
+        <p>Passkeys are a secure way to authenticate sensitive actions.
+            Janus uses them as an extra layer of security to authenticate you before allowing you to access
+            AWS credentials or the AWS console.</p>
+        <p>We recommend that you <strong>register at least two passkeys</strong> to ensure you have access to
+            your AWS accounts.
+            One should be on-device (e.g. Mac Touch ID) and the other off-device (e.g. security key or phone).</p>
 
         <div class="row">           
             <h4 class="header orange-text">Registered passkeys</h4>

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -87,6 +87,10 @@ export async function authenticatePasskey(targetHref, csrfToken) {
 
         if (!authOptionsResponse.ok) {
             console.error('Authentication options request failed:', authOptionsResponseJson);
+            /*
+             * We only get a 400 response here if the user has no registered passkeys.
+             * In this scenario, we redirect them to the user account page where they are urged to register one.
+             */
             if (authOptionsResponse.status === 400) {
                 window.location.href = '/user-account';
                 return;

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -88,16 +88,13 @@ export async function authenticatePasskey(targetHref, csrfToken) {
         if (!authOptionsResponse.ok) {
             console.error('Authentication options request failed:', authOptionsResponseJson);
             if (authOptionsResponse.status === 400) {
-                M.toast({
-                    html: 'Please register a passkey before attempting to authenticate.',
-                    classes: 'rounded red'
-                });
-            } else {
-                M.toast({
-                    html: 'Failed to get authentication options from server. Please try again.',
-                    classes: 'rounded red'
-                });
+                window.location.href = '/user-account';
+                return;
             }
+            M.toast({
+                html: 'Failed to get authentication options from server. Please try again.',
+                classes: 'rounded red'
+            });
             return;
         }
 


### PR DESCRIPTION
## What is the purpose of this change?

Currently, if a user tries to access a protected link when they haven't registered a passkey they are left on the page with a 400 error.
In this PR, the user is redirected to the user-account page where they are encouraged to register a passkey.

## What is the value of this change and how do we measure success?
This improves the UX by making it clear what's happening and nudging the user to take the right action.

## Images
### User account page for user with no passkeys:
![image](https://github.com/user-attachments/assets/e92f63fd-a985-412b-8d79-ee341f67f673)

