### PR TITLE
feat: Add CTA for users without passkey

### DIFF
--- a/app/views/userAccount.scala.html
+++ b/app/views/userAccount.scala.html
@@ -1,6 +1,7 @@
 @import com.gu.googleauth.UserIdentity
 @import com.gu.janus.model.JanusData
 @import logic.UserAccess.username
+@import logic.ViewHelpers.BannerLevel
 @import models.PasskeyMode
 @import play.api.Mode
 @import java.time.Instant
@@ -17,6 +18,14 @@
 )(implicit request: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("User account", Some(user), janusData) {
+
+    @if(passkeys.isEmpty) {
+        @fragments.bannerCta("No passkey registered", BannerLevel.Error) {
+            Janus now requires a passkey to access AWS resources.
+        } {
+            <a href="#registered-passkeys">Register passkey</a>
+        }
+    }
 
     <div class="container" id="user-account-container">
         <h1 class="header orange-text">Account</h1>
@@ -74,7 +83,7 @@
 
         <div class="row">
             <div class="col s12">
-                <h4 class="header orange-text">Registered passkeys</h4>
+                <h4 id="registered-passkeys" class="header orange-text">Registered passkeys</h4>
             </div>
             <div class="col s12">
                 <div class="card-panel">


### PR DESCRIPTION
Users without a passkey are being redirected to the user account page but it isn't clear why they are on that page.  They need to scroll down to see the passkey registration section.

This change shows a CTA banner at the top of the page to users without a passkey to make this clearer:

<img width="1434" height="377" alt="image" src="https://github.com/user-attachments/assets/6ae5710b-8d54-493c-ad77-f29d01167c0c" />
