### PR TITLE
fix: Stop sending null content-type request headers

### DIFF
--- a/frontend/passkeys.js
+++ b/frontend/passkeys.js
@@ -8,9 +8,9 @@ const passkeyApi = {
   async fetchWithCsrf(
     url,
     method = "POST",
-    body = null,
-    contentType = "application/x-www-form-urlencoded",
     csrfToken,
+    contentType = "application/x-www-form-urlencoded",
+    body = null,
   ) {
     const options = {
       method,
@@ -33,13 +33,7 @@ const passkeyApi = {
     endpoint = "/passkey/auth-options",
   ) {
     try {
-      const response = await this.fetchWithCsrf(
-        endpoint,
-        "POST",
-        null,
-        null,
-        csrfToken,
-      );
+      const response = await this.fetchWithCsrf(endpoint, "POST", csrfToken);
       const optionsJson = await response.json();
 
       if (!response.ok) {
@@ -76,13 +70,7 @@ const passkeyApi = {
     endpoint = "/passkey/registration-auth-options",
   ) {
     try {
-      const response = await this.fetchWithCsrf(
-        endpoint,
-        "POST",
-        null,
-        null,
-        csrfToken,
-      );
+      const response = await this.fetchWithCsrf(endpoint, "POST", csrfToken);
       const optionsJson = await response.json();
 
       if (!response.ok) {
@@ -170,8 +158,6 @@ export async function registerPasskey(csrfToken) {
     const regOptionsResponse = await passkeyApi.fetchWithCsrf(
       "/passkey/registration-options",
       "POST",
-      null,
-      null,
       csrfToken,
     );
     const regOptionsJson = await regOptionsResponse.json();
@@ -279,9 +265,9 @@ export async function deletePasskey(passkeyId, csrfToken) {
     const response = await passkeyApi.fetchWithCsrf(
       `/passkey/${passkeyId}`,
       "DELETE",
-      JSON.stringify(existingCredential.toJSON()),
-      "text/plain",
       csrfToken,
+      "text/plain",
+      JSON.stringify(existingCredential.toJSON()),
     );
 
     if (!response.ok) {


### PR DESCRIPTION
## What is the purpose of this change?
We were seeing warnings in the server log:
`Illegal header: Illegal 'content-type' header: Invalid input 'EOI', expected tchar, OWS or '/'`.

This is because `auth-options` requests were being sent from passkeys.js with a `null` content type header.
The root cause is that `fetchWithCsrf` is being called with `null` as the contentType argument.

The optional arguments of `fetchWithCsrf` are `contentType` and `body` so in this PR the argument list has been rearranged to put these at the end.

## What is the value of this change and how do we measure success?
This makes calls clearer and avoids inadvertently sending `null` as the `content type` header.
