### PR TITLE
chore: Require passkey authentication

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,8 +96,8 @@ passkeys {
   # Disabled: passkey authentication is never required (use only for emergencies).
   #
 //  mode=Disabled
-//  mode=Required
-  mode=IfUserHasPasskey
+//  mode=IfUserHasPasskey
+  mode=Required
 
   manager {
     contactLink = ${PASSKEY_MANAGER_CONTACT_LINK}


### PR DESCRIPTION
This changes the passkey authentication setting to `Required`, meaning that all users must authenticate with a passkey to get access to credentials.