### PR TITLE
Improve readability of passkey docs information

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -49,7 +49,7 @@
                     </div>
                     <p>Titan security keys are available from the IT service desk in any office.
                         This is the preferred and best-supported option.</p>
-                    <p class="passkey-advice-item__notice grey-text">
+                    <p class="passkey-advice-item__notice grey-text text-darken-1">
                         If you use a phone, the Microsoft Authenticator app will not work as it can only create
                         passkeys for Microsoft accounts. Instead, use your phone's built-in passkey storage, such
                         as Apple&nbsp;Passwords (iPhone) or Google&nbsp;Password&nbsp;Manager (Android).
@@ -66,11 +66,11 @@
                         <i class="material-icons passkey-advice-item__visual-icon" aria-hidden="true">fingerprint</i>
                     </div>
                     <p>On a Mac, register a passkey in the Chrome browser to use Touch&nbsp;ID.</p>
-                    <p class="passkey-advice-item__notice grey-text">
+                    <p class="passkey-advice-item__notice grey-text text-darken-1">
                         On Windows, a fingerprint passkey may not be available, as
                         Windows&nbsp;Hello is disabled by default. Use a portable passkey instead.
                     </p>
-                    <p class="passkey-advice-item__notice grey-text">
+                    <p class="passkey-advice-item__notice grey-text text-darken-1">
                         Firefox doesn't yet have its own passkey-management system, so you'll either need to use
                         Google&nbsp;Chrome for Janus or stick to using a portable passkey.
                     </p>


### PR DESCRIPTION

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

We shouldn't be using light grey text for prose, because the contrast isn't enough to make it readable. The light grey is ok for design elements (as used elsewhere in the app), but here we need to darken it.

## What is the value of this change and how do we measure success?

Improves the accessibility of this information, while preserving the visual structure that the previous design introduced.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

### Tweaked design
<img width="872" height="544" alt="Screenshot 2026-07-07 at 16 02 09" src="https://github.com/user-attachments/assets/c715d55f-b18d-4dc2-b0d2-92c7d229d795" />


### The existing version, for reference
<img width="855" height="525" alt="Screenshot 2026-07-07 at 12 02 27" src="https://github.com/user-attachments/assets/04fb5fc7-c127-4b15-9350-f397654a85e0" />


