### PR TITLE
Reinstate passkey authentication requirement

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,8 +96,8 @@ passkeys {
   # Disabled: passkey authentication is never required (use only for emergencies).
   #
 //  mode=Disabled
-//  mode=Required
-  mode=IfUserHasPasskey
+//  mode=IfUserHasPasskey
+  mode=Required
 
   manager {
     contactLink = ${PASSKEY_MANAGER_CONTACT_LINK}


### PR DESCRIPTION
Reinstates #916 now that #918 is out so that the action we require of the user is clearer.