### PR TITLE
feat(passkeys): Check access before registering

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -142,6 +142,7 @@ class PasskeyController(
     authAction(parse.empty) { request =>
       apiResponse(
         for {
+          _ <- verifyHasAccess(request.user)
           loadCredentialsResponse <- PasskeyDB.loadCredentials(request.user)
           options <- Passkey.authenticationOptions(
             appHost = host,
@@ -263,7 +264,9 @@ class PasskeyController(
   private def verifyHasAccess(
       user: UserIdentity
   ): Try[Unit] =
-    if hasAccess(user.username, janusData.access) then Success(())
+    if hasAccess(user.username, janusData.access) ||
+      hasAccess(user.username, janusData.admin)
+    then Success(())
     else Failure(JanusException.noAccessFailure(user))
 
   private def loadRegistrationChallenge(

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -1,7 +1,12 @@
 package models
 
 import com.gu.googleauth.UserIdentity
-import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, UNAUTHORIZED}
+import play.api.http.Status.{
+  BAD_REQUEST,
+  FORBIDDEN,
+  INTERNAL_SERVER_ERROR,
+  UNAUTHORIZED
+}
 import play.api.libs.json.{Json, Writes}
 
 enum AccountConfigStatus:
@@ -149,6 +154,15 @@ object JanusException {
         s"Authentication failed for user ${user.username}: ${cause.getMessage}",
       httpCode = UNAUTHORIZED,
       causedBy = Some(cause)
+    )
+
+  def noAccessFailure(user: UserIdentity): JanusException =
+    JanusException(
+      userMessage = "You haven't yet been granted any Janus permissions.",
+      engineerMessage =
+        s"Authorisation failed for user ${user.username}: no Janus permissions",
+      httpCode = FORBIDDEN,
+      causedBy = None
     )
 
   def noPasskeysRegistered(user: UserIdentity): JanusException =

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -66,9 +66,9 @@ const passkeyApi = {
 
       return optionsJson;
     } catch (error) {
-      console.error("Error fetching authentication options:", error);
+      console.error("Error fetching registration options:", error);
       displayToast(
-        "Network error while getting authentication options",
+        "Network error while getting registration options",
         messageType.error,
       );
       return null;

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -28,6 +28,56 @@ const passkeyApi = {
     return fetch(url, options);
   },
 
+  async getRegistrationOptions(
+    csrfToken,
+    endpoint = "/passkey/registration-options",
+  ) {
+    try {
+      const response = await this.fetchWithCsrf(
+        endpoint,
+        "POST",
+        null,
+        null,
+        csrfToken,
+      );
+      const optionsJson = await response.json();
+
+      if (!response.ok) {
+        console.error("Registration options request failed:", optionsJson);
+        displayToast(
+          optionsJson.message,
+          messageType.warning,
+        );
+        return null;
+      }
+
+      /*
+       * authenticatorSelection.authenticatorAttachment can be "platform" | "cross-platform" | null.
+       * A null value means any authenticator is allowed.
+       * Unfortunately, even though null is the recommended value, Safari won't allow it
+       * and Firefox gives a warning about it.
+       * So we remove the field if its value is null and all browsers are then happy.
+       * The effect is unchanged.
+       *
+       * This is a temporary measure until browsers accept the null value.
+       */
+      if (
+          optionsJson.authenticatorSelection?.authenticatorAttachment === null
+      ) {
+        delete optionsJson.authenticatorSelection.authenticatorAttachment;
+      }
+
+      return optionsJson;
+    } catch (error) {
+      console.error("Error fetching authentication options:", error);
+      displayToast(
+        "Network error while getting authentication options",
+        messageType.error,
+      );
+      return null;
+    }
+  },
+
   async getAuthenticationOptions(
     csrfToken,
     endpoint = "/passkey/auth-options",
@@ -167,29 +217,9 @@ export async function registerPasskey(csrfToken) {
     }
 
     // 3. Fetch the passkey creation options
-    const regOptionsResponse = await passkeyApi.fetchWithCsrf(
-      "/passkey/registration-options",
-      "POST",
-      null,
-      null,
-      csrfToken,
-    );
-    const regOptionsJson = await regOptionsResponse.json();
-
-    /*
-     * authenticatorSelection.authenticatorAttachment can be "platform" | "cross-platform" | null.
-     * A null value means any authenticator is allowed.
-     * Unfortunately, even though null is the recommended value, Safari won't allow it
-     * and Firefox gives a warning about it.
-     * So we remove the field if its value is null and all browsers are then happy.
-     * The effect is unchanged.
-     *
-     * This is a temporary measure until browsers accept the null value.
-     */
-    if (
-      regOptionsJson.authenticatorSelection?.authenticatorAttachment === null
-    ) {
-      delete regOptionsJson.authenticatorSelection.authenticatorAttachment;
+    const regOptionsJson = await passkeyApi.getRegistrationOptions(csrfToken);
+    if (!regOptionsJson) {
+      return;
     }
 
     // 4. Create a new passkey

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -44,10 +44,7 @@ const passkeyApi = {
 
       if (!response.ok) {
         console.error("Registration options request failed:", optionsJson);
-        displayToast(
-          optionsJson.message,
-          messageType.warning,
-        );
+        displayToast(optionsJson.message, messageType.warning);
         return null;
       }
 
@@ -62,7 +59,7 @@ const passkeyApi = {
        * This is a temporary measure until browsers accept the null value.
        */
       if (
-          optionsJson.authenticatorSelection?.authenticatorAttachment === null
+        optionsJson.authenticatorSelection?.authenticatorAttachment === null
       ) {
         delete optionsJson.authenticatorSelection.authenticatorAttachment;
       }

--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -33,18 +33,12 @@ const passkeyApi = {
     endpoint = "/passkey/registration-options",
   ) {
     try {
-      const response = await this.fetchWithCsrf(
-        endpoint,
-        "POST",
-        null,
-        null,
-        csrfToken,
-      );
+      const response = await this.fetchWithCsrf(endpoint, "POST", csrfToken);
       const optionsJson = await response.json();
 
       if (!response.ok) {
         console.error("Registration options request failed:", optionsJson);
-        displayToast(optionsJson.message, messageType.warning);
+        displayToast(optionsJson.message, messageType.error);
         return null;
       }
 
@@ -122,10 +116,7 @@ const passkeyApi = {
 
       if (!response.ok) {
         console.error("Authentication options request failed:", optionsJson);
-        displayToast(
-          "Failed to get authentication options from server. Please try again.",
-          messageType.warning,
-        );
+        displayToast(optionsJson.message, messageType.error);
         return null;
       }
 


### PR DESCRIPTION
## What is the purpose of this change?
This change adds a check that the user appears on the access list before allowing them to register a passkey.

If they aren't on the list, calls to `passkey/registration-options` and to `passkey/register` will fail with a 403.

The frontend code has been modified to respond to failure in registration-options to stop the flow as soon as possible.

## What is the value of this change and how do we measure success?
It's an additional check to ensure the user should be able to register a passkey before they try.
