### PR TITLE
feat: Make passkeys mandatory

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -113,14 +113,11 @@ class AppComponents(context: ApplicationLoader.Context)
         if !enabled then
           logger.warn("Passkey authentication is globally disabled!")
       )
-  private val passkeysEnablingCookieName: String =
-    configuration.get[String]("passkeys.enablingCookieName")
 
   private val passkeyAuthFilter =
     new PasskeyAuthFilter(
       host,
-      passkeysEnabled,
-      passkeysEnablingCookieName
+      passkeysEnabled
     )
   private val passkeyRegistrationAuthFilter =
     new PasskeyRegistrationAuthFilter(passkeyAuthFilter)
@@ -141,7 +138,6 @@ class AppComponents(context: ApplicationLoader.Context)
       host,
       Clients.stsClient,
       configuration,
-      passkeysEnablingCookieName,
       passkeyAuthenticatorMetadata,
       developerPolicyCachingService,
       metricsService
@@ -153,8 +149,7 @@ class AppComponents(context: ApplicationLoader.Context)
       passkeyRegistrationAuthAction,
       host,
       janusData,
-      passkeysEnabled,
-      passkeysEnablingCookieName
+      passkeysEnabled
     ),
     new Audit(janusData, controllerComponents, authAction),
     new RevokePermissions(
@@ -182,8 +177,7 @@ class AppComponents(context: ApplicationLoader.Context)
       janusData,
       controllerComponents,
       authAction,
-      configuration,
-      passkeysEnablingCookieName
+      configuration
     ),
     assets
   )

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -38,7 +38,6 @@ class Janus(
     host: String,
     stsClient: StsClient,
     configuration: Configuration,
-    passkeysEnablingCookieName: String,
     passkeyAuthenticatorMetadata: Map[AAGUID, PasskeyAuthenticator],
     developerPolicyService: DeveloperPolicyFinder
       with DeveloperPolicyStatusManager,
@@ -188,7 +187,6 @@ class Janus(
         passkeys,
         dateFormat,
         timeFormat,
-        passkeysEnablingCookieName,
         passkeysManagerLink(configuration),
         passkeysManagerLinkText(configuration)
       )

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -32,8 +32,7 @@ class PasskeyController(
     ],
     host: String,
     janusData: JanusData,
-    passkeysEnabled: Boolean,
-    enablingCookieName: String
+    passkeysEnabled: Boolean
 )(using dynamoDb: DynamoDbClient, mode: Mode, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with ResultHandler
@@ -99,13 +98,11 @@ class PasskeyController(
   }
 
   def showAuthPage: Action[AnyContent] = authAction { implicit request =>
-    val enablingCookieIsPresent =
-      request.cookies.get(enablingCookieName).isDefined
     Ok(
       views.html.passkeyAuth(
         request.user,
         janusData,
-        passkeysEnabled && enablingCookieIsPresent
+        passkeysEnabled
       )
     )
   }

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -5,36 +5,16 @@ import com.gu.janus.model.JanusData
 import play.api.mvc.*
 import play.api.{Configuration, Logging, Mode}
 
-import java.time.Duration
-
 class Utility(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
     authAction: AuthAction[AnyContent],
-    configuration: Configuration,
-    passkeysEnablingCookieName: String
+    configuration: Configuration
 )(using mode: Mode, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
 
   def healthcheck: Action[AnyContent] = Action {
     Ok("ok")
-  }
-
-  /** Temporary action to opt in to the passkeys integration */
-  def optInToPasskeys: Action[AnyContent] = authAction { _ =>
-    Redirect(routes.Janus.userAccount).withCookies(
-      Cookie(
-        name = passkeysEnablingCookieName,
-        value = "true",
-        maxAge = Some(Duration.ofDays(30).toSeconds.intValue)
-      )
-    )
-  }
-
-  /** Temporary action to opt out of the passkeys integration */
-  def optOutOfPasskeys: Action[AnyContent] = authAction { _ =>
-    Redirect(routes.Janus.userAccount)
-      .discardingCookies(DiscardingCookie(passkeysEnablingCookieName))
   }
 }

--- a/app/filters/PasskeyAuthFilter.scala
+++ b/app/filters/PasskeyAuthFilter.scala
@@ -32,16 +32,13 @@ import scala.util.{Failure, Success, Try}
   */
 class PasskeyAuthFilter(
     host: String,
-    passkeysEnabled: Boolean,
-    enablingCookieName: String
+    passkeysEnabled: Boolean
 )(using dynamoDb: DynamoDbClient, val executionContext: ExecutionContext)
     extends ActionFilter[UserIdentityRequest]
     with Logging {
 
   def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] = {
-    val enablingCookieIsPresent =
-      request.cookies.get(enablingCookieName).isDefined
-    if (passkeysEnabled && enablingCookieIsPresent) {
+    if (passkeysEnabled) {
       logger.info(s"Verifying passkey for user ${request.user.username} ...")
       Future(apiResponse(authenticatePasskey(request)))
     } else {

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -10,7 +10,6 @@
         passkeys: Seq[models.PasskeyMetadata],
         dateFormat: Instant => String,
         timeFormat: Instant => String,
-        passkeysEnablingCookieName: String,
         passkeyManagerLink: String,
         passkeyManagerLinkText: String
 )(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
@@ -23,36 +22,6 @@
         <p>You are logged in as <strong>@username(user)</strong>.</p>
 
         <h3 class="header orange-text">Passkeys</h3>
-
-        <div class="col s12">
-                <div role="region" id="passkey-status-heading" aria-label="Passkey authentication status">
-                    @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
-                    <div class="card-panel green lighten-4" role="status" aria-live="polite">
-                        <p><i class="material-icons" aria-hidden="true">check_circle</i> You are currently <strong>opted in</strong> to passkey authentication.</p>
-                        <div><a href="@routes.Utility.optOutOfPasskeys"
-                        class="btn red waves-effect waves-light"
-                        role="button"
-                        aria-describedby="passkey-status-heading">
-                            <i class="material-icons left" aria-hidden="true">cancel</i>
-                            <span>Opt out</span>
-                        </a></div>
-                    </div>
-                    } else {
-                    <div class="card-panel grey lighten-4" role="status" aria-live="polite">
-                        <p><i class="material-icons" aria-hidden="true">info</i> You are currently <strong>opted out</strong> of passkey authentication.</p>
-                        <div> 
-                            <a href="@routes.Utility.optInToPasskeys"
-                            class="btn green waves-effect waves-light"
-                            role="button"
-                            aria-describedby="passkey-status-heading">
-                            <i class="material-icons left" aria-hidden="true">check_circle</i>
-                            <span>Opt in</span>
-                            </a>
-                        </div>
-                    </div>               
-                    }
-                </div>
-            </div>
 
         <p>Passkeys are a secure way to authenticate sensitive actions.
             Janus uses them as an extra layer of security to authenticate you before allowing you to access

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -90,9 +90,8 @@ auth {
 }
 
 passkeys {
-  // Iff enabled=true and enabling cookie is present, passkey authentication is required to get credentials and access to AWS console
+  // Iff enabled=true, passkey authentication is required to get credentials and access to AWS console
   enabled=true
-  enablingCookieName=use-passkeys
   manager {
     contactLink = ${PASSKEY_MANAGER_CONTACT_LINK}
     contactLinkText = ${PASSKEY_MANAGER_CONTACT_LINK_TEXT}

--- a/conf/routes
+++ b/conf/routes
@@ -43,10 +43,6 @@ DELETE        /passkey/:passkeyId                       controllers.PasskeyContr
 GET           /policies-status/account/:account         controllers.AccountsController.policiesStatusForAccount(account: String)
 GET           /users/account/:account                   controllers.AccountsController.usersForAccount(account: String)
 
-# Tmp routes for passkey trial
-GET           /opt/in/passkeys                          controllers.Utility.optInToPasskeys
-GET           /opt/out/passkeys                         controllers.Utility.optOutOfPasskeys
-
 GET           /healthcheck                              controllers.Utility.healthcheck
 
 GET           /accounts                                 controllers.AccountsController.accounts

--- a/test/filters/PasskeyAuthFilterTest.scala
+++ b/test/filters/PasskeyAuthFilterTest.scala
@@ -4,7 +4,7 @@ import com.gu.googleauth.{AuthAction, UserIdentity}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.mvc.{AnyContentAsFormUrlEncoded, Cookie, Results}
+import play.api.mvc.{AnyContentAsFormUrlEncoded, Results}
 import play.api.test.{FakeHeaders, FakeRequest}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
@@ -26,7 +26,6 @@ class PasskeyAuthFilterTest
   }
 
   private val testHost = "test.example.com"
-  private val testCookieName = "test-cookie"
   private val testUser = UserIdentity(
     sub = "test-sub-id",
     email = "test@example.com",
@@ -36,18 +35,7 @@ class PasskeyAuthFilterTest
     avatarUrl = None
   )
 
-  private def createRequestWithCookie[A](body: A) = {
-    val cookie = Cookie(testCookieName, "present")
-    new AuthAction.UserIdentityRequest(
-      testUser,
-      FakeRequest("POST", "/test")
-        .withHeaders(FakeHeaders())
-        .withBody(body)
-        .withCookies(cookie)
-    )
-  }
-
-  private def createRequestWithoutCookie[A](body: A) = {
+  private def createRequest[A](body: A) = {
     new AuthAction.UserIdentityRequest(
       testUser,
       FakeRequest("POST", "/test")
@@ -69,24 +57,10 @@ class PasskeyAuthFilterTest
     "bypass authentication when disabled" in {
       val filter = new PasskeyAuthFilter(
         host = testHost,
-        passkeysEnabled = false,
-        enablingCookieName = testCookieName
+        passkeysEnabled = false
       )
 
-      val request = createRequestWithCookie(validFormBody)
-      val result = filter.filter(request).futureValue
-
-      result shouldBe None
-    }
-
-    "bypass authentication when enabling cookie is not present" in {
-      val filter = new PasskeyAuthFilter(
-        host = testHost,
-        passkeysEnabled = true,
-        enablingCookieName = testCookieName
-      )
-
-      val request = createRequestWithoutCookie(validFormBody)
+      val request = createRequest(validFormBody)
       val result = filter.filter(request).futureValue
 
       result shouldBe None


### PR DESCRIPTION
## What is the purpose of this change?
Currently users can opt in to step-up authentication with passkeys if they want to trial it.
In this change, we make the extra auth mandatory.
This is done by removing all references to the cookie that controls the trial.
There is still a global switch in the app config so that the feature can easily be disabled if it causes some significant unforeseen problem.

## What is the value of this change and how do we measure success?
If a user's machine is compromised there is less chance that credentials will be exfiltrated.

## See also
* [Asana ticket](https://app.asana.com/1/1210045093164357/project/1213783257830028/task/1215454015085362?focus=true)

## TODO before moving out of draft state
- [ ] Comms sent around
- [ ] Agreed switch on date has arrived
