### PR TITLE
refactor: Improve clarity of passkey authentication filter

### DIFF
--- a/app/filters/PasskeyAuthFilter.scala
+++ b/app/filters/PasskeyAuthFilter.scala
@@ -2,14 +2,15 @@ package filters
 
 import aws.{PasskeyChallengeDB, PasskeyDB}
 import com.gu.googleauth.AuthAction.UserIdentityRequest
+import com.gu.googleauth.UserIdentity
+import com.webauthn4j.data.AuthenticationData
 import logic.Passkey
 import models.JanusException
 import models.JanusException.throwableWrites
 import models.PasskeyFlow.Authentication
 import play.api.Logging
-import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.libs.json.Json.toJson
-import play.api.mvc.Results.Status
+import play.api.mvc.Results.{InternalServerError, Status}
 import play.api.mvc.{
   ActionFilter,
   AnyContentAsFormUrlEncoded,
@@ -17,6 +18,7 @@ import play.api.mvc.{
   Result
 }
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -47,58 +49,40 @@ class PasskeyAuthFilter(
       logger.info(
         s"Authenticating passkey for user ${request.user.username} ..."
       )
-      doFilter(request)
+      Future(apiResponse(authenticatePasskey(request)))
     } else Future.successful(None)
   }
 
-  private def doFilter[A](
+  private def authenticatePasskey[A](
       request: UserIdentityRequest[A]
-  ): Future[Option[Result]] =
-    Future(
-      apiResponse(
-        for {
-          challengeResponse <- PasskeyChallengeDB.loadChallenge(
-            request.user,
-            Authentication
-          )
-          challenge <- PasskeyChallengeDB.extractChallenge(
-            challengeResponse,
-            request.user
-          )
-          authData <- extractAuthenticationData(request)
-          credentialResponse <- PasskeyDB.loadCredential(
-            request.user,
-            authData.getCredentialId
-          )
-          _ <-
-            if (credentialResponse.hasItem) Success(())
-            else
-              Failure(
-                JanusException.authenticationFailure(
-                  request.user,
-                  new IllegalArgumentException("Invalid passkey credential")
-                )
-              )
-          credential <- PasskeyDB.extractCredential(
-            credentialResponse,
-            request.user
-          )
-          verifiedAuthData <- Passkey.verifiedAuthentication(
-            host,
-            request.user,
-            challenge,
-            authData,
-            credential
-          )
-          _ <- PasskeyChallengeDB.delete(request.user, Authentication)
-          _ <- PasskeyDB.updateCounter(request.user, verifiedAuthData)
-          _ <- PasskeyDB.updateLastUsedTime(request.user, verifiedAuthData)
-          _ = logger.info(
-            s"Authenticated passkey for user ${request.user.username}"
-          )
-        } yield ()
-      )
+  ): Try[Unit] = for {
+    challengeResponse <- PasskeyChallengeDB.loadChallenge(
+      request.user,
+      Authentication
     )
+    challenge <- PasskeyChallengeDB.extractChallenge(
+      challengeResponse,
+      request.user
+    )
+    authData <- extractAuthDataFromRequest(request)
+    credentialResponse <- PasskeyDB.loadCredential(
+      request.user,
+      authData.getCredentialId
+    )
+    _ <- validateCredentialExists(request.user, credentialResponse)
+    credential <- PasskeyDB.extractCredential(credentialResponse, request.user)
+    verifiedAuthData <- Passkey.verifiedAuthentication(
+      host,
+      request.user,
+      challenge,
+      authData,
+      credential
+    )
+    _ <- PasskeyChallengeDB.delete(request.user, Authentication)
+    _ <- PasskeyDB.updateCounter(request.user, verifiedAuthData)
+    _ <- PasskeyDB.updateLastUsedTime(request.user, verifiedAuthData)
+    _ = logger.info(s"Authenticated passkey for user ${request.user.username}")
+  } yield ()
 
   private def apiResponse(auth: => Try[Unit]): Option[Result] =
     auth match {
@@ -107,33 +91,51 @@ class PasskeyAuthFilter(
         Some(Status(err.httpCode)(toJson(err)))
       case Failure(err) =>
         logger.error(err.getMessage, err)
-        Some(Status(INTERNAL_SERVER_ERROR)(toJson(err)))
+        Some(InternalServerError(toJson(err)))
       case Success(_) => None
     }
 
-  private def extractAuthenticationData[A](request: UserIdentityRequest[A]) =
-    for {
-      body <- request.body match {
-        case AnyContentAsFormUrlEncoded(data) =>
-          data
-            .get("credentials")
-            .flatMap(_.headOption)
-            .toRight(
-              JanusException.missingFieldInRequest(request.user, "credentials")
-            )
-            .toTry
-        case AnyContentAsText(data) =>
-          Option(data)
-            .toRight(JanusException.missingFieldInRequest(request.user, "body"))
-            .toTry
-        case other =>
-          Failure(
-            JanusException.invalidRequest(
-              request.user,
-              s"Unexpected body type: ${other.getClass.getName}"
-            )
-          )
-      }
-      authData <- Passkey.parsedAuthentication(request.user, body)
-    } yield authData
+  private def extractAuthDataFromRequest[A](
+      request: UserIdentityRequest[A]
+  ): Try[AuthenticationData] = for {
+    body <- extractRequestBody(request)
+    authData <- Passkey.parsedAuthentication(request.user, body)
+  } yield authData
+
+  private def extractRequestBody[A](
+      request: UserIdentityRequest[A]
+  ): Try[String] = request.body match {
+    case AnyContentAsFormUrlEncoded(data) =>
+      data
+        .get("credentials")
+        .flatMap(_.headOption)
+        .toRight(
+          JanusException.missingFieldInRequest(request.user, "credentials")
+        )
+        .toTry
+    case AnyContentAsText(data) =>
+      Option(data)
+        .toRight(JanusException.missingFieldInRequest(request.user, "body"))
+        .toTry
+    case other =>
+      Failure(
+        JanusException.invalidRequest(
+          request.user,
+          s"Unexpected body type: ${other.getClass.getName}"
+        )
+      )
+  }
+
+  private def validateCredentialExists(
+      user: UserIdentity,
+      credentialResponse: GetItemResponse
+  ): Try[Unit] =
+    if (credentialResponse.hasItem) Success(())
+    else
+      Failure(
+        JanusException.authenticationFailure(
+          user,
+          new IllegalArgumentException("Invalid passkey credential")
+        )
+      )
 }


### PR DESCRIPTION
Some small improvements to the structure of the PasskeyAuthFilter in the hope of making its structure clearer.

### Refactoring for clarity and modularity:
* Renamed the `doFilter` method to `authenticatePasskey` to better reflect its purpose and changed its return type from `Future[Option[Result]]` to `Try[Unit`. ([app/filters/PasskeyAuthFilter.scalaL50-R58](diffhunk://#diff-56318c3aec7a1b8611cd782eef98cf5988839932247265bcef39ccca538ead29L50-R58))
* Replaced the `extractAuthenticationData` method with `extractAuthDataFromRequest` for improved naming consistency and extracted the logic for parsing the request body into a new helper method, `extractRequestBody`.
* Added a new helper method `validateCredentialExists` to encapsulate the logic for checking credential existence and handling related errors.

### Minor improvements:
* Adjusted logging statements for consistency and readability.
