### PR TITLE
Improve passkey banner display

### DIFF
--- a/app/logic/ViewHelpers.scala
+++ b/app/logic/ViewHelpers.scala
@@ -56,4 +56,17 @@ object ViewHelpers {
     case MaterialIcon(name: String)
     case AssetImage(path: String, alt: String)
   }
+
+  enum CtaLevel {
+    case Warn
+    case Error
+    case Info
+  }
+  object CtaLevel {
+    def cssClass(level: CtaLevel): String = level match {
+      case CtaLevel.Error => "banner-error red lighten-4"
+      case CtaLevel.Warn  => "banner-warn amber lighten-3"
+      case CtaLevel.Info  => "banner-info teal lighten-5"
+    }
+  }
 }

--- a/app/logic/ViewHelpers.scala
+++ b/app/logic/ViewHelpers.scala
@@ -57,16 +57,16 @@ object ViewHelpers {
     case AssetImage(path: String, alt: String)
   }
 
-  enum CtaLevel {
+  enum BannerLevel {
     case Warn
     case Error
     case Info
   }
-  object CtaLevel {
-    def cssClass(level: CtaLevel): String = level match {
-      case CtaLevel.Error => "banner-error red lighten-4"
-      case CtaLevel.Warn  => "banner-warn amber lighten-3"
-      case CtaLevel.Info  => "banner-info teal lighten-5"
+  object BannerLevel {
+    def cssClass(level: BannerLevel): String = level match {
+      case BannerLevel.Error => "banner-error red lighten-4"
+      case BannerLevel.Warn  => "banner-warn amber lighten-3"
+      case BannerLevel.Info  => "banner-info teal lighten-5"
     }
   }
 }

--- a/app/views/fragments/banner.scala.html
+++ b/app/views/fragments/banner.scala.html
@@ -1,0 +1,6 @@
+@import logic.ViewHelpers.CtaLevel
+
+@(ariaRegion: String, level: CtaLevel)(message: Html)
+
+@bannerCta(ariaRegion, level)(message){
+}

--- a/app/views/fragments/banner.scala.html
+++ b/app/views/fragments/banner.scala.html
@@ -1,6 +1,6 @@
-@import logic.ViewHelpers.CtaLevel
+@import logic.ViewHelpers.BannerLevel
 
-@(ariaRegion: String, level: CtaLevel)(message: Html)
+@(ariaRegion: String, level: BannerLevel)(message: Html)
 
 @bannerCta(ariaRegion, level)(message){
 }

--- a/app/views/fragments/bannerCta.scala.html
+++ b/app/views/fragments/bannerCta.scala.html
@@ -1,0 +1,17 @@
+@import logic.ViewHelpers.CtaLevel
+
+@(ariaRegion: String, level: CtaLevel)(message: Html)(cta: Html)
+
+
+<div role="region" aria-label="@ariaRegion">
+    <div class="main-banner @CtaLevel.cssClass(level)" role="status" aria-atomic="true">
+        <div class="container main-banner__container">
+            <div class="main-banner__message">
+                @message
+            </div>
+            <div class="main-banner__cta">
+                @cta
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/fragments/bannerCta.scala.html
+++ b/app/views/fragments/bannerCta.scala.html
@@ -1,10 +1,10 @@
-@import logic.ViewHelpers.CtaLevel
+@import logic.ViewHelpers.BannerLevel
 
-@(ariaRegion: String, level: CtaLevel)(message: Html)(cta: Html)
+@(ariaRegion: String, level: BannerLevel)(message: Html)(cta: Html)
 
 
 <div role="region" aria-label="@ariaRegion">
-    <div class="main-banner @CtaLevel.cssClass(level)" role="status" aria-atomic="true">
+    <div class="main-banner @BannerLevel.cssClass(level)" role="status" aria-atomic="true">
         <div class="container main-banner__container">
             <div class="main-banner__message">
                 @message

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -10,9 +10,10 @@
 @main("Your permissions", Some(user), janusData, displayMode) {
     @cacheStatus match {
         case DeveloperPolicyCacheStatus.Failure => {
-            @fragments.banner("Developer policy status", CtaLevel.Error) {
-                Developer policy failures detected - this may mean you have permissions that are not showing. Visit the <a href="@routes.AccountsController.accountDeveloperPolicies">
-                policies status page</a> for more information.
+            @fragments.bannerCta("Developer policy status", CtaLevel.Error) {
+                Developer policy failures detected - this may mean you have permissions that are not showing.
+            } {
+                <a href="@routes.AccountsController.accountDeveloperPolicies">status page</a>
             }
         }
         case DeveloperPolicyCacheStatus.Empty => {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,7 +2,7 @@
 @import com.gu.janus.model.{AwsAccount, JanusData}
 @import helper._
 @import models._
-@import logic.ViewHelpers.CtaLevel
+@import logic.ViewHelpers.BannerLevel
 @import play.api.Mode
 
 @(accountAccesses: List[AwsAccountAccess], cacheStatus: DeveloperPolicyCacheStatus, user: UserIdentity, janusData: JanusData, displayMode: DisplayMode, mfaComing: Boolean, mfaDaysRemaining: Long, mfaDisplayDate: String)(implicit req: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
@@ -10,26 +10,26 @@
 @main("Your permissions", Some(user), janusData, displayMode) {
     @cacheStatus match {
         case DeveloperPolicyCacheStatus.Failure => {
-            @fragments.bannerCta("Developer policy status", CtaLevel.Error) {
+            @fragments.bannerCta("Developer policy status", BannerLevel.Error) {
                 Developer policy failures detected - this may mean you have permissions that are not showing.
             } {
                 <a href="@routes.AccountsController.accountDeveloperPolicies">status page</a>
             }
         }
         case DeveloperPolicyCacheStatus.Empty => {
-            @fragments.banner("Developer policy status", CtaLevel.Warn) {
+            @fragments.banner("Developer policy status", BannerLevel.Warn) {
                 Developer policy cache is empty - this may mean you have permissions that are not showing. Try refreshing in a few moments.
             }
         }
         case DeveloperPolicyCacheStatus.Disabled => {
-            @fragments.banner("Developer policy status", CtaLevel.Error) {
+            @fragments.banner("Developer policy status", BannerLevel.Error) {
                 The developer policy service is disabled - this may mean you have permissions that are not showing. Please contact DevX Security for further information.
             }
         }
         case DeveloperPolicyCacheStatus.Success => {}
     }
     @if(mfaComing) {
-        @fragments.bannerCta("MFA status", CtaLevel.Warn) {
+        @fragments.bannerCta("MFA status", BannerLevel.Warn) {
             Janus will require Multi-Factor Authentication (MFA) in <strong>@mfaDaysRemaining</strong> days (@mfaDisplayDate).
         } {
             <a href="/user-account">Set up MFA</a>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -2,68 +2,63 @@
 @import com.gu.janus.model.{AwsAccount, JanusData}
 @import helper._
 @import models._
+@import logic.ViewHelpers.CtaLevel
 @import play.api.Mode
 
 @(accountAccesses: List[AwsAccountAccess], cacheStatus: DeveloperPolicyCacheStatus, user: UserIdentity, janusData: JanusData, displayMode: DisplayMode, mfaComing: Boolean, mfaDaysRemaining: Long, mfaDisplayDate: String)(implicit req: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Your permissions", Some(user), janusData, displayMode) {
-      <div class="container">
-          <h1 class="header orange-text hide">Your permissions</h1>
-          <div role="region" aria-label="Developer policy status">
-              @cacheStatus match {
-                  case DeveloperPolicyCacheStatus.Failure => {
-                      <div class="cache-status card-panel red lighten-4" role="status" aria-atomic="true">
-                      Developer policy failures detected - this may mean you have permissions that are not showing. Visit the <a href="@routes.AccountsController.accountDeveloperPolicies">policies status page</a> for more information.
-            </div>
-                  }
-                  case DeveloperPolicyCacheStatus.Empty => {
-                      <div class="cache-status card-panel yellow lighten-4" role="status" aria-atomic="true">
+    @cacheStatus match {
+        case DeveloperPolicyCacheStatus.Failure => {
+            @fragments.banner("Developer policy status", CtaLevel.Error) {
+                Developer policy failures detected - this may mean you have permissions that are not showing. Visit the <a href="@routes.AccountsController.accountDeveloperPolicies">
+                policies status page</a> for more information.
+            }
+        }
+        case DeveloperPolicyCacheStatus.Empty => {
+            @fragments.banner("Developer policy status", CtaLevel.Warn) {
                 Developer policy cache is empty - this may mean you have permissions that are not showing. Try refreshing in a few moments.
-                      </div>
-                  }
-                  case DeveloperPolicyCacheStatus.Disabled => {
-                      <div class="cache-status card-panel red lighten-4" role="status" aria-atomic="true">
+            }
+        }
+        case DeveloperPolicyCacheStatus.Disabled => {
+            @fragments.banner("Developer policy status", CtaLevel.Error) {
                 The developer policy service is disabled - this may mean you have permissions that are not showing. Please contact DevX Security for further information.
-                      </div>
-                  }
-                  case DeveloperPolicyCacheStatus.Success => {}
-              }
-          </div>
+            }
+        }
+        case DeveloperPolicyCacheStatus.Success => {}
+    }
+    @if(mfaComing) {
+        @fragments.bannerCta("MFA status", CtaLevel.Warn) {
+            Janus will require Multi-Factor Authentication (MFA) in <strong>@mfaDaysRemaining</strong> days (@mfaDisplayDate).
+        } {
+            <a href="/user-account">Set up MFA</a>
+        }
+    }
+    <div class="container">
+        <h1 class="header orange-text hide">Your permissions</h1>
 
-          <div role="region" aria-label="MFA status">
-              @if(mfaComing) {
-                  <div class="mfa-status card-panel red lighten-4" role="status" aria-atomic="true">
-                          <p class="warning">
-                              Janus will require Multi-Factor Authentication (MFA) in @mfaDaysRemaining days (@mfaDisplayDate).
-                              <br/>
-                              Set up MFA on your <a href="/user-account"> Janus account page</a>.
-                          </p>
-                  </div>
-              }
-
-          </div>
-          <div class="index-main__container">
-          @form(routes.Janus.favourite()) {
-              @CSRF.formField
-              @fragments.awsAccounts(accountAccesses, allowFavs = true, displayMode)
-          }
-          </div>
-          <div class="row">
-              <div class="col">
-                  <p>
-                      If these permissions don't seem right, you can check them in
-                      @janusData.permissionsRepo match {
-                          case None => {
-                              Janus' configuration.
-                  }
-                      case Some(repoUrl) => {
-                          <a href="@repoUrl">Janus' configuration</a>.
-                      }
-                  }
-                  </p>
-              </div>
-          </div>
-      </div>
+        <div class="index-main__container">
+        @form(routes.Janus.favourite()) {
+            @CSRF.formField
+            @fragments.awsAccounts(accountAccesses, allowFavs = true, displayMode)
+        }
+        </div>
+        <div class="row">
+            <div class="col">
+                <p>
+                    If these permissions don't seem right, you can check them in
+                    @janusData.permissionsRepo match {
+                        case None => {
+                            Janus' configuration.
+                        }
+                        case Some(repoUrl) => {
+                            <a href="@repoUrl">Janus' configuration</a>.
+                        }
+                    }
+                </p>
+            </div>
+        </div>
+    </div>
 
   @fragments.multiSelectHero()
 }

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -303,10 +303,6 @@ textarea.textarea--aws-profile-id.aws-profile-id {
     font-size: 0.8rem;
 }
 
-
-.cache-status.card-panel .mfa-status.card-panel {
-    margin: 20px 0 -10px;
-}
 .admin-notice-panel {
     margin-bottom: 0;
 }
@@ -812,3 +808,89 @@ a.copy-text--button__small {
     font-size: 12px;
     vertical-align: -1px;
 }
+
+/* CTA Banner */
+.main-banner {
+    padding: 10px 0;
+}
+
+.main-banner__container {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px 20px;
+}
+
+.main-banner__message {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: 0;
+}
+
+.main-banner__cta {
+    flex: 0 0 auto;
+    margin-left: auto;
+}
+
+/* Style CTA link as a link button */
+.main-banner__cta a {
+    display: inline-block;
+    white-space: nowrap;
+    padding: 0 1.25rem;
+    height: 36px;
+    line-height: 36px;
+    border-radius: 2px;
+    color: #fff;
+    font-weight: 500;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+    text-align: center;
+    transition: background-color 0.2s ease;
+}
+
+.main-banner__cta a:hover,
+.main-banner__cta a:focus {
+    filter: grayscale(7%);
+}
+
+.main-banner__cta a:active {
+    filter: grayscale(20%);
+}
+
+/* Below 600px the CTA wraps under the full-width message */
+@media screen and (max-width: 600px) {
+    .main-banner__container {
+        flex-wrap: wrap;
+    }
+
+    .main-banner__cta {
+        width: 100%;
+        margin-left: 0;
+    }
+
+    .main-banner__cta a {
+        display: block;
+        width: 100%;
+    }
+}
+
+.main-banner.banner-error {
+    border-bottom: solid 1px #c62828;
+}
+.main-banner.banner-error .main-banner__cta a {
+    background-color: #c62828;
+}
+.main-banner.banner-warn {
+    border-bottom: solid 1px #f57f17;
+}
+.main-banner.banner-warn .main-banner__cta a {
+    background-color: #f57f17;
+}
+.main-banner.banner-info {
+    border-bottom: solid 1px #00695c;
+}
+.main-banner.banner-info .main-banner__cta a {
+    background-color: #00695c;
+}
+


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

The passkey banner is front and centre for all our users (now only most, if some have set up MFA). This means it warrants a bit of design attention.

This PR introduces natively styled banners, and uses them for both the MFA notification and the existing developer policy service status messages.

Relatedly, I've switched the MFA banner from "error" to "warning". I think this is correct, because until MFA is required it isn't an error state to not have MFA. If we add a "you cannot proceed without MFA" banner in the future, I think that one **would** be an error.





## What is the value of this change and how do we measure success?

This takes up a lot less screen space at the top of the critical permissions page, and the design looks much more integrated in to Janus.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

#### Error banner
<img width="784" height="164" alt="Screenshot 2026-06-29 at 10 32 32" src="https://github.com/user-attachments/assets/c6a3b052-2652-4e14-a6dc-115d6261cb3c" />

#### Warning banner
<img width="784" height="164" alt="Screenshot 2026-06-29 at 10 32 43" src="https://github.com/user-attachments/assets/ccfc03ee-5509-4c84-8e38-86964fd5413d" />

#### Info banner
<img width="784" height="164" alt="Screenshot 2026-06-29 at 10 32 51" src="https://github.com/user-attachments/assets/bcbabd80-f02a-4f9c-8812-bbe159971d82" />

#### Stacked banners
<img width="784" height="223" alt="Screenshot 2026-06-29 at 10 33 48" src="https://github.com/user-attachments/assets/b2e722c1-71d9-4fd8-90e9-9956ae594deb" />


## Any additional notes?

