### PR TITLE
chore: Review dependencies before merging

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,13 +15,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       # Required because Dependabot Alerts doesn't natively support Scala
-      - uses: guardian/setup-scala@v1
+      - uses: guardian/setup-scala@cc7b39e238d789370aa98fa5f07e609b6527657d # v1.1.0
       - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
       
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# Avoids introducing vulnerable dependencies to the main branch.
+
+name: Dependency review
+on:
+  pull_request:
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # To write dependency submission
+      contents: write
+      # To write comment on PR
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # Required because Dependabot Alerts doesn't natively support Scala
+      - uses: guardian/setup-scala@v1
+      - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always


### PR DESCRIPTION
## What is the purpose of this change?
This change will warn us in advance if we are potentially introducing a vulnerability to the main branch.

## What is the value of this change and how do we measure success?
The workflow will fail if a high level vulnerability is being introduced.

## Any additional notes?
Running as a separate workflow because it only makes sense to run when there are changes to a pull request.

If successful, could auto-add to other repos.

See ['Dependency Review' comment](https://github.com/guardian/janus-app/pull/666#issuecomment-3187517197) below for output.