### PR TITLE
refactor: Remove fallback parsing method for old Developer Policies

### DIFF
--- a/app/logic/DeveloperPolicies.scala
+++ b/app/logic/DeveloperPolicies.scala
@@ -18,18 +18,6 @@ object DeveloperPolicies {
   private val DeveloperPolicyPath: Regex =
     """/developer-policy/(guardian/[^\s/]+)/([^\s/]+)/([^\s/]+)/([^\s/]+)/""".r
 
-  /** A temporary solution while we have two forms of managed policy to parse.
-    * This can be removed when all developer policies are built using GuCDK
-    * v63.1.0 or equivalent.
-    */
-  def toDeveloperPolicyWithFallback(
-      account: AwsAccount,
-      policy: Policy
-  ): Option[DeveloperPolicy] =
-    toDeveloperPolicy(account, policy).orElse(
-      toDeveloperPolicyFromOldPolicy(account, policy)
-    )
-
   /** Creates a DeveloperPolicy from an AWS IAM managed policy if it's possible.
     *
     * @param account
@@ -53,26 +41,6 @@ object DeveloperPolicies {
       stackName,
       stage,
       friendlyName,
-      account
-    )
-
-  private[logic] def toDeveloperPolicyFromOldPolicy(
-      account: AwsAccount,
-      policy: Policy
-  ): Option[DeveloperPolicy] =
-    /* Old AWS managed policy path structure was:
-     * /developer-policy/<grant-id>/
-     */
-    for {
-      policyGrantId <- policy.path.split('/').lift(2)
-    } yield DeveloperPolicy(
-      policyArnString = policy.arn,
-      policyName = policy.policyName,
-      policyGrantId,
-      sourceRepo = "guardian/unknown",
-      stack = "unknown",
-      stage = "unknown",
-      friendlyName = Option(policy.description).getOrElse("unknown"),
       account
     )
 

--- a/app/services/DeveloperPolicyCachingService.scala
+++ b/app/services/DeveloperPolicyCachingService.scala
@@ -165,10 +165,7 @@ class DeveloperPolicyCachingService(
     for {
       awsPolicy <- Iam.getPolicyDetails(iam, summary)
       policy <- IO.fromOption(
-        DeveloperPolicies.toDeveloperPolicyWithFallback(
-          account,
-          awsPolicy
-        )
+        DeveloperPolicies.toDeveloperPolicy(account, awsPolicy)
       )(
         new Exception(
           s"Policy path doesn't contain developer policy ID at expected position in IAM policy ${awsPolicy.arn}"

--- a/test/logic/DeveloperPoliciesTest.scala
+++ b/test/logic/DeveloperPoliciesTest.scala
@@ -5,8 +5,6 @@ import logic.DeveloperPolicies.{
   DEVELOPER_POLICY_NAMESPACE_PREFIX,
   developerPolicySlug,
   toDeveloperPolicy,
-  toDeveloperPolicyFromOldPolicy,
-  toDeveloperPolicyWithFallback,
   toPermission
 }
 import models.*
@@ -121,101 +119,6 @@ class DeveloperPoliciesTest
         .build()
 
       toDeveloperPolicy(account, policy) shouldBe None
-    }
-  }
-
-  "toDeveloperPolicyFromOldPolicy" - {
-    "should return a DeveloperPolicy using the third path segment as the grant ID" in {
-      val oldPolicy = Policy
-        .builder()
-        .arn("arn:aws:iam::123:policy/developer-policy/old-grant-id/p1")
-        .path("/developer-policy/old-grant-id/")
-        .policyName("p1")
-        .description("Old description")
-        .build()
-
-      val result = toDeveloperPolicyFromOldPolicy(account, oldPolicy)
-
-      result.value shouldBe DeveloperPolicy(
-        policyArnString =
-          "arn:aws:iam::123:policy/developer-policy/old-grant-id/p1",
-        policyName = "p1",
-        policyGrantId = "old-grant-id",
-        sourceRepo = "guardian/unknown",
-        stack = "unknown",
-        stage = "unknown",
-        friendlyName = "Old description",
-        account
-      )
-    }
-
-    "should use 'unknown' as description when description is null" in {
-      val oldPolicy = Policy
-        .builder()
-        .arn("arn:aws:iam::123:policy/developer-policy/grant-x/pol")
-        .path("/developer-policy/grant-x/")
-        .policyName("pol")
-        .build()
-
-      val result = toDeveloperPolicyFromOldPolicy(account, oldPolicy)
-
-      result.value.friendlyName shouldBe "unknown"
-    }
-
-    "should return None when the path has no third segment" in {
-      val shortPathPolicy = Policy
-        .builder()
-        .arn("arn:aws:iam::123:policy/developer-policy/pol")
-        .path("/developer-policy/")
-        .policyName("pol")
-        .build()
-
-      toDeveloperPolicyFromOldPolicy(account, shortPathPolicy) shouldBe None
-    }
-  }
-
-  "toDeveloperPolicyWithFallback" - {
-    "should parse a new-style policy path successfully" in {
-      val result = toDeveloperPolicyWithFallback(account, policy)
-
-      result.value shouldBe DeveloperPolicy(
-        policyArnString =
-          "arn:aws:iam::123:policy/developer-policy/guardian/janus-app/my-stack/PROD/dev-pol-id/p1",
-        policyName = "p1",
-        policyGrantId = "dev-pol-id",
-        sourceRepo = "guardian/janus-app",
-        stack = "my-stack",
-        stage = "PROD",
-        friendlyName = "Description",
-        account
-      )
-    }
-
-    "should fall back to the old-style parse when the new-style parse fails" in {
-      val oldStylePolicy = Policy
-        .builder()
-        .arn("arn:aws:iam::123:policy/developer-policy/old-grant-id/p1")
-        .path("/developer-policy/old-grant-id/")
-        .policyName("p1")
-        .description("Old description")
-        .build()
-
-      val result = toDeveloperPolicyWithFallback(account, oldStylePolicy)
-
-      result.value.policyGrantId shouldBe "old-grant-id"
-      result.value.stack shouldBe "unknown"
-      result.value.stage shouldBe "unknown"
-    }
-
-    "should return None when neither parse succeeds" in {
-      val unrecognisedPolicy = Policy
-        .builder()
-        .arn("arn:aws:iam::123:policy/unrelated/")
-        .path("/")
-        .policyName("p1")
-        .build()
-
-      toDeveloperPolicyWithFallback(account, unrecognisedPolicy) shouldBe None
     }
   }
 


### PR DESCRIPTION
## What is the purpose of this change?
This removes some redundant code.  Now that all dev policies are defined using GuCDK [v63.1.0](https://github.com/guardian/cdk/releases/tag/v63.1.0) we don't need a fallback parsing method as none are in the legacy format.

## What is the value of this change and how do we measure success?
Less code to maintain.  Code fails faster.

## TODO before merging
- [x] Update last legacy dev policy: https://github.com/guardian/devx-backup-monitoring/pull/216