### PR TITLE
Add session tags to role assumption

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -33,6 +33,9 @@ object Federation {
 
   private val awsMinimumSessionLength = 900.seconds
 
+  private val usernameTagKey = "gu:janus:user"
+  private val permissionTagKey = "gu:janus:permission"
+
   private val signInUrl = "https://signin.aws.amazon.com/federation"
   private val consoleUrl = "https://console.aws.amazon.com/"
 
@@ -100,6 +103,16 @@ object Federation {
       .roleArn(roleArn)
       .roleSessionName(username)
       .durationSeconds(duration.getSeconds.toInt)
+      .tags(
+        // these tags are added to the assumed session
+        Tag.builder().key(usernameTagKey).value(username).build(),
+        Tag.builder().key(permissionTagKey).value(permission.id).build()
+      )
+      .transitiveTagKeys(
+        // these tags persist through chained role assumption to preserve governance information
+        usernameTagKey,
+        permissionTagKey
+      )
     permission.policy.foreach { policy =>
       requestBuilder.policy(policy)
     }


### PR DESCRIPTION

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Adds tags to the assumed STS session for Janus users, that document the username and permission ID. These tags are marked as "transitive", which means they will also be propogated through subsequent role assumptions.

This adds a few useful benefits:

### Governance

These tags embed useful Janus information into the session, which means the username and permission will be clearly visible in AWS' native security and auditing tooling

### Access control

These tags can be used to enforce tag based access control, which can provide an extra layer of security to operations that should be locked down to a specific permission. If a team wants to be sure that only a specific permission can grant access to a resource in AWS, they'll be able to use the new `gu:janus:permission` tag in an IAM condition. This allows teams to demand explicit access to a resource.

## What is the value of this change and how do we measure success?

This won't make any difference for normal use but will improve incident response and offers teams additional protections.

