### PR TITLE
chore: Give Scala Steward access to Example project

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,5 @@
+# See https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+
 pullRequests.frequency = "30 days"
+
+buildRoots = [".", "example"]


### PR DESCRIPTION
## What is the purpose of this change?
This repo contains a separate SBT project holding an example app.  This change ensures that Scala Steward keeps the dependencies of the project up to date along with the main SBT projects that are configured at the repo root level.

## What is the value of this change and how do we measure success?
All Scala dependencies kept up to date throughout repo.
