### PR TITLE
Handle mixed case email addresses in passkey checks

### DIFF
--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -271,11 +271,12 @@ class PasskeyController(
 
   private def verifyHasAccess(
       user: UserIdentity
-  ): Try[Unit] =
-    if hasAccess(user.username, janusData.access) ||
-      hasAccess(user.username, janusData.admin)
+  ): Try[Unit] = {
+    if hasAccess(user, janusData.access) ||
+      hasAccess(user, janusData.admin)
     then Success(())
     else Failure(JanusException.noAccessFailure(user))
+  }
 
   private def loadRegistrationChallenge(
       user: UserIdentity

--- a/app/logic/UserAccess.scala
+++ b/app/logic/UserAccess.scala
@@ -82,8 +82,9 @@ object UserAccess {
 
   /** Checks if the username is explicitly mentioned in the provided ACL.
     */
-  def hasAccess(username: String, acl: ACL): Boolean = {
-    acl.userAccess.contains(username)
+  def hasAccess(user: UserIdentity, acl: ACL): Boolean = {
+    import logic.UserAccess.username
+    acl.userAccess.contains(username(user))
   }
 
   /** Returns the set of developer policy grants explicitly assigned to the user

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -38,7 +38,7 @@
                         <ul class="right hide-on-med-and-down">
                             <li><a href="/accounts">Accounts</a></li>
                             <li><a href="/support">Support</a></li>
-                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
+                            @if(hasAccess(user, janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/user-account">@user.firstName @user.lastName</a></li>
                         </ul>
@@ -47,7 +47,7 @@
                             <li><a href="/">Home</a></li>
                             <li><a href="/accounts">Accounts</a></li>
                             @if(isSupportUser(username(user), Instant.now(), janusData.support)) { <li><a href="/support">Support</a></li> }
-                            @if(hasAccess(username(user), janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
+                            @if(hasAccess(user, janusData.admin)) { <li><a href="/superuser">Admin</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/user-account">@user.firstName @user.lastName <i class="material-icons right">perm_identity</i></a></li>
                         </ul>

--- a/test/logic/UserAccessTest.scala
+++ b/test/logic/UserAccessTest.scala
@@ -533,12 +533,22 @@ class UserAccessTest
       allTestPerms
     )
 
+    def getUserIdentityForEmail(email: String) =
+      UserIdentity("", email, "", "", 0L, None)
+
     "returns true when given a user that has an entry" in {
-      hasAccess("test.user", adminACL) shouldEqual true
+      val user = getUserIdentityForEmail("test.user@guardian.co.uk")
+      hasAccess(user, adminACL) shouldEqual true
+    }
+
+    "returns true when given a user that has an entry but Google Auth has given us a capitalised email" in {
+      val user = getUserIdentityForEmail("Test.User@guardian.co.uk")
+      hasAccess(user, adminACL) shouldEqual true
     }
 
     "returns false if the user is not explicitly mentioned" in {
-      hasAccess("not.in.the.list", adminACL) shouldEqual false
+      val user = getUserIdentityForEmail("not.in.the.list@guardian.co.uk")
+      hasAccess(user, adminACL) shouldEqual false
     }
   }
 


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Ensure that the email address used to check passkeys is also lower cased.

This is the minimal version to solve the problem of "Justin.Rowles" vs "justin.rowles".  The maximal version is in https://github.com/guardian/janus-app/pull/901, which has the same principle applied to everywhere that passes in a username.

## What is the value of this change and how do we measure success?


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->


## Any additional notes?

