### PR TITLE
refactor: Improve passkey registration/authentication options

### DIFF
--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -184,6 +184,7 @@ object PasskeyDB {
           )
         )
         .toSeq
+        .sortBy(_.registrationTime)
     } else Nil
 
   /** The device hosting the passkey keeps a count of how many times the passkey


### PR DESCRIPTION
## What is the purpose of this change?
This PR improves the options for registration and authentication to give the browser better information to decide which authenticator to offer for registration or authentication.
Assuming that the first passkey a user registers is likely to be their primary option, we pass that one first in the allowed credentials block to hint to the browser to use that one.
We also suggest using the hints block that on-device should be the first option, followed by security key and then hybrid (mostly phone).

In practice, the browser largely makes its own decisions and uses the OS option if the user is signed into a relevant account.

## What is the value of this change and how do we measure success?
A little more user-friendly and predictable experience.
