### PR TITLE
Refactor: Improvements to passkeys code

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -92,7 +92,7 @@ class AppComponents(context: ApplicationLoader.Context)
     controllerComponents.parsers.default
   )(executionContext)
 
-  private val passkeyAuthenticators =
+  private val passkeyAuthenticatorMetadata =
     PasskeyAuthenticator.fromResource(
       "passkeys_aaguid_descriptions.json"
     )
@@ -119,7 +119,8 @@ class AppComponents(context: ApplicationLoader.Context)
       authAction,
       host,
       Clients.stsClient,
-      configuration
+      configuration,
+      passkeyAuthenticatorMetadata
     ),
     new Audit(janusData, controllerComponents, authAction),
     new RevokePermissions(
@@ -144,8 +145,7 @@ class AppComponents(context: ApplicationLoader.Context)
       host,
       janusData,
       passkeysEnabled,
-      passkeysEnablingCookieName,
-      passkeyAuthenticators
+      passkeysEnablingCookieName
     ),
     new Utility(janusData, controllerComponents, authAction, configuration),
     assets

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -179,7 +179,7 @@ class PasskeyController(
             Json.obj(
               "success" -> true,
               "message" -> s"Passkey '$passkeyName' was successfully deleted",
-              "redirect" -> "/user-account"
+              "redirect" -> routes.Janus.userAccount.url
             )
           )
         }

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -110,7 +110,7 @@ class PasskeyController(
           appHost = host,
           user = request.user,
           challenge = new DefaultChallenge(),
-          existingPasskeys
+          existingPasskeys = existingPasskeys
         )
         _ <- PasskeyChallengeDB.insert(
           UserChallenge(request.user, Authentication, options.getChallenge)

--- a/app/controllers/ResultHandler.scala
+++ b/app/controllers/ResultHandler.scala
@@ -1,0 +1,55 @@
+package controllers
+
+import models.JanusException.throwableWrites
+import models.{JanusException, PasskeyEncodings}
+import play.api.Logging
+import play.api.http.MimeTypes
+import play.api.libs.json.Json.toJson
+import play.api.mvc.*
+import play.twirl.api.Html
+
+import scala.util.{Failure, Success, Try}
+
+/** Provides utilities for handling API responses and redirects in a
+  * standardized way. It transforms Try-based computation results into
+  * appropriate Play HTTP results.
+  */
+private[controllers] trait ResultHandler extends Results with Logging {
+
+  def apiResponse[A](action: => Try[A]): Result =
+    action match {
+      case Failure(err: JanusException) =>
+        logger.error(err.engineerMessage, err.causedBy.orNull)
+        Status(err.httpCode)(toJson(err))
+      case Failure(err) =>
+        logger.error(err.getMessage, err)
+        InternalServerError(toJson(err))
+      case Success(result: Result) => result
+      case Success(html: Html)     => Ok(html)
+      case Success(a) =>
+        val json = PasskeyEncodings.mapper.writeValueAsString(a)
+        Ok(json).as(MimeTypes.JSON)
+    }
+
+  /** Redirects to a specified path and flashes messages on error. */
+  def redirectResponseOnError[A](
+      redirectPath: String
+  )(action: => Try[A]): Result =
+    action match {
+      case Failure(err: JanusException) =>
+        logger.error(err.engineerMessage, err.causedBy.orNull)
+        Redirect(redirectPath)
+          .flashing("error" -> err.userMessage)
+      case Failure(err) =>
+        logger.error(err.getMessage, err)
+        Redirect(redirectPath)
+          .flashing(
+            "error" -> "An unexpected error occurred"
+          )
+      case Success(result: Result) => result
+      case Success(html: Html)     => Ok(html)
+      case Success(a) =>
+        val json = PasskeyEncodings.mapper.writeValueAsString(a)
+        Ok(json).as(MimeTypes.JSON)
+    }
+}

--- a/app/controllers/ResultHandler.scala
+++ b/app/controllers/ResultHandler.scala
@@ -24,6 +24,7 @@ private[controllers] trait ResultHandler extends Results with Logging {
       case Failure(err) =>
         logger.error(err.getMessage, err)
         InternalServerError(toJson(err))
+      case Success(result: Result) => result
       case Success(html: Html) => Ok(html)
       case Success(a) =>
         val json = PasskeyEncodings.mapper.writeValueAsString(a)

--- a/app/controllers/ResultHandler.scala
+++ b/app/controllers/ResultHandler.scala
@@ -24,30 +24,7 @@ private[controllers] trait ResultHandler extends Results with Logging {
       case Failure(err) =>
         logger.error(err.getMessage, err)
         InternalServerError(toJson(err))
-      case Success(result: Result) => result
-      case Success(html: Html)     => Ok(html)
-      case Success(a) =>
-        val json = PasskeyEncodings.mapper.writeValueAsString(a)
-        Ok(json).as(MimeTypes.JSON)
-    }
-
-  /** Redirects to a specified path and flashes messages on error. */
-  def redirectResponseOnError[A](
-      redirectPath: String
-  )(action: => Try[A]): Result =
-    action match {
-      case Failure(err: JanusException) =>
-        logger.error(err.engineerMessage, err.causedBy.orNull)
-        Redirect(redirectPath)
-          .flashing("error" -> err.userMessage)
-      case Failure(err) =>
-        logger.error(err.getMessage, err)
-        Redirect(redirectPath)
-          .flashing(
-            "error" -> "An unexpected error occurred"
-          )
-      case Success(result: Result) => result
-      case Success(html: Html)     => Ok(html)
+      case Success(html: Html) => Ok(html)
       case Success(a) =>
         val json = PasskeyEncodings.mapper.writeValueAsString(a)
         Ok(json).as(MimeTypes.JSON)

--- a/app/controllers/ResultHandler.scala
+++ b/app/controllers/ResultHandler.scala
@@ -25,7 +25,7 @@ private[controllers] trait ResultHandler extends Results with Logging {
         logger.error(err.getMessage, err)
         InternalServerError(toJson(err))
       case Success(result: Result) => result
-      case Success(html: Html) => Ok(html)
+      case Success(html: Html)     => Ok(html)
       case Success(a) =>
         val json = PasskeyEncodings.mapper.writeValueAsString(a)
         Ok(json).as(MimeTypes.JSON)

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@
 GET     /                           controllers.Janus.index
 GET     /superuser                  controllers.Janus.admin
 GET     /support                    controllers.Janus.support
+GET     /user-account               controllers.Janus.userAccount
 GET     /console                    controllers.Janus.consoleLogin(permissionId: String)
 GET     /consoleUrl                 controllers.Janus.consoleUrl(permissionId: String)
 GET     /credentials                controllers.Janus.credentials(permissionId: String)
@@ -38,8 +39,6 @@ POST    /passkey/protected-credentials-page controllers.PasskeyController.protec
 GET     /passkey/pretend-aws-console        controllers.PasskeyController.pretendAwsConsole
 POST    /passkey/protected-redirect         controllers.PasskeyController.protectedRedirect
 GET     /passkey/mock-home                  controllers.PasskeyController.mockHome
-
-GET     /user-account               controllers.PasskeyController.showUserAccountPage
 
 GET     /healthcheck                controllers.Utility.healthcheck
 GET     /accounts                   controllers.Utility.accounts


### PR DESCRIPTION
This pull request refactors the handling of passkeys, introduces a new `ResultHandler` trait for standardised response handling and simplifies the `PasskeyController`. The changes improve code modularity and maintainability and reduce duplication and improve maintainability.

### Passkey-related refactoring:

* [`app/AppComponents.scala`](diffhunk://#diff-6b72d7326232bd79ee27038565637854aa6c65208c0a563207fce9787b2ea647L95-R95): Renamed `passkeyAuthenticators` to `passkeyAuthenticatorMetadata` and passed it as a new dependency to the `Janus` controller. Removed its usage from the `PasskeyController`. [[1]](diffhunk://#diff-6b72d7326232bd79ee27038565637854aa6c65208c0a563207fce9787b2ea647L95-R95) [[2]](diffhunk://#diff-6b72d7326232bd79ee27038565637854aa6c65208c0a563207fce9787b2ea647L122-R123) [[3]](diffhunk://#diff-6b72d7326232bd79ee27038565637854aa6c65208c0a563207fce9787b2ea647L147-R148)
* [`app/controllers/Janus.scala`](diffhunk://#diff-7ebc3def08c39769f2b0e152b9891084e6be013ffc4de7d8ea164fa571b845fbL3-R31): Added `passkeyAuthenticatorMetadata` as a dependency and introduced a new `userAccount` action to handle user account views, including passkey metadata. [[1]](diffhunk://#diff-7ebc3def08c39769f2b0e152b9891084e6be013ffc4de7d8ea164fa571b845fbL3-R31) [[2]](diffhunk://#diff-7ebc3def08c39769f2b0e152b9891084e6be013ffc4de7d8ea164fa571b845fbR102-R129)

### Controller simplification:

* [`app/controllers/PasskeyController.scala`](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fL62-L99): Removed redundant methods (`apiResponse`, `redirectResponseOnError`, `validateRegistrationData`, `performPasskeyRegistration`, etc.) and moved shared functionality to the new `ResultHandler` trait. Simplified passkey registration and validation logic. [[1]](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fL62-L99) [[2]](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fL150-L203) [[3]](diffhunk://#diff-c598597e1c4a7dcb243f4ea2669b34ac7af0ea330884fb9d08abc2e09e19f73fL339-R294)

### Introduction of `ResultHandler`:

* [`app/controllers/ResultHandler.scala`](diffhunk://#diff-bdd29aee62c43bc26ec4ffbe7fe25198832771169d93e5a7067a38f7a51627abR1-R32): Created a new trait to centralise API response handling and reduce duplication across controllers. This includes methods for handling `Try` results and generating appropriate HTTP responses.

### Routing updates:

* [`conf/routes`](diffhunk://#diff-3668dd1c5d74e6d728b59d45112f57372248fbbcde03767f2fe38499aceef443R9): Updated routes to reflect the new `userAccount` action in the `Janus` controller and removed the redundant `showUserAccountPage` route from `PasskeyController`. [[1]](diffhunk://#diff-3668dd1c5d74e6d728b59d45112f57372248fbbcde03767f2fe38499aceef443R9) [[2]](diffhunk://#diff-3668dd1c5d74e6d728b59d45112f57372248fbbcde03767f2fe38499aceef443L42-L43)
