### PR TITLE
Revert "chore: Require passkey authentication"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,8 +96,8 @@ passkeys {
   # Disabled: passkey authentication is never required (use only for emergencies).
   #
 //  mode=Disabled
-//  mode=IfUserHasPasskey
-  mode=Required
+//  mode=Required
+  mode=IfUserHasPasskey
 
   manager {
     contactLink = ${PASSKEY_MANAGER_CONTACT_LINK}


### PR DESCRIPTION
Reverts guardian/janus-app#916 because needs a little more work on UX for users without a passkey.