### PR TITLE
feat(passkeys): Support password manager browser extensions

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -96,6 +96,7 @@ class AppComponents(context: ApplicationLoader.Context)
     PasskeyAuthenticator.fromResource(
       "passkeys_aaguid_descriptions.json"
     )
+  private val passwordManagers = Set("LastPass")
 
   private val passkeysEnabled: Boolean =
     configuration
@@ -141,7 +142,12 @@ class AppComponents(context: ApplicationLoader.Context)
       host,
       janusData,
       passkeysEnabled,
-      passkeysEnablingCookieName
+      passkeysEnablingCookieName,
+      passkeyAuthenticatorMetadata.collect {
+        case (aaguid, authenticator)
+            if passwordManagers.contains(authenticator.description) =>
+          aaguid
+      }.toSet
     ),
     new Audit(janusData, controllerComponents, authAction),
     new RevokePermissions(

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -55,4 +55,24 @@ class Utility(
     Redirect(routes.Janus.userAccount)
       .discardingCookies(DiscardingCookie(passkeysEnablingCookieName))
   }
+
+  /** Test endpoint for passkey autofill behavior - INSECURE, for testing only
+    */
+  def testPasskeyAutofill: Action[AnyContent] = Action { implicit request =>
+    Ok(views.html.testPasskeyAutofill())
+  }
+
+  /** Test endpoint for button-triggered passkey behavior - INSECURE, for
+    * testing only
+    */
+  def testPasskeyButton: Action[AnyContent] = Action { implicit request =>
+    Ok(views.html.testPasskeyButton())
+  }
+
+  /** Test endpoint for passkey creation on page load - INSECURE, for testing
+    * only
+    */
+  def testPasskeyCreate: Action[AnyContent] = Action { implicit request =>
+    Ok(views.html.testPasskeyCreate())
+  }
 }

