### PR TITLE
feat(setup): Automate AWS profile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,9 @@ line that invalidates the template
 
 Janus requires an AWS profile called `janus` to exist in your local AWS
 credentials file. Local dev is in a separate profile name so it is not
-overwritten when you obtain credentials using Janus. The credentials do
-not need to be real, you can get the application to run by adding the
-following to your AWS credentials file:
+overwritten when you obtain credentials using Janus.
 
-```
-[janus]
-aws_access_key_id = FAKE000KEYID
-aws_secret_access_key = FAKE000SECRETKEY
-```
+The `setup.sh` script will automatically configure this profile for you.
 
 #### Install Java
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 # Create a placeholder directory for janus-app config in ~/.gu
 mkdir -p ~/.gu/janus-app/data
-chown -R $(whoami):$(whoami) ~/.gu/janus-app/data
+chown -R $(whoami):staff ~/.gu/janus-app/data
 
 aws --profile security --region eu-west-1 sts get-caller-identity >/dev/null
 if [[ $? -ne 0 ]]; then
@@ -37,6 +37,15 @@ if [[ ! -f ~/.gu/janus-app/janusData.conf ]]; then
 else
   echo "janusData.conf is present"
 fi
+
+# Need AWS profile 'janus' to test access to dev-playground account.
+# See Readme.md 'Janus AWS Profile' section.
+aws --profile security --region eu-west-1 ssm get-parameter \
+  --name "/DEV/security/janus/janus.aws.profile" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text \
+  | aws configure import --csv file:///dev/stdin
 
 docker compose -f local-dev/docker-compose.yml up -d
 aws dynamodb list-tables --profile security --region eu-west-1 --endpoint http://localhost:8000


### PR DESCRIPTION
## Problem
We currently have quite an awkward manual process for getting hold of 'janus' AWS profile credentials, which have to be permanent for reasons explained [here]().
This manual process doesn't work in a repeatable dev container at all.

## Solution implemented
We now store the creds in an encrypted SSM param and install them locally as part of the new scripted setup process.

## Tested
Successfully ran the setup script using the standard dev permission locally and in a dev container in VSCode.
Verified that the janus profile ends up in the dev container's local creds store.
Running the app using the start script in a dev container allows getting creds for the dev playground account.

## See also
* The dev policy for running Janus locally needs to be able to read the new param:
https://github.com/guardian/janus/pull/5574