### PR TITLE
feat(passkeys): Add opt-in/out routes

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -152,7 +152,13 @@ class AppComponents(context: ApplicationLoader.Context)
       host,
       janusData
     ),
-    new Utility(janusData, controllerComponents, authAction, configuration),
+    new Utility(
+      janusData,
+      controllerComponents,
+      authAction,
+      configuration,
+      passkeysEnablingCookieName
+    ),
     assets
   )
 }

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -139,7 +139,8 @@ class Janus(
         janusData,
         passkeys,
         dateFormat,
-        timeFormat
+        timeFormat,
+        passkeysEnablingCookieName
       )
     }
   }

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -7,11 +7,14 @@ import logic.Owners
 import play.api.mvc.*
 import play.api.{Configuration, Logging, Mode}
 
+import java.time.Duration
+
 class Utility(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
     authAction: AuthAction[AnyContent],
-    configuration: Configuration
+    configuration: Configuration,
+    passkeysEnablingCookieName: String
 )(using mode: Mode, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
@@ -41,5 +44,22 @@ class Utility(
       s"410 response served for request '${request.method} ${request.path}' from user ${request.user.username}"
     )
     Gone(views.html.gone(request.user, janusData))
+  }
+
+  /** Temporary action to opt in to the passkeys integration */
+  def optInToPasskeys: Action[AnyContent] = authAction { _ =>
+    Redirect(routes.Janus.userAccount).withCookies(
+      Cookie(
+        name = passkeysEnablingCookieName,
+        value = "true",
+        maxAge = Some(Duration.ofDays(30).toSeconds.intValue)
+      )
+    )
+  }
+
+  /** Temporary action to opt out of the passkeys integration */
+  def optOutOfPasskeys: Action[AnyContent] = authAction { _ =>
+    Redirect(routes.Janus.userAccount)
+      .discardingCookies(DiscardingCookie(passkeysEnablingCookieName))
   }
 }

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -15,34 +15,35 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <div role="region" aria-labelledby="passkey-status-heading">
-            <h4 id="passkey-status-heading" class="sr-only">Passkey authentication status</h4>
-            @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
-                <p class="green-text" role="status" aria-live="polite">
-                    <i class="material-icons left" aria-hidden="true">check_circle</i>
-                    <span>You are currently opted in to passkey authentication.</span>
-                </p>
-                <a href="@routes.Utility.optOutOfPasskeys"
-                   class="btn red waves-effect waves-light"
-                   role="button"
-                   aria-describedby="passkey-status-heading">
-                    <i class="material-icons left" aria-hidden="true">cancel</i>
-                    <span>Opt out</span>
-                </a>
-            } else {
-                <p class="grey-text" role="status" aria-live="polite">
-                    <i class="material-icons left" aria-hidden="true">info</i>
-                    <span>You are currently opted out of passkey authentication.</span>
-                </p>
-                <a href="@routes.Utility.optInToPasskeys"
-                   class="btn green waves-effect waves-light"
-                   role="button"
-                   aria-describedby="passkey-status-heading">
-                    <i class="material-icons left" aria-hidden="true">check_circle</i>
-                    <span>Opt in</span>
-                </a>
-            }
-        </div>
+        <div class="col s12">
+                <div role="region" id="passkey-status-heading" aria-label="Passkey authentication status">
+                    @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
+                    <div class="card-panel green lighten-4" role="status" aria-live="polite">
+                        <p><i class="material-icons" aria-hidden="true">check_circle</i> You are currently <strong>opted in</strong> to passkey authentication.</p>
+                        <div><a href="@routes.Utility.optOutOfPasskeys"
+                        class="btn red waves-effect waves-light"
+                        role="button"
+                        aria-describedby="passkey-status-heading">
+                            <i class="material-icons left" aria-hidden="true">cancel</i>
+                            <span>Opt out</span>
+                        </a></div>
+                    </div>
+                    } else {
+                    <div class="card-panel grey lighten-4" role="status" aria-live="polite">
+                        <p><i class="material-icons" aria-hidden="true">info</i> You are currently <strong>opted out</strong> of passkey authentication.</p>
+                        <div> 
+                            <a href="@routes.Utility.optInToPasskeys"
+                            class="btn green waves-effect waves-light"
+                            role="button"
+                            aria-describedby="passkey-status-heading">
+                            <i class="material-icons left" aria-hidden="true">check_circle</i>
+                            <span>Opt in</span>
+                            </a>
+                        </div>
+                    </div>               
+                    }
+                </div>
+            </div>
 
         <p>Passkeys are a secure way to authenticate sensitive actions.
             Janus uses them as an extra layer of security to authenticate you before allowing you to access

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -4,7 +4,7 @@
 @import play.api.Mode
 @import java.time.Instant
 
