### PR TITLE
feat(passkeys): Authenticate registration flow

### DIFF
--- a/app/controllers/PasskeyAuthFilter.scala
+++ b/app/controllers/PasskeyAuthFilter.scala
@@ -117,9 +117,12 @@ class PasskeyAuthFilter(
               JanusException.missingFieldInRequest(request.user, "credentials")
             )
             .toTry
-        case _ =>
+        case other =>
           Failure(
-            JanusException.missingFieldInRequest(request.user, "credentials")
+            JanusException.invalidRequest(
+              request.user,
+              s"Unexpected body type: ${other.getClass.getName}"
+            )
           )
       }
       authData <- Passkey.parsedAuthentication(request.user, body)

--- a/app/filters/PasskeyRegistrationAuthFilter.scala
+++ b/app/filters/PasskeyRegistrationAuthFilter.scala
@@ -1,0 +1,61 @@
+package filters
+
+import aws.PasskeyDB
+import com.gu.googleauth.AuthAction.UserIdentityRequest
+import controllers.PasskeyAuthFilter
+import play.api.Logging
+import play.api.mvc.Results.InternalServerError
+import play.api.mvc.{ActionFilter, Result}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** This filter determines if a user should be allowed to register passkeys:
+  *   - If the user has no existing passkey credentials in the database, they're
+  *     allowed to register (filter returns None)
+  *   - If the user already has passkey credentials, the request is delegated to
+  *     the standard PasskeyAuthFilter
+  *
+  * @param authFilter
+  *   The passkey authentication filter to delegate to if the user already has
+  *   credentials
+  * @param dynamoDb
+  *   The AWS DynamoDB client for database access
+  * @param ec
+  *   Execution context for asynchronous operations
+  */
+class PasskeyRegistrationAuthFilter(authFilter: PasskeyAuthFilter)(using
+    dynamoDb: DynamoDbClient,
+    ec: ExecutionContext
+) extends ActionFilter[UserIdentityRequest]
+    with Logging {
+
+  def executionContext: ExecutionContext = ec
+
+  /** Filters requests by checking if the user has registered passkeys.
+    *
+    * @param request
+    *   The incoming user identity request
+    * @tparam A
+    *   The request body type
+    * @return
+    *   None if the user has no passkeys and can proceed with registration,
+    *   otherwise the result of the delegated passkey auth filter or an error
+    *   response
+    */
+  def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] =
+    PasskeyDB
+      .loadCredentials(request.user)
+      .fold(
+        err => {
+          logger.error(
+            s"Failed to load existing credentials for user ${request.user.username}",
+            err
+          )
+          Future.successful(Some(InternalServerError("DB load error")))
+        },
+        dbResponse =>
+          if !dbResponse.items.isEmpty then authFilter.filter(request)
+          else Future.successful(None)
+      )
+}

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -37,13 +37,23 @@ object JanusException {
     )
   }
 
+  def invalidRequest(
+      user: UserIdentity,
+      detail: String
+  ): JanusException = JanusException(
+    userMessage = s"Invalid request",
+    engineerMessage = s"Invalid request for user ${user.username}: $detail",
+    httpCode = BAD_REQUEST,
+    causedBy = None
+  )
+
   def missingFieldInRequest(
       user: UserIdentity,
       fieldName: String
   ): JanusException = JanusException(
-    userMessage = s"Missing $fieldName field",
+    userMessage = s"Missing '$fieldName' field",
     engineerMessage =
-      s"Missing $fieldName in request body for user ${user.username}",
+      s"Missing '$fieldName' field in request body for user ${user.username}",
     httpCode = BAD_REQUEST,
     causedBy = None
   )

--- a/conf/routes
+++ b/conf/routes
@@ -27,10 +27,11 @@ GET     /loginError                 controllers.AuthController.loginError
 GET     /oauthCallback              controllers.AuthController.oauthCallback
 GET     /logout                     controllers.AuthController.logout
 
-POST    /passkey/registration-options   controllers.PasskeyController.registrationOptions
-POST    /passkey/auth-options           controllers.PasskeyController.authenticationOptions
-POST    /passkey/register               controllers.PasskeyController.register
-DELETE  /passkey/:passkeyId      controllers.PasskeyController.deletePasskey(passkeyId: String)
+POST    /passkey/registration-options       controllers.PasskeyController.registrationOptions
+POST    /passkey/auth-options               controllers.PasskeyController.authenticationOptions
+POST    /passkey/registration-auth-options  controllers.PasskeyController.registrationAuthenticationOptions
+POST    /passkey/register                   controllers.PasskeyController.register
+DELETE  /passkey/:passkeyId                 controllers.PasskeyController.deletePasskey(passkeyId: String)
 
 # Temporary endpoints for testing passkey auth
 POST    /passkey/protected-credentials-page controllers.PasskeyController.protectedCredentialsPage


### PR DESCRIPTION
## What is the purpose of this change?
This makes some changes on the frontend and server so that the registration of a new passkey is authenticated using an existing passkey if there are any.
On the server, we have introduced a new filter that intercepts registration calls and either passes the request to the standard passkey authentication filter if the user already has passkeys registered or passes the request straight to the controller method if there are no existing passkeys to authenticate the request.
On the frontend, we modify the flow slightly so that before registration we fetch authentication options and then authenticate with an existing passkey if there is one.  We then send the authentication data with the registration request to the server so that it can be verified there.

## What is the value of this change and how do we measure success?
This mitigates against a malicious actor registering a passkey on someone else's account in order to gain access.
