### PR TITLE
feat(passkey): Introduce 3 value PasskeyMode

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -106,22 +106,15 @@ class AppComponents(context: ApplicationLoader.Context)
       "passkeys_aaguid_descriptions.json"
     )
 
-  private val passkeysEnabled: Boolean =
-    configuration
-      .get[Boolean]("passkeys.enabled")
-      .tap(enabled =>
-        if !enabled then
-          logger.warn("Passkey authentication is globally disabled!")
-      )
-  private val passkeysEnablingCookieName: String =
-    configuration.get[String]("passkeys.enablingCookieName")
+  private val passkeyMode = Config
+    .passkeyMode(configuration)
+    .tap {
+      case PasskeyMode.Disabled =>
+        logger.warn("Passkey authentication is globally disabled!")
+      case _ =>
+    }
 
-  private val passkeyAuthFilter =
-    new PasskeyAuthFilter(
-      host,
-      passkeysEnabled,
-      passkeysEnablingCookieName
-    )
+  private val passkeyAuthFilter = new PasskeyAuthFilter(host, passkeyMode)
   private val passkeyRegistrationAuthFilter =
     new PasskeyRegistrationAuthFilter(passkeyAuthFilter)
 
@@ -141,7 +134,7 @@ class AppComponents(context: ApplicationLoader.Context)
       host,
       Clients.stsClient,
       configuration,
-      passkeysEnablingCookieName,
+      passkeyMode,
       passkeyAuthenticatorMetadata,
       developerPolicyCachingService,
       metricsService
@@ -153,8 +146,7 @@ class AppComponents(context: ApplicationLoader.Context)
       passkeyRegistrationAuthAction,
       host,
       janusData,
-      passkeysEnabled,
-      passkeysEnablingCookieName
+      passkeyMode
     ),
     new Audit(janusData, controllerComponents, authAction),
     new RevokePermissions(
@@ -182,8 +174,7 @@ class AppComponents(context: ApplicationLoader.Context)
       janusData,
       controllerComponents,
       authAction,
-      configuration,
-      passkeysEnablingCookieName
+      configuration
     ),
     assets
   )

--- a/app/aws/PasskeyDB.scala
+++ b/app/aws/PasskeyDB.scala
@@ -166,6 +166,23 @@ object PasskeyDB {
       dynamoDB.query(request)
     }.adaptError(err => JanusException.failedToLoadDbItem(user, tableName, err))
 
