### PR TITLE
css to control spinner rotation direction

### DIFF
--- a/app/views/accountPolicies.scala.html
+++ b/app/views/accountPolicies.scala.html
@@ -73,7 +73,7 @@
                                     <span role="heading" aria-level="2">@account.name</span>
                                     <span class="right">
                                         @if(serviceEnabled) {
-                                            <i class="material-icons small rotate">autorenew</i>
+                                            <i class="material-icons small rotate-clockwise">autorenew</i>
                                         } else {
                                             <i class="material-icons small">sync_problem</i>
                                         }

--- a/app/views/developerPoliciesStatus.scala.html
+++ b/app/views/developerPoliciesStatus.scala.html
@@ -53,7 +53,7 @@
                 <span class="right valign-wrapper">
                     @if(serviceEnabled) {
                         <span class="grey-text">Sync not yet completed</span>
-                        <i class="material-icons small rotate">autorenew</i>
+                        <i class="material-icons small rotate-clockwise">autorenew</i>
                     } else {
                         <span class="grey-text">Sync service disabled</span>
                         <i class="material-icons small">sync_problem</i>

--- a/app/views/passkeyAuth.scala.html
+++ b/app/views/passkeyAuth.scala.html
@@ -11,7 +11,7 @@
             <div class="passkey-prompt">
                 <i class="material-icons passkey-prompt__icon" aria-hidden="true">fingerprint</i>
                 <p class="passkey-prompt__text">Follow the prompts on your device to authenticate.</p>
-                <i class="material-icons passkey-prompt__spinner rotate" aria-hidden="true">sync</i>
+                <i class="material-icons passkey-prompt__spinner rotate-counterclockwise" aria-hidden="true">sync</i>
             </div>
         }
     </div>

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -714,11 +714,17 @@ a.copy-text--button__small {
     grid-template-columns: 1fr;
 }
 
-.rotate{
-    animation: spinner 5s linear infinite;
+.rotate-clockwise {
+    animation: spinner-clockwise 5s linear infinite;
 }
-@keyframes spinner {
+@keyframes spinner-clockwise {
     to { transform: rotate(360deg); }
+}
+.rotate-counterclockwise {
+    animation: spinner-counterclockwise 5s linear infinite;
+}
+@keyframes spinner-counterclockwise {
+    to { transform: rotate(-360deg); }
 }
 
 .developer-policy-chips {


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Updates the spinner on the passkey auth page to rotate in the same direction as the arrows point

Before:


https://github.com/user-attachments/assets/830b5b74-b8fa-4b1f-8a3e-c18e4c489d03


After:


https://github.com/user-attachments/assets/766a4afa-f854-4ea9-a080-418208c37db5



## What is the value of this change and how do we measure success?

Andrew gets less distracted by the spinner on the passkey auth page 😅 