--- a/app/views/testPasskeyAutofill.scala.html
+++ b/app/views/testPasskeyAutofill.scala.html
@@ -1,0 +1,151 @@
+@import views.html.helper.CSPNonce
+
+@()(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Passkey Autofill</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .status {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .info { background-color: #e3f2fd; }
+        .success { background-color: #e8f5e9; }
+        .error { background-color: #ffebee; }
+        pre {
+            background-color: #f5f5f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+    <h1>Test Passkey Autofill</h1>
+    <p>This page triggers navigator.credentials.get on page load to test passkey autofill behavior.</p>
+
+    <div id="status" class="status info">Initializing...</div>
+
+    <h2>Logs:</h2>
+    <pre id="logs"></pre>
+
+    <script @{CSPNonce.attr}>
+        const statusEl = document.getElementById('status');
+        const logsEl = document.getElementById('logs');
+
+        function log(message) {
+            const timestamp = new Date().toISOString();
+            logsEl.textContent += `[${timestamp}] ${message}\n`;
+            console.log(message);
+        }
+
+        function updateStatus(message, type = 'info') {
+            statusEl.textContent = message;
+            statusEl.className = `status ${type}`;
+        }
+
+        // Generate a random challenge (32 bytes) and convert to Uint8Array
+        function generateChallenge() {
+            const array = new Uint8Array(32);
+            crypto.getRandomValues(array);
+            return array;
+        }
+
+        async function testCredentialGet() {
+            log('Page loaded, starting credential.get test...');
+            log('User Agent: ' + navigator.userAgent);
+            updateStatus('Testing navigator.credentials.get...', 'info');
+
+            try {
+                // Check if WebAuthn is supported
+                if (!window.PublicKeyCredential) {
+                    throw new Error('WebAuthn is not supported in this browser');
+                }
+                log('WebAuthn API is available');
+
+                // Create a proper authentication request with random challenge
+                const challenge = generateChallenge();
+                const publicKeyCredentialRequestOptions = {
+                    challenge: challenge,
+                    timeout: 60000,
+                    userVerification: 'preferred',
+                    // Don't specify rpId - let browser use current domain
+                    // rpId: window.location.hostname,
+                };
+
+                log('Calling navigator.credentials.get with options:');
+                log(JSON.stringify({
+                    challenge: `Uint8Array(32) [${Array.from(challenge.slice(0, 4)).join(', ')}...]`,
+                    timeout: publicKeyCredentialRequestOptions.timeout,
+                    userVerification: publicKeyCredentialRequestOptions.userVerification,
+                    rpId: publicKeyCredentialRequestOptions.rpId || '(browser default)',
+                }, null, 2));
+
+                log('Waiting for user interaction with passkey prompt...');
+                updateStatus('Passkey prompt shown - waiting for user action...', 'info');
+
+                // Set a timeout to log progress
+                const progressInterval = setInterval(() => {
+                    log('Still waiting for credentials.get to resolve...');
+                }, 5000);
+
+                const credential = await navigator.credentials.get({
+                    publicKey: publicKeyCredentialRequestOptions
+                });
+
+                clearInterval(progressInterval);
+
+                if (credential) {
+                    log('✅ Credential received!');
+                    log(`Credential ID: ${credential.id}`);
+                    log(`Credential Type: ${credential.type}`);
+                    log(`Credential rawId length: ${credential.rawId.byteLength} bytes`);
+                    if (credential.response) {
+                        log(`Response authenticatorData length: ${credential.response.authenticatorData?.byteLength || 'N/A'} bytes`);
+                        log(`Response signature length: ${credential.response.signature?.byteLength || 'N/A'} bytes`);
+                    }
+                    updateStatus('✅ Success! Credential received.', 'success');
+                } else {
+                    log('⚠️ No credential returned (user likely cancelled)');
+                    updateStatus('No credential returned', 'info');
+                }
+            } catch (error) {
+                log(`❌ Error: ${error.name} - ${error.message}`);
+
+                // Log specific error types
+                if (error.name === 'NotAllowedError') {
+                    log('This usually means: user cancelled, timeout, or no passkeys registered for this domain');
+                } else if (error.name === 'SecurityError') {
+                    log('This usually means: invalid rpId or HTTPS requirement not met');
+                } else if (error.name === 'AbortError') {
+                    log('This usually means: request was aborted');
+                } else if (error.name === 'NotSupportedError') {
+                    log('This usually means: WebAuthn not supported or feature disabled');
+                }
+
+                log(`Full error stack: ${error.stack || 'No stack trace'}`);
+                updateStatus(`❌ Error: ${error.name} - ${error.message}`, 'error');
+            }
+        }
+
+        // Run the test when the page loads
+        window.addEventListener('DOMContentLoaded', () => {
+            log('DOMContentLoaded event fired');
+            log('Starting test in 1 second...');
+            // Small delay to ensure page is fully loaded
+            setTimeout(testCredentialGet, 1000);
+        });
+    </script>
+</body>
+</html>

--- a/app/views/testPasskeyButton.scala.html
+++ b/app/views/testPasskeyButton.scala.html
@@ -1,0 +1,203 @@
+@import views.html.helper.CSPNonce
+
+@()(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Passkey Button</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .status {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .info { background-color: #e3f2fd; }
+        .success { background-color: #e8f5e9; }
+        .error { background-color: #ffebee; }
+        .warning { background-color: #fff3e0; }
+        pre {
+            background-color: #f5f5f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+        .button-container {
+            margin: 20px 0;
+        }
+        button {
+            background-color: #2196F3;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            font-size: 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: background-color 0.3s;
+        }
+        button:hover:not(:disabled) {
+            background-color: #1976D2;
+        }
+        button:disabled {
+            background-color: #BDBDBD;
+            cursor: not-allowed;
+        }
+    </style>
+</head>
+<body>
+    <h1>Test Passkey Button</h1>
+    <p>This page has a button that triggers navigator.credentials.get when clicked.</p>
+
+    <div class="button-container">
+        <button id="testButton">Click to Test Passkey</button>
+    </div>
+
+    <div id="status" class="status info">Ready. Click the button to start the test.</div>
+
+    <h2>Logs:</h2>
+    <pre id="logs"></pre>
+
+    <script @{CSPNonce.attr}>
+        const statusEl = document.getElementById('status');
+        const logsEl = document.getElementById('logs');
+        const testButton = document.getElementById('testButton');
+
+        function log(message) {
+            const timestamp = new Date().toISOString();
+            logsEl.textContent += `[${timestamp}] ${message}\n`;
+            console.log(message);
+        }
+
+        function updateStatus(message, type = 'info') {
+            statusEl.textContent = message;
+            statusEl.className = `status ${type}`;
+        }
+
+        // Generate a random challenge (32 bytes) and convert to Uint8Array
+        function generateChallenge() {
+            const array = new Uint8Array(32);
+            crypto.getRandomValues(array);
+            return array;
+        }
+
+        async function testCredentialGet() {
+            log('Button clicked, starting credential.get test...');
+            log('User Agent: ' + navigator.userAgent);
+            log('Browser: ' + (navigator.userAgent.includes('Firefox') ? 'Firefox' :
+                              navigator.userAgent.includes('Safari') ? 'Safari' :
+                              navigator.userAgent.includes('Chrome') ? 'Chrome' : 'Other'));
+            updateStatus('Testing navigator.credentials.get...', 'info');
+
+            // Disable button during test
+            testButton.disabled = true;
+            testButton.textContent = 'Testing...';
+
+            try {
+                // Check if WebAuthn is supported
+                if (!window.PublicKeyCredential) {
+                    throw new Error('WebAuthn is not supported in this browser');
+                }
+                log('✅ WebAuthn API is available');
+
+                // Check if conditional mediation is available (for debugging)
+                if (window.PublicKeyCredential.isConditionalMediationAvailable) {
+                    const conditionalAvailable = await PublicKeyCredential.isConditionalMediationAvailable();
+                    log(`Conditional mediation available: ${conditionalAvailable}`);
+                }
+
+                // Create a proper authentication request with random challenge
+                const challenge = generateChallenge();
+                const publicKeyCredentialRequestOptions = {
+                    challenge: challenge,
+                    timeout: 60000,
+                    userVerification: 'preferred',
+                    // Don't specify rpId - let browser use current domain
+                };
+
+                log('Options prepared:');
+                log(JSON.stringify({
+                    challenge: `Uint8Array(32) [${Array.from(challenge.slice(0, 4)).join(', ')}...]`,
+                    timeout: publicKeyCredentialRequestOptions.timeout,
+                    userVerification: publicKeyCredentialRequestOptions.userVerification,
+                    rpId: publicKeyCredentialRequestOptions.rpId || '(browser default - current origin)',
+                }, null, 2));
+
+                log('🚀 Calling navigator.credentials.get (MODAL UI)...');
+                updateStatus('Calling credentials.get...', 'info');
+
+                // IMPORTANT: Call credentials.get immediately to preserve user gesture
+                // Firefox is strict - any delay can cause AbortError
+                const credentialPromise = navigator.credentials.get({
+                    publicKey: publicKeyCredentialRequestOptions
+                    // NO mediation property - this will use modal UI, not conditional/autofill
+                });
+
+                log('✅ credentials.get called successfully');
+                log('Waiting for user interaction with passkey prompt...');
+                updateStatus('Passkey prompt shown - waiting for user action...', 'info');
+
+                // Set a timeout to log progress
+                const progressInterval = setInterval(() => {
+                    log('Still waiting for credentials.get to resolve...');
+                }, 5000);
+
+                const credential = await credentialPromise;
+
+                clearInterval(progressInterval);
+
+                if (credential) {
+                    log('✅ Credential received!');
+                    log(`Credential ID: ${credential.id}`);
+                    log(`Credential Type: ${credential.type}`);
+                    log(`Credential rawId length: ${credential.rawId.byteLength} bytes`);
+                    if (credential.response) {
+                        log(`Response authenticatorData length: ${credential.response.authenticatorData?.byteLength || 'N/A'} bytes`);
+                        log(`Response signature length: ${credential.response.signature?.byteLength || 'N/A'} bytes`);
+                    }
+                    updateStatus('✅ Success! Credential received.', 'success');
+                } else {
+                    log('⚠️ No credential returned (user likely cancelled)');
+                    updateStatus('No credential returned', 'warning');
+                }
+            } catch (error) {
+                log(`❌ Error: ${error.name} - ${error.message}`);
+
+                // Log specific error types
+                if (error.name === 'NotAllowedError') {
+                    log('This usually means: user cancelled, timeout, or no passkeys registered for this domain');
+                } else if (error.name === 'SecurityError') {
+                    log('This usually means: invalid rpId or HTTPS requirement not met');
+                } else if (error.name === 'AbortError') {
+                    log('This usually means: request was aborted');
+                } else if (error.name === 'NotSupportedError') {
+                    log('This usually means: WebAuthn not supported or feature disabled');
+                }
+
+                log(`Full error stack: ${error.stack || 'No stack trace'}`);
+                updateStatus(`❌ Error: ${error.name} - ${error.message}`, 'error');
+            } finally {
+                // Re-enable button after test
+                testButton.disabled = false;
+                testButton.textContent = 'Click to Test Passkey';
+            }
+        }
+
+        // Add click event listener to button
+        testButton.addEventListener('click', testCredentialGet);
+
+        // Log when page is ready
+        window.addEventListener('DOMContentLoaded', () => {
+            log('Page loaded and ready');
+            log('Click the button above to trigger credentials.get');
+        });
+    </script>
+</body>
+</html>

--- a/app/views/testPasskeyCreate.scala.html
+++ b/app/views/testPasskeyCreate.scala.html
@@ -1,0 +1,239 @@
+@import views.html.helper.CSPNonce
+
+@()(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Passkey Create</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        .status {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .info { background-color: #e3f2fd; }
+        .success { background-color: #e8f5e9; }
+        .error { background-color: #ffebee; }
+        .warning { background-color: #fff3e0; }
+        pre {
+            background-color: #f5f5f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+    <h1>Test Passkey Create</h1>
+    <p>This page triggers navigator.credentials.create on page load to test passkey registration.</p>
+
+    <div id="status" class="status info">Initializing...</div>
+
+    <h2>Logs:</h2>
+    <pre id="logs"></pre>
+
+    <script @{CSPNonce.attr}>
+        const statusEl = document.getElementById('status');
+        const logsEl = document.getElementById('logs');
+
+        function log(message) {
+            const timestamp = new Date().toISOString();
+            logsEl.textContent += `[${timestamp}] ${message}\n`;
+            console.log(message);
+        }
+
+        function updateStatus(message, type = 'info') {
+            statusEl.textContent = message;
+            statusEl.className = `status ${type}`;
+        }
+
+        // Generate a random challenge (32 bytes) and convert to Uint8Array
+        function generateChallenge() {
+            const array = new Uint8Array(32);
+            crypto.getRandomValues(array);
+            return array;
+        }
+
+        // Generate a random user ID
+        function generateUserId() {
+            const array = new Uint8Array(16);
+            crypto.getRandomValues(array);
+            return array;
+        }
+
+        async function testCredentialCreate() {
+            log('Page loaded, starting credential.create test...');
+            log('User Agent: ' + navigator.userAgent);
+            log('Browser: ' + (navigator.userAgent.includes('Firefox') ? 'Firefox' :
+                              navigator.userAgent.includes('Safari') ? 'Safari' :
+                              navigator.userAgent.includes('Chrome') ? 'Chrome' : 'Other'));
+            updateStatus('Testing navigator.credentials.create...', 'info');
+
+            try {
+                // Check if WebAuthn is supported
+                if (!window.PublicKeyCredential) {
+                    throw new Error('WebAuthn is not supported in this browser');
+                }
+                log('✅ WebAuthn API is available');
+
+                // Create a proper registration request
+                const challenge = generateChallenge();
+                const userId = generateUserId();
+                const userName = 'test-user-' + Date.now();
+                const userDisplayName = 'Test User';
+
+                const publicKeyCredentialCreationOptions = {
+                    challenge: challenge,
+                    rp: {
+                        name: 'Janus Test',
+                        // id will default to current domain
+                    },
+                    user: {
+                        id: userId,
+                        name: userName,
+                        displayName: userDisplayName,
+                    },
+                    pubKeyCredParams: [
+                        { alg: -7, type: 'public-key' },  // ES256
+                        { alg: -257, type: 'public-key' }, // RS256
+                    ],
+                    authenticatorSelection: {
+                        authenticatorAttachment: 'platform',
+                        userVerification: 'preferred',
+                        residentKey: 'preferred',
+                    },
+                    timeout: 60000,
+                    attestation: 'none',
+                };
+
+                log('Options prepared:');
+                log(JSON.stringify({
+                    challenge: `Uint8Array(32) [${Array.from(challenge.slice(0, 4)).join(', ')}...]`,
+                    rp: publicKeyCredentialCreationOptions.rp,
+                    user: {
+                        id: `Uint8Array(16) [${Array.from(userId.slice(0, 4)).join(', ')}...]`,
+                        name: userName,
+                        displayName: userDisplayName,
+                    },
+                    pubKeyCredParams: publicKeyCredentialCreationOptions.pubKeyCredParams,
+                    authenticatorSelection: publicKeyCredentialCreationOptions.authenticatorSelection,
+                    timeout: publicKeyCredentialCreationOptions.timeout,
+                    attestation: publicKeyCredentialCreationOptions.attestation,
+                }, null, 2));
+
+                log('');
+                log('🚀 Calling navigator.credentials.create...');
+                updateStatus('Calling credentials.create...', 'info');
+
+                // Detect if credentials API has been overridden
+                if (window.__nativeCredentialsCreate) {
+                    log('⚠️ WARNING: Credentials API has been overridden by extension');
+                    log('ℹ️ Using __nativeCredentialsCreate to bypass extension override');
+                }
+
+                log('Waiting for user interaction with passkey creation prompt...');
+                updateStatus('Passkey creation prompt shown - waiting for user action...', 'info');
+
+                // Set a timeout to log progress
+                const progressInterval = setInterval(() => {
+                    log('Still waiting for credentials.create to resolve...');
+                }, 5000);
+
+                // Use native API if available to bypass extension interference
+                // const credentialsAPI = window.__nativeCredentialsCreate || navigator.credentials.create.bind(navigator.credentials);
+                const credentialsAPI = navigator.credentials.create;
+
+                const credential = await credentialsAPI({
+                    publicKey: publicKeyCredentialCreationOptions
+                });
+
+                clearInterval(progressInterval);
+
+                if (credential) {
+                    log('✅ Credential created!');
+                    log(`Credential ID: ${credential.id}`);
+                    log(`Credential Type: ${credential.type}`);
+                    log(`Credential rawId length: ${credential.rawId.byteLength} bytes`);
+                    log(`Authenticator Attachment: ${credential.authenticatorAttachment || 'not specified'}`);
+                    if (credential.response) {
+                        log(`Response attestationObject length: ${credential.response.attestationObject?.byteLength || 'N/A'} bytes`);
+                        log(`Response clientDataJSON length: ${credential.response.clientDataJSON?.byteLength || 'N/A'} bytes`);
+
+                        // Parse and log client data
+                        try {
+                            const clientDataJSON = JSON.parse(
+                                new TextDecoder().decode(credential.response.clientDataJSON)
+                            );
+                            log(`Client Data: ${JSON.stringify(clientDataJSON, null, 2)}`);
+                        } catch (e) {
+                            log('Could not parse client data JSON');
+                        }
+                    }
+                    updateStatus('✅ Success! Passkey created.', 'success');
+                } else {
+                    log('⚠️ No credential returned (user likely cancelled)');
+                    updateStatus('No credential returned', 'warning');
+                }
+            } catch (error) {
+                log(`❌ Error: ${error.name} - ${error.message}`);
+
+                // Log specific error types
+                if (error.name === 'NotAllowedError') {
+                    log('This usually means: user cancelled or not allowed by browser');
+                } else if (error.name === 'SecurityError') {
+                    log('This usually means: invalid rpId or HTTPS requirement not met');
+                } else if (error.name === 'AbortError') {
+                    log('This usually means: request was aborted');
+                    log('');
+                    log('🔍 DEBUGGING:');
+                    if (window.__nativeCredentialsCreate || window.__nativeCredentialsGet) {
+                        log('   Extension detected - try disabling browser extensions');
+                    }
+                    log('   1. Test in Firefox/Chrome Private Window');
+                    log('   2. Disable password manager extensions');
+                    log('   3. Try a fresh browser profile');
+                } else if (error.name === 'NotSupportedError') {
+                    log('This usually means: WebAuthn not supported or feature disabled');
+                } else if (error.name === 'InvalidStateError') {
+                    log('This usually means: authenticator already contains a credential for this user');
+                    log('This is normal if you have already registered on this device');
+                }
+
+                log('');
+                log(`Full error stack: ${error.stack || 'No stack trace'}`);
+                updateStatus(`❌ Error: ${error.name} - ${error.message}`, 'error');
+            }
+        }
+
+        // Run the test when the page loads
+        window.addEventListener('DOMContentLoaded', () => {
+            log('DOMContentLoaded event fired');
+            log('');
+
+            // Check if credentials API has been overridden by extension or library
+            if (window.__nativeCredentialsGet || window.__nativeCredentialsCreate) {
+                log('⚠️ WARNING: Credentials API has been overridden!');
+                log('Detected: window.__nativeCredentialsGet = ' + (!!window.__nativeCredentialsGet));
+                log('Detected: window.__nativeCredentialsCreate = ' + (!!window.__nativeCredentialsCreate));
+                log('');
+                log('This is likely caused by a browser extension (password manager, etc.)');
+                log('The test will use the native API to bypass the override.');
+                log('');
+            }
+
+            log('Starting test in 1 second...');
+            // Small delay to ensure page is fully loaded
+            setTimeout(testCredentialCreate, 1000);
+        });
+    </script>
+</body>
+</html>

--- a/conf/routes
+++ b/conf/routes
@@ -43,6 +43,9 @@ DELETE  /passkey/:passkeyId                 controllers.PasskeyController.delete
 # Tmp routes for passkey trial
 GET     /opt/in/passkeys            controllers.Utility.optInToPasskeys
 GET     /opt/out/passkeys           controllers.Utility.optOutOfPasskeys
+GET     /test/passkey-autofill      controllers.Utility.testPasskeyAutofill
+GET     /test/passkey-button        controllers.Utility.testPasskeyButton
+GET     /test/passkey-create        controllers.Utility.testPasskeyCreate
 
 GET     /healthcheck                controllers.Utility.healthcheck
 GET     /accounts                   controllers.Utility.accounts

--- a/frontend/utils/passkeys.js
+++ b/frontend/utils/passkeys.js
@@ -191,9 +191,8 @@ const passkeyApi = {
       console.debug("Use autofill UI: ", useAutofill);
 
       const credentialsGet = useAutofill
-        ? navigator.credentials.get.bind(navigator.credentials) // Use regular API for autofill
-        : window.__nativeCredentialsGet ||
-          navigator.credentials.get.bind(navigator.credentials);
+        ? navigator.credentials.get.bind(navigator.credentials)
+        : window.__nativeCredentialsGet;
 
       const credentials = await credentialsGet({
         publicKey: authOptions,

--- a/frontend/utils/passkeys.js
+++ b/frontend/utils/passkeys.js
@@ -166,8 +166,12 @@ const passkeyApi = {
 
   async getUserCredential(authOptionsJson) {
     try {
+      console.debug("Auth options JSON: ", authOptionsJson);
+
       const authOptions =
         PublicKeyCredential.parseRequestOptionsFromJSON(authOptionsJson);
+
+      console.debug("Auth options: ", authOptions);
 
       /* LastPass binds its own code to the credentials get call,
        * which fails in certain cases.
@@ -181,9 +185,12 @@ const passkeyApi = {
         authOptionsJson.enablePasswordManagers,
       );
       const credentialsGet =
-        extensionDetected && !authOptionsJson.enablePasswordManagers
+        !!window.__nativeCredentialsGet &&
+        !authOptionsJson.enablePasswordManagers
           ? window.__nativeCredentialsGet
           : navigator.credentials.get.bind(navigator.credentials);
+
+      console.debug("Calling credentials get...");
 
       return await credentialsGet({
         publicKey: authOptions,
@@ -191,6 +198,8 @@ const passkeyApi = {
     } catch (err) {
       if (err.name === "AbortError") {
         console.debug("Modal UI was aborted (possibly by autofill UI)");
+        const extensionDetected = !!window.__nativeCredentialsGet;
+        console.debug("Browser extension detected: ", extensionDetected);
         return null;
       } else if (err.name === "NotAllowedError") {
         console.debug(

--- a/frontend/utils/passkeys.js
+++ b/frontend/utils/passkeys.js
@@ -255,7 +255,7 @@ function normaliseCredentialJson(obj) {
     } else if (value && typeof value === "object") {
       normalised[key] = normaliseCredentialJson(value);
     } else if (value && typeof value === "function") {
-      // ignore
+      // Skip function properties as they cannot be serialized to JSON
     } else {
       normalised[key] = value;
     }

--- a/frontend/utils/passkeys.js
+++ b/frontend/utils/passkeys.js
@@ -423,7 +423,7 @@ export async function authenticatePasskey(targetHref, csrfToken) {
         csrfToken: csrfToken,
       });
     } else {
-      console.error("No passkey chosen");
+      console.error("Passkey authentication cancelled or no credential selected");
     }
   } catch (err) {
     passkeyApi.handlePasskeyError(err, "authentication");

--- a/frontend/utils/passkeys.js
+++ b/frontend/utils/passkeys.js
@@ -423,7 +423,9 @@ export async function authenticatePasskey(targetHref, csrfToken) {
         csrfToken: csrfToken,
       });
     } else {
-      console.error("Passkey authentication cancelled or no credential selected");
+      console.error(
+        "Passkey authentication cancelled or no credential selected",
+      );
     }
   } catch (err) {
     passkeyApi.handlePasskeyError(err, "authentication");

--- a/test/logic/PasskeyTest.scala
+++ b/test/logic/PasskeyTest.scala
@@ -135,12 +135,14 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
       )
       val challenge = new DefaultChallenge("challenge".getBytes(UTF_8))
       val emptyPasskeys = Seq.empty[PasskeyMetadata]
+      val passwordManagerAaguids = Set.empty[AAGUID]
 
       val options = Passkey.authenticationOptions(
         appHost,
         testUser,
         challenge,
-        emptyPasskeys
+        emptyPasskeys,
+        passwordManagerAaguids
       )
       val json = PasskeyEncodings.mapper
         .writerWithDefaultPrettyPrinter()
@@ -153,7 +155,8 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
           |  "allowCredentials" : [ ],
           |  "userVerification" : "required",
           |  "hints" : [ "client-device", "security-key", "hybrid" ],
-          |  "extensions" : null
+          |  "extensions" : null,
+          |  "enablePasswordManagers" : false
           |}""".stripMargin
     }
 
@@ -178,12 +181,14 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
           authenticator = None
         )
       )
+      val passwordManagerAaguids = Set.empty[AAGUID]
 
       val options = Passkey.authenticationOptions(
         appHost,
         testUser,
         challenge,
-        existingPasskeys
+        existingPasskeys,
+        passwordManagerAaguids
       )
       val json = PasskeyEncodings.mapper
         .writerWithDefaultPrettyPrinter()
@@ -199,7 +204,8 @@ class PasskeyTest extends AnyFreeSpec with should.Matchers with EitherValues {
           |  } ],
           |  "userVerification" : "required",
           |  "hints" : [ "client-device", "security-key", "hybrid" ],
-          |  "extensions" : null
+          |  "extensions" : null,
+          |  "enablePasswordManagers" : false
           |}""".stripMargin
     }
   }


### PR DESCRIPTION
## What is the purpose of this change?
This change enables passkeys to be authenticated by and stored in password managers, as well as the native options provided by the OS and the browser currently.

### Conditions for changed experience
1. A password manager extension is enabled in the browser
2. The user is signed into the password manager
3. They have a passkey for Janus stored in it

### The changed experience
At registration and authentication time, an autofill UI dialog provided by the password manager appears top right instead of the native modal dialog.  (If multiple password managers are installed, a dialog supplied by one of them opens.  I'm not sure what the rules of precedence are here.)

## What is the value of this change and how do we measure success?
Users can be provided with an org-managed password manager extension to make it easier to provide passkeys.

> [!CAUTION]
> Not all password managers respect the [user verification options of the WebAuthn spec](https://web.dev/articles/webauthn-user-verification) without further configuration.  Even though the authentication response they send to the server for verification claims that user verification took place.
 
## To Test

There are many scenarios but these are the important ones:

| Test | Local Chrome | Local Firefox | Local Safari | Prod Chrome | Prod Firefox | Prod Safari |
|-----|---------|--------|-------|-------|-------|-------|
| Sent straight through to target when opted out of passkeys feature | ✅ | ✅ | ✅ |
| Registered new passkey from password manager | ✅ | ✅ | ✅ |
| Registered new Yubikey passkey | ✅ | ✅ | ✅ |
| Registered new Yubikey passkey when passkey from password manager already registered | ✅ | ✅ | ✅ |
| Authenticated with passkey from password manager | ✅ | ✅ | ✅ |
| Authenticated with Yubikey | ✅ | ✅ | ✅ |
| Authenticated with Yubikey when no password manager enabled | ✅ | ✅ | ✅ |
| Authenticated with Yubikey when password manager enabled but has no passkey for domain | ✅ | ✅ | ✅ |
| Redirected to user account page when no passkeys registered | ✅ | ✅ | ✅ |
