### PR TITLE
feat(nav): change user name in nav to point to user account page

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -40,7 +40,7 @@
                             <li><a href="/support">Support</a></li>
                             @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
-                            <li><a href="/logout">@user.firstName @user.lastName</a></li>
+                            <li><a href="/user-account">@user.firstName @user.lastName</a></li>
                         </ul>
 
                         <ul id="nav-mobile" class="sidenav">
@@ -49,7 +49,7 @@
                             @if(isSupportUser(username(user), Instant.now(), janusData.support)) { <li><a href="/support">Support</a></li> }
                             @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
-                            <li><a href="/logout">@user.firstName @user.lastName <i class="material-icons right">power_settings_new</i></a></li>
+                            <li><a href="/user-account">@user.firstName @user.lastName <i class="material-icons right">perm_identity</i></a></li>
                         </ul>
                     }
 


### PR DESCRIPTION
## What is the purpose of this change?

To navigate to the user account page when the user clicks on their name in the navigation. This used to log them out, but straight back in again. The icon on mobile has changed to indicate the change in functionality.

## What is the value of this change and how do we measure success?

The user account page is where passkeys are managed, so linking to this from the user name makes sense.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

### Before (mobile)
<img width="304" height="221" alt="image" src="https://github.com/user-attachments/assets/972dfca8-65f4-462b-92c1-26a3d28bce4d" />


### After (mobile)
<img width="312" height="227" alt="image" src="https://github.com/user-attachments/assets/48800320-b1dd-4dd3-bf86-00fda36c4502" />


## Any additional notes?
It might be worth putting the icon on the page for all media sizes, not just mobile. Would be keen to hear thoughts.
We may be able to remove the logout functionality now altogether as it's largely redundant, but this can be done in a follow-up PR.