-@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.PasskeyMetadata], dateFormat: Instant => String, timeFormat: Instant => String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeys: Seq[models.PasskeyMetadata], dateFormat: Instant => String, timeFormat: Instant => String, passkeysEnablingCookieName: String)(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("User account", Some(user), janusData) {
 
@@ -15,6 +15,22 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
+        <div class="card-panel">
+        @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
+            <p class="green-text"><i class="material-icons left">check_circle</i>You are currently opted in to passkey authentication.</p>
+            <a href="/opt/out/passkeys" class="btn red waves-effect waves-light">
+                <i class="material-icons left">cancel</i>
+                Opt out
+            </a>
+        } else {
+            <p class="grey-text"><i class="material-icons left">info</i>You are currently opted out of passkey authentication.</p>
+            <a href="/opt/in/passkeys" class="btn green waves-effect waves-light">
+                <i class="material-icons left">check_circle</i>
+                Opt in
+            </a>
+        }
+        </div>
+
         <p>Passkeys are a secure way to authenticate sensitive actions.
             Janus uses them as an extra layer of security to authenticate you before allowing you to access
             AWS credentials or the AWS console.</p>
@@ -23,7 +39,7 @@
             One should be on-device (e.g. Mac Touch ID or Windows Hello)
             and the other off-device (e.g. security key or phone).</p>
 
-        <div class="row">           
+        <div class="row">
             <h4 class="header orange-text">Registered passkeys</h4>
             <div class="col s12">
                 <div class="card-panel">

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -15,20 +15,33 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <div class="card-panel">
-        @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
-            <p class="green-text"><i class="material-icons left">check_circle</i>You are currently opted in to passkey authentication.</p>
-            <a href="@routes.Utility.optOutOfPasskeys" class="btn red waves-effect waves-light">
-                <i class="material-icons left">cancel</i>
-                Opt out
-            </a>
-        } else {
-            <p class="grey-text"><i class="material-icons left">info</i>You are currently opted out of passkey authentication.</p>
-            <a href="@routes.Utility.optInToPasskeys" class="btn green waves-effect waves-light">
-                <i class="material-icons left">check_circle</i>
-                Opt in
-            </a>
-        }
+        <div role="region" aria-labelledby="passkey-status-heading">
+            <h4 id="passkey-status-heading" class="sr-only">Passkey authentication status</h4>
+            @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
+                <p class="green-text" role="status" aria-live="polite">
+                    <i class="material-icons left" aria-hidden="true">check_circle</i>
+                    <span>You are currently opted in to passkey authentication.</span>
+                </p>
+                <a href="@routes.Utility.optOutOfPasskeys"
+                   class="btn red waves-effect waves-light"
+                   role="button"
+                   aria-describedby="passkey-status-heading">
+                    <i class="material-icons left" aria-hidden="true">cancel</i>
+                    <span>Opt out</span>
+                </a>
+            } else {
+                <p class="grey-text" role="status" aria-live="polite">
+                    <i class="material-icons left" aria-hidden="true">info</i>
+                    <span>You are currently opted out of passkey authentication.</span>
+                </p>
+                <a href="@routes.Utility.optInToPasskeys"
+                   class="btn green waves-effect waves-light"
+                   role="button"
+                   aria-describedby="passkey-status-heading">
+                    <i class="material-icons left" aria-hidden="true">check_circle</i>
+                    <span>Opt in</span>
+                </a>
+            }
         </div>
 
         <p>Passkeys are a secure way to authenticate sensitive actions.

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -18,13 +18,13 @@
         <div class="card-panel">
         @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
             <p class="green-text"><i class="material-icons left">check_circle</i>You are currently opted in to passkey authentication.</p>
-            <a href="/opt/out/passkeys" class="btn red waves-effect waves-light">
+            <a href="@routes.Utility.optOutOfPasskeys" class="btn red waves-effect waves-light">
                 <i class="material-icons left">cancel</i>
                 Opt out
             </a>
         } else {
             <p class="grey-text"><i class="material-icons left">info</i>You are currently opted out of passkey authentication.</p>
-            <a href="/opt/in/passkeys" class="btn green waves-effect waves-light">
+            <a href="@routes.Utility.optInToPasskeys" class="btn green waves-effect waves-light">
                 <i class="material-icons left">check_circle</i>
                 Opt in
             </a>

--- a/conf/routes
+++ b/conf/routes
@@ -34,6 +34,10 @@ POST    /passkey/registration-auth-options  controllers.PasskeyController.regist
 POST    /passkey/register                   controllers.PasskeyController.register
 DELETE  /passkey/:passkeyId                 controllers.PasskeyController.deletePasskey(passkeyId: String)
 
+# Tmp routes for passkey trial
+GET     /opt/in/passkeys            controllers.Utility.optInToPasskeys
+GET     /opt/out/passkeys           controllers.Utility.optOutOfPasskeys
+
 GET     /healthcheck                controllers.Utility.healthcheck
 GET     /accounts                   controllers.Utility.accounts
 

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -441,3 +441,15 @@ a.copy-text--button__small {
 .hidden {
     display: none;
 }
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}


### PR DESCRIPTION
## What is the purpose of this change?
@tjsilver and @akash1810 have suggested we should introduce a more user-friendly way to opt in to the passkey authentication integration while it's being trialled.
This change provides new routes to opt in and out, and adds them to the user-account page for convenience.

## What is the value of this change and how do we measure success?
This will avoid people forgetting how to opt in and out if they want to.

## Images
### When opted in
<img width="984" height="359" alt="image" src="https://github.com/user-attachments/assets/65f411bd-eb8b-49c0-9999-a4a53ab956b2" />

### When opted out
<img width="996" height="374" alt="image" src="https://github.com/user-attachments/assets/f5ec012a-f7f6-409c-8cc2-37e6db75e7ad" />

## Any additional notes?
This assumes you know how to get to the user account page, which we should probably link to from the current log-out page eventually.