+  /** Returns true iff the user has at least one passkey registered. */
+  def hasPasskey(
+      user: UserIdentity
+  )(using dynamoDB: DynamoDbClient): Try[Boolean] =
+    Try {
+      val expressionValues = Map(
+        ":username" -> AttributeValue.fromS(user.username)
+      )
+      val request = QueryRequest
+        .builder()
+        .tableName(tableName)
+        .keyConditionExpression("username = :username")
+        .expressionAttributeValues(expressionValues.asJava)
+        .build()
+      dynamoDB.query(request).count() > 0
+    }.adaptError(err => JanusException.failedToLoadDbItem(user, tableName, err))
+
   def extractMetadata(response: QueryResponse): Seq[PasskeyMetadata] =
     if (response.hasItems && !response.items().isEmpty) {
       response

--- a/app/conf/Config.scala
+++ b/app/conf/Config.scala
@@ -11,6 +11,7 @@ import com.gu.janus.model._
 import com.gu.play.secretrotation.SnapshotProvider
 import models._
 import models.AccountConfigStatus.*
+import models.PasskeyMode
 import play.api.Configuration
 
 import java.io.{File, FileInputStream}
@@ -117,6 +118,23 @@ object Config {
 
   def twoFAGroup(config: Configuration): String = {
     requiredString(config, "auth.google.2faGroupId")
+  }
+
+  /** Reads the passkey mode from config key `passkeys.mode`. Fails at startup
+    * if the value is unrecognised.
+    */
+  def passkeyMode(config: Configuration): PasskeyMode = {
+    val raw = requiredString(config, "passkeys.mode")
+    raw match {
+      case "Disabled"         => PasskeyMode.Disabled
+      case "IfUserHasPasskey" => PasskeyMode.IfUserHasPasskey
+      case "Required"         => PasskeyMode.Required
+      case other              =>
+        throw new JanusConfigurationException(
+          s"Unrecognised passkeys.mode value '$other'. Expected one of: Disabled, IfUserHasPasskey, Required",
+          "passkeys.mode"
+        )
+    }
   }
 
   /** Link suitable for an HTML anchor href attribute. E.g. a URL or an email

--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -11,7 +11,12 @@ import conf.Config.{passkeysManagerLink, passkeysManagerLinkText}
 import logic.*
 import logic.PlayHelpers.splitQuerystringParam
 import models.AccessSource.Internal
-import models.{AccountAccess, DeveloperPolicy, PasskeyAuthenticator}
+import models.{
+  AccountAccess,
+  DeveloperPolicy,
+  PasskeyAuthenticator,
+  PasskeyMode
+}
 import play.api.mvc.*
 import play.api.{Configuration, Logging, Mode}
 import services.{
@@ -38,7 +43,7 @@ class Janus(
     host: String,
     stsClient: StsClient,
     configuration: Configuration,
-    passkeysEnablingCookieName: String,
+    passkeyMode: PasskeyMode,
     passkeyAuthenticatorMetadata: Map[AAGUID, PasskeyAuthenticator],
     developerPolicyService: DeveloperPolicyFinder
       with DeveloperPolicyStatusManager,
@@ -188,7 +193,7 @@ class Janus(
         passkeys,
         dateFormat,
         timeFormat,
-        passkeysEnablingCookieName,
+        passkeyMode,
         passkeysManagerLink(configuration),
         passkeysManagerLinkText(configuration)
       )

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -11,6 +11,7 @@ import logic.Passkey
 import logic.UserAccess.hasAccess
 import models.JanusException
 import models.PasskeyFlow.{Authentication, Registration}
+import models.PasskeyMode
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
 import play.api.data.validation.Constraints.*
@@ -19,6 +20,7 @@ import play.api.mvc.*
 import play.api.{Logging, Mode}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.{Failure, Success, Try}
 
 /** Controller for handling passkey registration and authentication. */
@@ -32,10 +34,13 @@ class PasskeyController(
     ],
     host: String,
     janusData: JanusData,
-    passkeysEnabled: Boolean,
-    enablingCookieName: String
-)(using dynamoDb: DynamoDbClient, mode: Mode, assetsFinder: AssetsFinder)
-    extends AbstractController(controllerComponents)
+    passkeyMode: PasskeyMode
+)(using
+    dynamoDb: DynamoDbClient,
+    mode: Mode,
+    assetsFinder: AssetsFinder,
+    ec: ExecutionContext
+) extends AbstractController(controllerComponents)
     with ResultHandler
     with Logging {
 
@@ -98,16 +103,48 @@ class PasskeyController(
         )
   }
 
-  def showAuthPage: Action[AnyContent] = authAction { implicit request =>
-    val enablingCookieIsPresent =
-      request.cookies.get(enablingCookieName).isDefined
-    Ok(
-      views.html.passkeyAuth(
-        request.user,
-        janusData,
-        passkeysEnabled && enablingCookieIsPresent
-      )
-    )
+  def showAuthPage: Action[AnyContent] = authAction.async { implicit request =>
+    passkeyMode match {
+      case PasskeyMode.Disabled =>
+        Future.successful(
+          Ok(
+            views.html
+              .passkeyAuth(request.user, janusData, passkeyAuthRequired = false)
+          )
+        )
+      case PasskeyMode.Required =>
+        Future.successful(
+          Ok(
+            views.html
+              .passkeyAuth(request.user, janusData, passkeyAuthRequired = true)
+          )
+        )
+      case PasskeyMode.IfUserHasPasskey =>
+        Future(blocking(PasskeyDB.hasPasskey(request.user)))
+          .flatMap(Future.fromTry)
+          .map(hasPasskey =>
+            Ok(
+              views.html.passkeyAuth(
+                request.user,
+                janusData,
+                passkeyAuthRequired = hasPasskey
+              )
+            )
+          )
+          .recover { case err =>
+            logger.error(
+              s"Failed to determine passkey status for ${request.user.username}",
+              err
+            )
+            InternalServerError(
+              views.html.error(
+                "An error occurred whilst checking your passkey status. Please try again.",
+                Some(request.user),
+                janusData
+              )
+            )
+          }
+    }
   }
 
   /** See

--- a/app/controllers/Utility.scala
+++ b/app/controllers/Utility.scala
@@ -5,36 +5,16 @@ import com.gu.janus.model.JanusData
 import play.api.mvc.*
 import play.api.{Configuration, Logging, Mode}
 
-import java.time.Duration
-
 class Utility(
     janusData: JanusData,
     controllerComponents: ControllerComponents,
     authAction: AuthAction[AnyContent],
-    configuration: Configuration,
-    passkeysEnablingCookieName: String
+    configuration: Configuration
 )(using mode: Mode, assetsFinder: AssetsFinder)
     extends AbstractController(controllerComponents)
     with Logging {
 
   def healthcheck: Action[AnyContent] = Action {
     Ok("ok")
-  }
-
-  /** Temporary action to opt in to the passkeys integration */
-  def optInToPasskeys: Action[AnyContent] = authAction { _ =>
-    Redirect(routes.Janus.userAccount).withCookies(
-      Cookie(
-        name = passkeysEnablingCookieName,
-        value = "true",
-        maxAge = Some(Duration.ofDays(30).toSeconds.intValue)
-      )
-    )
-  }
-
-  /** Temporary action to opt out of the passkeys integration */
-  def optOutOfPasskeys: Action[AnyContent] = authAction { _ =>
-    Redirect(routes.Janus.userAccount)
-      .discardingCookies(DiscardingCookie(passkeysEnablingCookieName))
   }
 }

