### PR TITLE
refactor: Introduce PasskeyFlow enum

### DIFF
--- a/app/controllers/PasskeyAuthFilter.scala
+++ b/app/controllers/PasskeyAuthFilter.scala
@@ -5,6 +5,7 @@ import com.gu.googleauth.AuthAction.UserIdentityRequest
 import logic.Passkey
 import models.JanusException
 import models.JanusException.throwableWrites
+import models.PasskeyFlow.Authentication
 import play.api.Logging
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.libs.json.Json.toJson
@@ -51,7 +52,10 @@ class PasskeyAuthFilter(
     Future(
       apiResponse(
         for {
-          challengeResponse <- PasskeyChallengeDB.loadChallenge(request.user)
+          challengeResponse <- PasskeyChallengeDB.loadChallenge(
+            request.user,
+            Authentication
+          )
           challenge <- PasskeyChallengeDB.extractChallenge(
             challengeResponse,
             request.user
@@ -81,7 +85,7 @@ class PasskeyAuthFilter(
             authData,
             credential
           )
-          _ <- PasskeyChallengeDB.delete(request.user)
+          _ <- PasskeyChallengeDB.delete(request.user, Authentication)
           _ <- PasskeyDB.updateCounter(request.user, verifiedAuthData)
           _ <- PasskeyDB.updateLastUsedTime(request.user, verifiedAuthData)
           _ = logger.info(

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -12,6 +12,7 @@ import logic.AccountOrdering.orderedAccountAccess
 import logic.UserAccess.{userAccess, username}
 import logic.{Date, Favourites, Passkey}
 import models.JanusException.throwableWrites
+import models.PasskeyFlow.{Authentication, Registration}
 import models.{JanusException, PasskeyAuthenticator, PasskeyEncodings}
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
@@ -101,7 +102,7 @@ class PasskeyController(
           existingPasskeys = PasskeyDB.extractMetadata(loadCredentialsResponse)
         )
         _ <- PasskeyChallengeDB.insert(
-          UserChallenge(request.user, options.getChallenge)
+          UserChallenge(request.user, Registration, options.getChallenge)
         )
         _ = logger.info(
           s"Created registration options for user ${request.user.username}"
@@ -174,7 +175,7 @@ class PasskeyController(
       registrationData: RegistrationData
   ): Try[Result] =
     for {
-      challengeResponse <- PasskeyChallengeDB.loadChallenge(user)
+      challengeResponse <- PasskeyChallengeDB.loadChallenge(user, Registration)
       challenge <- PasskeyChallengeDB.extractChallenge(challengeResponse, user)
       credRecord <- Passkey.verifiedRegistration(
         host,
@@ -183,7 +184,7 @@ class PasskeyController(
         registrationData.passkey
       )
       _ <- PasskeyDB.insert(user, credRecord, registrationData.passkeyName)
-      _ <- PasskeyChallengeDB.delete(user)
+      _ <- PasskeyChallengeDB.delete(user, Registration)
       _ = logger.info(s"Registered passkey for user ${user.username}")
     } yield {
       Redirect("/user-account")
@@ -204,7 +205,7 @@ class PasskeyController(
           existingPasskeys = PasskeyDB.extractMetadata(loadCredentialsResponse)
         )
         _ <- PasskeyChallengeDB.insert(
-          UserChallenge(request.user, options.getChallenge)
+          UserChallenge(request.user, Authentication, options.getChallenge)
         )
         _ = logger.info(
           s"Created authentication options for user ${request.user.username}"

--- a/app/models/Passkey.scala
+++ b/app/models/Passkey.scala
@@ -7,7 +7,6 @@ import com.webauthn4j.data.*
 import com.webauthn4j.data.attestation.authenticator.AAGUID
 import com.webauthn4j.data.client.challenge.DefaultChallenge
 import com.webauthn4j.util.Base64UrlUtil
-import models.PasskeyAuthenticator.logger
 import play.api.Logging
 import play.api.libs.json.{JsError, JsSuccess, Json, Reads}
 
@@ -24,6 +23,9 @@ case class PasskeyMetadata(
     lastUsedTime: Option[Instant],
     authenticator: Option[PasskeyAuthenticator]
 )
+
+enum PasskeyFlow:
+  case Registration, Authentication
 
 object PasskeyEncodings {
 


### PR DESCRIPTION
## What is the purpose of this change?
This change introduces a new `PasskeyFlow` enum, which is to enable us to distinguish between passkey challenges that have been stored for an authentication flow and those that have been stored for a registration flow.

## What is the value of this change and how do we measure success?
This will ensure that the right challenge is compared during the passkey verification process.
There are various scenarios where challenges can get confused.  But this becomes more of an issue when passkeys are used to authenticate passkey registration requests.

## Any additional notes?
The change adds a new `flow` key attribute to items in the `PasskeyChallenge` Dynamo table.
The table configuration will need to be updated to reflect this change.
