### PR TITLE
Provide clarity to users for "admin" permissions

### DIFF
--- a/app/logic/AccountOrdering.scala
+++ b/app/logic/AccountOrdering.scala
@@ -28,9 +28,12 @@ object AccountOrdering {
         else favIndex
       }
       .map { case (account, accountAccess) =>
+        val (adminPermissions, standardPermissions) =
+          partitionAdminPermissions(accountAccess.permissions.sorted)
         AwsAccountAccess(
           awsAccount = account,
-          permissions = accountAccess.permissions.sorted,
+          standardPermissions = standardPermissions,
+          adminPermissions = adminPermissions,
           developerPolicies = accountAccess.developerPolicies
             .flatMap { policy =>
               userPolicyGrants
@@ -46,6 +49,14 @@ object AccountOrdering {
           isFavourite = favourites.contains(account.authConfigKey)
         )
       }
+
+  /** Short-term account permissions are treated as admin permissions, and are
+    * displayed in their own UI section to discourage day-to-day use.
+    */
+  def partitionAdminPermissions(
+      permissions: List[Permission]
+  ): (List[Permission], List[Permission]) =
+    permissions.partition(_.shortTerm)
 
   /** 'dev' then then alphabetical 'others', finally 'cloudformation' (admin)
     * hard-coded dev/admin conventions for now, TODO: find a better

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -66,7 +66,8 @@ case class SourcedAccountAccess(
 
 case class AwsAccountAccess(
     awsAccount: AwsAccount,
-    permissions: List[Permission],
+    standardPermissions: List[Permission],
+    adminPermissions: List[Permission],
     developerPolicies: List[(DeveloperPolicyGrant, List[DeveloperPolicy])],
     isFavourite: Boolean
 )

--- a/app/views/fragments/awsAccounts.scala.html
+++ b/app/views/fragments/awsAccounts.scala.html
@@ -29,46 +29,35 @@
                 </div>
                 <div class="aws-account-body">
                 @fragments.developerPolicyGrants(accountAccess, allowFavs = true, displayMode)
-                @for(permission <- accountAccess.permissions) {
+                @for(permission <- accountAccess.standardPermissions) {
                     <div class="card-content card-content--permission-heading">
                         <p>
                             @permission.description
-                            @if(permission.shortTerm) {
-                                <i class="material-icons tooltipped" data-position="bottom" data-delay="50" data-tooltip="This permission only grants short-term access">error</i>
-                            }
                         </p>
                     </div>
-                    <div class="card-action card-action--permission">
-                        <div class="card-action-group__row row">
-                            <div class="card-action-group col m6 s12">
-                                <a href="/console?permissionId=@permission.id"
-                                   class="waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(permission.shortTerm) {short} else {standard} card-action-link--spaced"
-                                >
-                                    <i class="material-icons">cloud</i>
-                                </a>
-                                <a href="/consoleUrl?permissionId=@permission.id"
-                                   class="right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(permission.shortTerm) {short} else {standard}"
-                                >
-                                    <i class="material-icons black-text">link</i>
-                                </a>
-                            </div>
-                            <div class="card-action-group card-action-group--divider col m6 s12">
-                                <a href="/credentials?permissionId=@permission.id"
-                                   class="waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(permission.shortTerm) {short} else {standard}"
-                                >
-                                    <i class="material-icons">vpn_key</i>
-                                </a>
-                                @if(!permission.shortTerm) {
-                                    <div class="multi-select__container right">
-                                        <label class="multi-select__label">
-                                            <input class="multi-select__checkbox" type="checkbox" name="@permission.id" id="@permission.id" data-permission-id="@permission.id">
-                                            <span></span>
-                                        </label>
-                                    </div>
-                                }
-                            </div>
-                        </div>
+                    @fragments.permissionActions(permission)
+                }
+                @if(accountAccess.adminPermissions.nonEmpty) {
+                    <div class="card-content card-content--permission-group-header grey-text text-darken-2">
+                        <span class="developer-policy-grant-name admin-permissions-header">
+                            <i class="material-icons tiny" aria-hidden="true">admin_panel_settings</i>
+                            Admin permissions
+                        </span>
                     </div>
+                    <div class="card-content card-content--admin-permissions-note grey-text text-darken-1">
+                        <p>
+                            Do not expose admin credentials to untrusted code or AI tools
+                        </p>
+                    </div>
+                    @for(permission <- accountAccess.adminPermissions) {
+                        <div class="card-content card-content--permission-heading">
+                            <p>
+                                @permission.description
+                                <i class="material-icons tooltipped" data-position="bottom" data-delay="50" data-tooltip="Admin permission - grants short-term access only">admin_panel_settings</i>
+                            </p>
+                        </div>
+                        @fragments.permissionActions(permission)
+                    }
                 }
                 </div>
                 <div class="card-action card-action--audit-log">

--- a/app/views/fragments/developerPolicyGrants.scala.html
+++ b/app/views/fragments/developerPolicyGrants.scala.html
@@ -12,6 +12,9 @@
                     <div class="card-content card-content--permission-group-header grey-text text-darken-2">
                         <div class="developer-policy-grant-header">
                             <span class="developer-policy-grant-name">
+                                @if(grant.shortTerm) {
+                                    <i class="material-icons tiny tooltipped" data-position="bottom" data-delay="50" data-tooltip="This grant provides admin permissions (short-term access only)">admin_panel_settings</i>
+                                }
                                 @grant.name
                             </span>
                             <span class="developer-policy-grant-id tooltipped" data-position="bottom" data-delay="50" data-tooltip="Developer policy grant ID">
@@ -42,46 +45,16 @@
                             <div class="card-content--permission-heading__text">
                                 @policyPerm.description
                                 @if(policyPerm.shortTerm) {
-                                    <i class="material-icons tooltipped" data-position="bottom" data-delay="50" data-tooltip="This permission only grants short-term access">error</i>
+                                    <i class="material-icons tooltipped" data-position="bottom" data-delay="50" data-tooltip="Admin permission - grants short-term access only">admin_panel_settings</i>
                                 }
                             </div>
                         </div>
-                        <div class="card-action card-action--permission">
-                            <div class="card-action-group__row row">
-                                <div class="card-action-group col m6 s12">
-                                    <a href="/console?permissionId=@policyPerm.id"
-                                       class="waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(policyPerm.shortTerm) {short} else {standard} card-action-link--spaced"
-                                    >
-                                        <i class="material-icons">cloud</i>
-                                    </a>
-                                    <a href="/consoleUrl?permissionId=@policyPerm.id"
-                                       class="right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(policyPerm.shortTerm) {short} else {standard}"
-                                    >
-                                        <i class="material-icons black-text">link</i>
-                                    </a>
-                                </div>
-                                <div class="card-action-group card-action-group--divider col m6 s12">
-                                    <a href="/credentials?permissionId=@policyPerm.id"
-                                       class="waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(policyPerm.shortTerm) {short} else {standard}"
-                                    >
-                                        <i class="material-icons">vpn_key</i>
-                                    </a>
-                                    @if(!policyPerm.shortTerm) {
-                                        <div class="multi-select__container right">
-                                            <label class="multi-select__label">
-                                                <input class="multi-select__checkbox" type="checkbox" name="@policyPerm.id" id="@policyPerm.id" data-permission-id="@policyPerm.id">
-                                                <span></span>
-                                            </label>
-                                        </div>
-                                    }
-                                </div>
-                            </div>
-                        </div>
+                        @fragments.permissionActions(policyPerm)
                     }
                 }
 
                 @* Show a lower divider if there is content to divide *@
-                @if(accountAccess.developerPolicies.nonEmpty && accountAccess.permissions.nonEmpty) {
+                @if(accountAccess.developerPolicies.nonEmpty && accountAccess.standardPermissions.nonEmpty) {
                     <div class="card-content card-content--permission-group-header grey-text text-darken-2">
                         <span class="developer-policy-grant-name">
                             Account permissions

--- a/app/views/fragments/permissionActions.scala.html
+++ b/app/views/fragments/permissionActions.scala.html
@@ -1,0 +1,34 @@
+@import com.gu.janus.model.Permission
+@(permission: Permission)
+
+                        <div class="card-action card-action--permission">
+                            <div class="card-action-group__row row">
+                                <div class="card-action-group col m6 s12">
+                                    <a href="/console?permissionId=@permission.id"
+                                       class="waves-effect waves-light btn federation__link federation__link--cta federation__link--@if(permission.shortTerm) {short} else {standard} card-action-link--spaced"
+                                    >
+                                        <i class="material-icons">cloud</i>
+                                    </a>
+                                    <a href="/consoleUrl?permissionId=@permission.id"
+                                       class="right waves-effect waves-light btn-flat federation__link janus-btn--flat card-action-link--tight federation__link--@if(permission.shortTerm) {short} else {standard}"
+                                    >
+                                        <i class="material-icons black-text">link</i>
+                                    </a>
+                                </div>
+                                <div class="card-action-group card-action-group--divider col m6 s12">
+                                    <a href="/credentials?permissionId=@permission.id"
+                                       class="waves-effect waves-light btn federation__link federation__link--cta federation__link--credentials federation__link--@if(permission.shortTerm) {short} else {standard}"
+                                    >
+                                        <i class="material-icons">vpn_key</i>
+                                    </a>
+                                    @if(!permission.shortTerm) {
+                                        <div class="multi-select__container right">
+                                            <label class="multi-select__label">
+                                                <input class="multi-select__checkbox" type="checkbox" name="@permission.id" id="@permission.id" data-permission-id="@permission.id">
+                                                <span></span>
+                                            </label>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        </div>

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -303,6 +303,16 @@ textarea.textarea--aws-profile-id.aws-profile-id {
     font-size: 0.8rem;
 }
 
+.card .card-content.card-content--admin-permissions-note {
+    padding: 4px 17px;
+    background-color: rgb(255 248 225 / 65%);
+    font-size: 12px;
+}
+
+.card .card-content.card-content--admin-permissions-note p {
+    margin: 0;
+}
+
 .admin-notice-panel {
     margin-bottom: 0;
 }

--- a/test/logic/AccountOrderingTest.scala
+++ b/test/logic/AccountOrderingTest.scala
@@ -97,14 +97,15 @@ class AccountOrderingTest
     }
 
     "sorts the account permissions" in {
-      val fooPerms =
+      val fooAccess =
         orderedAccountAccess(awsAccountsAccess, devPolicyGrants, Nil)
           .find(_.awsAccount == fooAct)
           .value
-          .permissions
-      fooPerms shouldEqual List(
+      fooAccess.standardPermissions shouldEqual List(
         developerPermission(fooAct),
-        s3ManagerPermission(fooAct),
+        s3ManagerPermission(fooAct)
+      )
+      fooAccess.adminPermissions shouldEqual List(
         accountAdminPermission(fooAct)
       )
     }
@@ -188,6 +189,39 @@ class AccountOrderingTest
             .developerPolicies
         fooPolicies shouldEqual Nil
       }
+    }
+  }
+
+  "partitionAdminPermissions" - {
+    "returns short-term permissions as admin permissions" in {
+      val (adminPerms, _) = partitionAdminPermissions(
+        List(fooDev, fooCf, fooS3)
+      )
+      adminPerms shouldEqual List(fooCf)
+    }
+
+    "returns permissions that are not short-term as standard permissions" in {
+      val (_, standardPerms) = partitionAdminPermissions(
+        List(fooDev, fooCf, fooS3)
+      )
+      standardPerms shouldEqual List(fooDev, fooS3)
+    }
+
+    "preserves the provided order within each group" in {
+      val permissions = List(
+        developerPermission(fooAct),
+        accountAdminPermission(fooAct),
+        kinesisReadPermission(fooAct),
+        accountAdminPermission(barAct),
+        s3ReaderPermission(fooAct)
+      )
+      val (adminPerms, standardPerms) = partitionAdminPermissions(permissions)
+      standardPerms shouldEqual permissions.filterNot(_.shortTerm)
+      adminPerms shouldEqual permissions.filter(_.shortTerm)
+    }
+
+    "returns empty groups for no permissions" in {
+      partitionAdminPermissions(Nil) shouldEqual (Nil, Nil)
     }
   }
 


### PR DESCRIPTION


<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

**Direct Janus' users away from sensitive permissions outside of limited administrative activities.**

Uses the existing `shortTerm` flag on permissions to underpin modelling and UX for admin permissions. This allows us to provide a UX nudge away from using those permissions for day-to-day work to reduce the risk of supply-chain attacks and AI tooling.

## What is the value of this change and how do we measure success?

We'll expect to see reduced use of administrative permissions, especially for CLI sessions via Janus-bestowed credentials.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

Administrative permissions are grouped in their own section, which includes a warning notice at the top. Here's how it appears on the UI.

<img width="423" height="372" alt="Screenshot 2026-07-20 at 10 22 22" src="https://github.com/user-attachments/assets/8f275ec2-47b2-4b8b-ada6-eb0a9ac2b3c5" />

## Any additional notes?

This will come with some tweaks to our permissions in the config repository as well.

It's worth calling out that because re-uses the `shortTerm` flag, we only get this behaviour for permissions that can tolerate the lower session times. This makes sense because it prevents the multi-step rollout of a config change, and means we don't have two mostly overlapping concepts in the config format and codebase(s).