--- a/app/filters/PasskeyAuthFilter.scala
+++ b/app/filters/PasskeyAuthFilter.scala
@@ -6,9 +6,11 @@ import com.gu.googleauth.UserIdentity
 import com.webauthn4j.data.AuthenticationData
 import logic.Passkey
 import models.JanusException
-import models.JanusException.throwableWrites
+import models.JanusException.janusExceptionWrites
 import models.PasskeyFlow.Authentication
+import models.PasskeyMode
 import play.api.Logging
+import play.api.libs.json.Json
 import play.api.libs.json.Json.toJson
 import play.api.mvc.Results.{InternalServerError, Status}
 import play.api.mvc.{
@@ -20,36 +22,68 @@ import play.api.mvc.{
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 import scala.util.{Failure, Success, Try}
+import java.util.UUID
 
 /** Verifies passkeys and only allows an action to continue if verification is
-  * successful. If passkeys are disabled globally or for the current request,
-  * the action is allowed to continue.
+  * successful. If passkeys are globally disabled, or the mode is
+  * [[PasskeyMode.IfUserHasPasskey]] and the user has no registered passkeys,
+  * the action is allowed to continue without passkey verification.
   *
   * See
   * [[https://webauthn4j.github.io/webauthn4j/en/#webauthn-assertion-verification-and-post-processing]].
   */
 class PasskeyAuthFilter(
     host: String,
-    passkeysEnabled: Boolean,
-    enablingCookieName: String
+    passkeyMode: PasskeyMode
 )(using dynamoDb: DynamoDbClient, val executionContext: ExecutionContext)
     extends ActionFilter[UserIdentityRequest]
     with Logging {
 
-  def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] = {
-    val enablingCookieIsPresent =
-      request.cookies.get(enablingCookieName).isDefined
-    if (passkeysEnabled && enablingCookieIsPresent) {
-      logger.info(s"Verifying passkey for user ${request.user.username} ...")
-      Future(apiResponse(authenticatePasskey(request)))
-    } else {
-      logger.info(
-        s"Passing through request for '${request.method} ${request.path}' by ${request.user.username}"
-      )
-      Future.successful(None)
+  def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] =
+    passkeyMode match {
+      case PasskeyMode.Disabled =>
+        passThrough(request)
+      case PasskeyMode.Required =>
+        verifyPasskey(request)
+      case PasskeyMode.IfUserHasPasskey =>
+        Future(blocking(PasskeyDB.hasPasskey(request.user)))
+          .flatMap(Future.fromTry)
+          .transformWith {
+            case Success(true)  => verifyPasskey(request)
+            case Success(false) => passThrough(request)
+            case Failure(err)   =>
+              Future.successful(
+                Some(
+                  internalError(
+                    s"Failed to determine passkey status for ${request.user.username}",
+                    err
+                  )
+                )
+              )
+          }
     }
+
+  /** Skips the passkey-status check and proceeds directly to verification.
+    *
+    * Used by [[PasskeyRegistrationAuthFilter]] because it has already confirmed
+    * the user has registered passkeys.
+    */
+  private[filters] def verifyPasskey[A](
+      request: UserIdentityRequest[A]
+  ): Future[Option[Result]] = {
+    logger.info(s"Verifying passkey for user ${request.user.username} ...")
+    Future(blocking(apiResponse(authenticatePasskey(request))))
+  }
+
+  private def passThrough[A](
+      request: UserIdentityRequest[A]
+  ): Future[Option[Result]] = {
+    logger.info(
+      s"Passing through request for '${request.method} ${request.path}' by ${request.user.username}"
+    )
+    Future.successful(None)
   }
 
   private def authenticatePasskey[A](
@@ -89,10 +123,25 @@ class PasskeyAuthFilter(
         logger.error(err.engineerMessage, err.causedBy.orNull)
         Some(Status(err.httpCode)(toJson(err)))
       case Failure(err) =>
-        logger.error(err.getMessage, err)
-        Some(InternalServerError(toJson(err)))
+        Some(internalError(err.getMessage, err))
       case Success(_) => None
     }
+
+  /** Generates a unique error ID, logs it with full details and returns a 500
+    * response containing only the ID and a generic user-safe message. We can
+    * use the ID to correlate the response with server logs in principle.
+    */
+  private def internalError(context: String, err: Throwable): Result = {
+    val errorId = UUID.randomUUID().toString
+    logger.error(s"$context [errorId=$errorId]", err)
+    InternalServerError(
+      Json.obj(
+        "status" -> "error",
+        "message" -> "An unexpected error occurred",
+        "errorId" -> errorId
+      )
+    )
+  }
 
   private def extractAuthDataFromRequest[A](
       request: UserIdentityRequest[A]

--- a/app/filters/PasskeyRegistrationAuthFilter.scala
+++ b/app/filters/PasskeyRegistrationAuthFilter.scala
@@ -8,13 +8,13 @@ import play.api.mvc.Results.InternalServerError
 import play.api.mvc.{ActionFilter, Result}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, blocking}
 
 /** This filter determines if a user should be allowed to register passkeys:
   *   - If the user has no existing passkey credentials in the database, they're
   *     allowed to register (filter returns None)
   *   - If the user already has passkey credentials, the request is delegated to
-  *     the standard PasskeyAuthFilter
+  *     the standard [[PasskeyAuthFilter]].
   *
   * @param authFilter
   *   The passkey authentication filter to delegate to if the user already has
@@ -40,31 +40,36 @@ class PasskeyRegistrationAuthFilter(authFilter: PasskeyAuthFilter)(using
     *   The request body type
     * @return
     *   None if the user has no passkeys and can proceed with registration,
-    *   otherwise the result of the delegated passkey auth filter or an error
-    *   response
+    *   otherwise the result of passkey verification or an error response
     */
   def filter[A](request: UserIdentityRequest[A]): Future[Option[Result]] =
-    PasskeyDB
-      .loadCredentials(request.user)
-      .fold(
-        err => {
-          logger.error(
-            s"Failed to load existing credentials for user ${request.user.username}",
-            err
+    Future(blocking(PasskeyDB.hasPasskey(request.user)))
+      .flatMap(Future.fromTry)
+      .flatMap {
+        case true  => authFilter.verifyPasskey(request)
+        case false => Future.successful(None)
+      }
+      .recoverWith { case err =>
+        hasPasskeyLookupError(request.user.username, err)
+      }
+
+  private def hasPasskeyLookupError(
+      username: String,
+      err: Throwable
+  ): Future[Option[Result]] = {
+    logger.error(
+      s"Failed to determine if user $username already has a passkey. ",
+      err
+    )
+    Future.successful(
+      Some(
+        InternalServerError(
+          Json.obj(
+            "error" -> "DB load error",
+            "message" -> "Failed to determine if user already has a passkey."
           )
-          Future.successful(
-            Some(
-              InternalServerError(
-                Json.obj(
-                  "error" -> "DB load error",
-                  "message" -> "Failed to load existing credentials for the user."
-                )
-              )
-            )
-          )
-        },
-        dbResponse =>
-          if !dbResponse.items.isEmpty then authFilter.filter(request)
-          else Future.successful(None)
+        )
       )
+    )
+  }
 }

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -10,6 +10,21 @@ import play.api.http.Status.{
 }
 import play.api.libs.json.{Json, Writes}
 
+/** Controls when passkey authentication is enforced. */
+enum PasskeyMode {
+
+  /** Passkey authentication is never required. */
+  case Disabled
+
+  /** Passkey authentication is required only if the user has at least one
+    * passkey registered.
+    */
+  case IfUserHasPasskey
+
+  /** Passkey authentication is always required. */
+  case Required
+}
+
 enum AccountConfigStatus:
   case FederationConfigError(causedBy: Throwable)
   case ConfigSuccess

--- a/app/views/passkeyAuth.scala.html
+++ b/app/views/passkeyAuth.scala.html
@@ -3,15 +3,17 @@
 @import play.api.Mode
 @import views.html.helper.CSPNonce
 
-@(user: UserIdentity, janusData: JanusData, passkeysEnabled: Boolean)(implicit req: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
+@(user: UserIdentity, janusData: JanusData, passkeyAuthRequired: Boolean)(implicit req: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Passkey authentication", Some(user), janusData) {
-    <div class="container" data-passkeys-enabled="@passkeysEnabled">
-        <div class="passkey-prompt">
-            <i class="material-icons passkey-prompt__icon" aria-hidden="true">fingerprint</i>
-            <p class="passkey-prompt__text">Follow the prompts on your device to authenticate.</p>
-            <i class="material-icons passkey-prompt__spinner rotate" aria-hidden="true">sync</i>
-        </div>
+    <div class="container" data-passkeys-enabled="@passkeyAuthRequired">
+        @if(passkeyAuthRequired) {
+            <div class="passkey-prompt">
+                <i class="material-icons passkey-prompt__icon" aria-hidden="true">fingerprint</i>
+                <p class="passkey-prompt__text">Follow the prompts on your device to authenticate.</p>
+                <i class="material-icons passkey-prompt__spinner rotate" aria-hidden="true">sync</i>
+            </div>
+        }
     </div>
 
     @if(mode == Mode.Dev) {

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -1,6 +1,7 @@
 @import com.gu.googleauth.UserIdentity
 @import com.gu.janus.model.JanusData
 @import logic.UserAccess.username
+@import models.PasskeyMode
 @import play.api.Mode
 @import java.time.Instant
 
@@ -10,7 +11,7 @@
         passkeys: Seq[models.PasskeyMetadata],
         dateFormat: Instant => String,
         timeFormat: Instant => String,
-        passkeysEnablingCookieName: String,
+        passkeyMode: PasskeyMode,
         passkeyManagerLink: String,
         passkeyManagerLinkText: String
 )(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
@@ -25,42 +26,16 @@
         <h3 class="header orange-text">Passkeys</h3>
 
         <div class="col s12">
-                <div role="region" id="passkey-status-heading" aria-label="Passkey authentication status">
-                    @if(request.cookies.get(passkeysEnablingCookieName).isDefined) {
-                    <div class="card-panel green lighten-4" role="status" aria-live="polite">
-                        <p><i class="material-icons" aria-hidden="true">check_circle</i> You are currently <strong>opted in</strong> to passkey authentication.</p>
-                        <div><a href="@routes.Utility.optOutOfPasskeys"
-                        class="btn red waves-effect waves-light"
-                        role="button"
-                        aria-describedby="passkey-status-heading">
-                            <i class="material-icons left" aria-hidden="true">cancel</i>
-                            <span>Opt out</span>
-                        </a></div>
-                    </div>
-                    } else {
-                    <div class="card-panel grey lighten-4" role="status" aria-live="polite">
-                        <p><i class="material-icons" aria-hidden="true">info</i> You are currently <strong>opted out</strong> of passkey authentication.</p>
-                        <div> 
-                            <a href="@routes.Utility.optInToPasskeys"
-                            class="btn green waves-effect waves-light"
-                            role="button"
-                            aria-describedby="passkey-status-heading">
-                            <i class="material-icons left" aria-hidden="true">check_circle</i>
-                            <span>Opt in</span>
-                            </a>
-                        </div>
-                    </div>               
-                    }
-                </div>
-            </div>
+        </div>
 
         <p>Passkeys are a secure way to authenticate sensitive actions.
             Janus uses them as an extra layer of security to authenticate you before allowing you to access
             AWS credentials or the AWS console.</p>
         <p>We recommend that you <strong>register at least two passkeys</strong> to ensure you have access to
-            your AWS accounts.
-            One should be on-device (e.g. Mac Touch ID or Windows Hello)
-            and the other off-device (e.g. security key or phone).</p>
+            your AWS accounts.<br />
+            One should be on-device if possible (e.g. Chrome browser)
+            and the other off-device (e.g. security key or phone).<br />
+            On a Windows device you will need two off-device passkeys as Windows Hello is disabled by default.</p>
         <p>Please contact <a href="@passkeyManagerLink">@passkeyManagerLinkText</a> if you have any problems
             registering or using passkeys.</p>
 
@@ -103,15 +78,26 @@
                                 }
                             </tbody>
                         </table>
-                    } else {                                 
-                        <div class="center-align">
-                            <div class="alert-box">
-                                <i class="material-icons medium red-text">error</i>
-                                <h5>No Passkeys Registered</h5>
-                                <p>Before you can access AWS credentials or console you must register at least one passkey.</p>
-                            </div>
-                        </div>
-                    }                    
+                    } else {
+                        @passkeyMode match {
+                            case PasskeyMode.Required => {
+                                <div class="center-align">
+                                    <div class="alert-box">
+                                        <i class="material-icons medium red-text">error</i>
+                                        <h5>No Passkeys Registered</h5>
+                                        <p>Before you can access AWS credentials or console you must register at least one passkey.</p>
+                                    </div>
+                                </div>
+                            }
+                            case PasskeyMode.IfUserHasPasskey => {
+                                <p>You have no passkeys registered.</p>
+                                <p>Registering a passkey will enable passkey authentication for your account.</p>
+                            }
+                            case PasskeyMode.Disabled => {
+                                <p>You have no passkeys registered.</p>
+                            }
+                        }
+                    }
                     <div class="section">
                         <button id="register-passkey" class="btn">
                             Register a new passkey

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -36,6 +36,7 @@
             One should be on-device if possible (e.g. Chrome browser)
             and the other off-device (e.g. security key or phone).<br />
             On a Windows device you will need two off-device passkeys as Windows Hello is disabled by default.</p>
+        <p>Guardian users can collect a Titan security key from the IT service desk in any office.</p>
         <p>Please contact <a href="@passkeyManagerLink">@passkeyManagerLinkText</a> if you have any problems
             registering or using passkeys.</p>
 

--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -25,9 +25,6 @@
 
         <h3 class="header orange-text">Passkeys</h3>
 
-        <div class="col s12">
-        </div>
-
         <p>Passkeys are a secure way to authenticate sensitive actions.
             Janus uses them as an extra layer of security to authenticate you before allowing you to access
             AWS credentials or the AWS console.</p>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -90,9 +90,15 @@ auth {
 }
 
 passkeys {
-  // Iff enabled=true and enabling cookie is present, passkey authentication is required to get credentials and access to AWS console
-  enabled=true
-  enablingCookieName=use-passkeys
+  # Passkey authentication mode. One of: Disabled, IfUserHasPasskey, Required.
+  # IfUserHasPasskey: passkey authentication is required for any user who has at least one passkey registered.
+  # Required: passkey authentication is required for all users.
+  # Disabled: passkey authentication is never required (use only for emergencies).
+  #
+//  mode=Disabled
+//  mode=Required
+  mode=IfUserHasPasskey
+
   manager {
     contactLink = ${PASSKEY_MANAGER_CONTACT_LINK}
     contactLinkText = ${PASSKEY_MANAGER_CONTACT_LINK_TEXT}

--- a/conf/routes
+++ b/conf/routes
@@ -43,9 +43,6 @@ DELETE        /passkey/:passkeyId                       controllers.PasskeyContr
 GET           /policies-status/account/:account         controllers.AccountsController.policiesStatusForAccount(account: String)
 GET           /users/account/:account                   controllers.AccountsController.usersForAccount(account: String)
 
-# Tmp routes for passkey trial
-GET           /opt/in/passkeys                          controllers.Utility.optInToPasskeys
-GET           /opt/out/passkeys                         controllers.Utility.optOutOfPasskeys
 
 GET           /healthcheck                              controllers.Utility.healthcheck
 

--- a/docs/PasskeysIntegration.md
+++ b/docs/PasskeysIntegration.md
@@ -54,6 +54,19 @@ graph TB
     PCDB --> DynamoChallenges
 ```
 
+## Passkey authentication mode
+
+Whether passkey authentication is enforced is controlled by the `passkeys.mode` config value,
+modelled as a `PasskeyMode` enum with three cases:
+
+| Value | Behaviour |
+|---|---|
+| `Disabled` | Passkey authentication is never required. Use only in an emergency. |
+| `IfUserHasPasskey` | Passkey authentication is required for any user who has at least one passkey registered. |
+| `Required` | Passkey authentication is required for all users. |
+
+The default value is currently `IfUserHasPasskey`.
+
 ## Terminology
 
 ### Authenticator
@@ -75,6 +88,9 @@ the authenticator.
 ### [models/Passkey](/app/models/Passkey.scala)
 All the passkey-specific models passed between views and the database are defined here.
 Also model <-> Json marshalling rules.
+
+### [models/PasskeyMode](/app/models/models.scala)
+Scala 3 enum controlling when passkey authentication is enforced. Read from config at startup.
 
 ### [controllers/PasskeyController](/app/controllers/PasskeyController.scala)
 This holds actions for registration of passkeys and for providing registration and authentication options to browsers

--- a/test/conf/ConfigTest.scala
+++ b/test/conf/ConfigTest.scala
@@ -1,15 +1,15 @@
 package conf
 
-import com.gu.janus.model._
+import com.gu.janus.model.*
 import com.typesafe.config.ConfigFactory
-import fixtures.Fixtures._
-import models.AccountConfigStatus
+import conf.Config.JanusConfigurationException
+import fixtures.Fixtures.*
 import models.AccountConfigStatus.*
+import models.PasskeyMode
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
 
-import java.time.Duration
 import scala.util.Success
 
 class ConfigTest extends AnyFreeSpec with Matchers {
@@ -232,6 +232,42 @@ class ConfigTest extends AnyFreeSpec with Matchers {
         ) shouldEqual ConfigWarn(Set("bar", "baz"))
       }
 
+    }
+  }
+
+  "passkeyMode" - {
+    def configWith(value: String): Configuration =
+      Configuration(ConfigFactory.parseString(s"""passkeys.mode = "$value""""))
+
+    "returns Disabled when configured as 'Disabled'" in {
+      Config.passkeyMode(
+        configWith("Disabled")
+      ) shouldEqual PasskeyMode.Disabled
+    }
+
+    "returns IfUserHasPasskey when configured as 'IfUserHasPasskey'" in {
+      Config.passkeyMode(
+        configWith("IfUserHasPasskey")
+      ) shouldEqual PasskeyMode.IfUserHasPasskey
+    }
+
+    "returns Required when configured as 'Required'" in {
+      Config.passkeyMode(
+        configWith("Required")
+      ) shouldEqual PasskeyMode.Required
+    }
+
+    "throws JanusConfigurationException for an unrecognised value" in {
+      a[JanusConfigurationException] should be thrownBy {
+        Config.passkeyMode(configWith("unknown"))
+      }
+    }
+
+    "throws JanusConfigurationException when the key is absent" in {
+      val emptyConfig = Configuration(ConfigFactory.parseString("{}"))
+      a[JanusConfigurationException] should be thrownBy {
+        Config.passkeyMode(emptyConfig)
+      }
     }
   }
 

--- a/test/filters/PasskeyAuthFilterTest.scala
+++ b/test/filters/PasskeyAuthFilterTest.scala
@@ -1,12 +1,17 @@
 package filters
 
 import com.gu.googleauth.{AuthAction, UserIdentity}
+import models.PasskeyMode
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.mvc.{AnyContentAsFormUrlEncoded, Cookie, Results}
+import play.api.mvc.{AnyContentAsFormUrlEncoded, Results}
 import play.api.test.{FakeHeaders, FakeRequest}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{
+  QueryRequest,
+  QueryResponse
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -16,17 +21,26 @@ class PasskeyAuthFilterTest
     with ScalaFutures
     with Results {
 
-  given DynamoDbClient = {
-    // Stub implementation for testing
-    val mockClient = new DynamoDbClient {
-      override def serviceName(): String = "dynamodb-mock"
-      override def close(): Unit = {}
-    }
-    mockClient
+  /** Base stub used for modes that perform no passkey status lookup. The
+    * default interface implementations will throw if any DynamoDB method is
+    * called.
+    */
+  private given DynamoDbClient = new DynamoDbClient {
+    override def serviceName(): String = "dynamodb-mock"
+    override def close(): Unit = {}
   }
 
+  /** Produces a client whose query method returns the given passkey count. */
+  private def dynamoWithPasskeyCount(count: Int): DynamoDbClient =
+    new DynamoDbClient {
+      override def serviceName(): String = "dynamodb-mock"
+      override def close(): Unit = {}
+      override def query(request: QueryRequest): QueryResponse =
+        QueryResponse.builder().count(count).build()
+    }
+
   private val testHost = "test.example.com"
-  private val testCookieName = "test-cookie"
+
   private val testUser = UserIdentity(
     sub = "test-sub-id",
     email = "test@example.com",
@@ -36,25 +50,13 @@ class PasskeyAuthFilterTest
     avatarUrl = None
   )
 
-  private def createRequestWithCookie[A](body: A) = {
-    val cookie = Cookie(testCookieName, "present")
-    new AuthAction.UserIdentityRequest(
-      testUser,
-      FakeRequest("POST", "/test")
-        .withHeaders(FakeHeaders())
-        .withBody(body)
-        .withCookies(cookie)
-    )
-  }
-
-  private def createRequestWithoutCookie[A](body: A) = {
+  private def createRequest[A](body: A) =
     new AuthAction.UserIdentityRequest(
       testUser,
       FakeRequest("POST", "/test")
         .withHeaders(FakeHeaders())
         .withBody(body)
     )
-  }
 
   private val validFormBody = AnyContentAsFormUrlEncoded(
     Map(
@@ -66,30 +68,48 @@ class PasskeyAuthFilterTest
 
   "PasskeyAuthFilter" - {
 
-    "bypass authentication when disabled" in {
-      val filter = new PasskeyAuthFilter(
-        host = testHost,
-        passkeysEnabled = false,
-        enablingCookieName = testCookieName
-      )
-
-      val request = createRequestWithCookie(validFormBody)
-      val result = filter.filter(request).futureValue
-
-      result shouldBe None
+    "when mode is Disabled" - {
+      "bypasses authentication regardless of registered passkeys" in {
+        val filter = new PasskeyAuthFilter(
+          host = testHost,
+          passkeyMode = PasskeyMode.Disabled
+        )
+        val result = filter.filter(createRequest(validFormBody)).futureValue
+        result shouldBe None
+      }
     }
 
-    "bypass authentication when enabling cookie is not present" in {
-      val filter = new PasskeyAuthFilter(
-        host = testHost,
-        passkeysEnabled = true,
-        enablingCookieName = testCookieName
-      )
+    "when mode is IfUserHasPasskey" - {
+      "bypasses authentication when user has no passkeys registered" in {
+        given DynamoDbClient = dynamoWithPasskeyCount(0)
+        val filter = new PasskeyAuthFilter(
+          host = testHost,
+          passkeyMode = PasskeyMode.IfUserHasPasskey
+        )
+        val result = filter.filter(createRequest(validFormBody)).futureValue
+        result shouldBe None
+      }
 
-      val request = createRequestWithoutCookie(validFormBody)
-      val result = filter.filter(request).futureValue
+      "attempts passkey authentication when user has a passkey registered" in {
+        given DynamoDbClient = dynamoWithPasskeyCount(1)
+        val filter = new PasskeyAuthFilter(
+          host = testHost,
+          passkeyMode = PasskeyMode.IfUserHasPasskey
+        )
+        val result = filter.filter(createRequest(validFormBody)).futureValue
+        result shouldBe defined
+      }
+    }
 
-      result shouldBe None
+    "when mode is Required" - {
+      "attempts passkey authentication regardless of registered passkeys" in {
+        val filter = new PasskeyAuthFilter(
+          host = testHost,
+          passkeyMode = PasskeyMode.Required
+        )
+        val result = filter.filter(createRequest(validFormBody)).futureValue
+        result shouldBe defined
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem
We are relying on clientside cookies to opt in to a preview of passkey auth, which is overcomplicating things.
It will also require a big change to switch over to mandated passkey auth.
We want auth to have no dependence on clientside settings and for it to be a simple config change to make passkey auth mandatory but also for it to be disabled or optional in the future.

## Solution implemented
This change introduces a passkey mode with three values.  This is the effect of the different values:

| Mode | Authentication | User account page | Interstitial |
|--------|--------|--------|--------|
| Disabled | User sent straight through to the creds page or console | No message in passkey registration section | Blank page |
| **IfUserHasPasskey** (current setting) | User sent straight through unless they have registered a key, in which case they go through the auth flow | Invited to create a passkey in passkey registration section | Message if user has registered a key, otherwise a blank page |
| Required | User goes through the auth flow if they have a key, otherwise they get redirected to the user account page | Required to create a passkey in passkey registration section (red alert icon) | Showing message |

The 'opt in' and 'opt out' routes have also been removed.

## See also
* [Asana ticket](https://app.asana.com/1/1210045093164357/project/1213783257830028/task/1215598074057725?focus=true)
