### PR TITLE
Provide DEV configuration file path to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,6 +90,8 @@ lazy val root: Project = (project in file("."))
       "-J-Xms1g",
       "-J-Xmx1g"
     ),
+    // use local config when running the app in dev mode from sbt
+    Runtime / javaOptions += s"-Dconfig.file=${sys.props("user.home")}/.gu/janus-app/janus.local.conf",
     // allows us to kick off the frontend dev-server when the API is run
     playRunHooks ++= Seq(
       RunClientHook(root.base),


### PR DESCRIPTION

## What is the purpose of this change?

When running the Play app locally using `sbt`, we now provide the path of the local configuration file. This prevents the user needing to remember to pass the correct `-Dconfig.file` property to sbt on every invocation.

## What is the value of this change and how do we measure success?

This makes it easier to set up a local dev environment, and simpler to use.
