### PR TITLE
Redo "Add session tags to role assumption"

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -33,6 +33,9 @@ object Federation {
 
   private val awsMinimumSessionLength = 900.seconds
 
+  private val usernameTagKey = "gu:janus:user"
+  private val permissionTagKey = "gu:janus:permission"
+
   private val signInUrl = "https://signin.aws.amazon.com/federation"
   private val consoleUrl = "https://console.aws.amazon.com/"
 
@@ -100,6 +103,16 @@ object Federation {
       .roleArn(roleArn)
       .roleSessionName(username)
       .durationSeconds(duration.getSeconds.toInt)
+      .tags(
+        // these tags are added to the assumed session
+        Tag.builder().key(usernameTagKey).value(username).build(),
+        Tag.builder().key(permissionTagKey).value(permission.id).build()
+      )
+      .transitiveTagKeys(
+        // these tags persist through chained role assumption to preserve governance information
+        usernameTagKey,
+        permissionTagKey
+      )
     permission.policy.foreach { policy =>
       requestBuilder.policy(policy)
     }


### PR DESCRIPTION
Redoes guardian/janus-app#823

(by reverting guardian/janus-app#828)

Adds tags to the assumed STS session for Janus users, that document the username and permission ID. These tags are marked as "transitive", which means they will also be propogated through subsequent role assumptions.

The benefits are listed in #823, so the additional information is:

This has been tested in detail locally, after these changes:
https://github.com/guardian/janus/pull/5428
https://github.com/guardian/janus/pull/5437

I've also tested this on-instance with the following CLI command (substituting an appropriate role for assumption):

```
aws sts assume-role --role-arn "arn:aws:iam::012345678910:role/federation/role-xxx" --role-session-name "TagsTest" --tags Key="gu:janus:test",Value="test"
```

This call failed before the StackSet update, and now succeeds, using the real instance profile and a real integration stack from the stackset.

I think this is now ready to be (carefully) released.
