### PR TITLE
Extends the maximum session length for "short-term" permissions

### DIFF
--- a/app/aws/Federation.scala
+++ b/app/aws/Federation.scala
@@ -24,7 +24,7 @@ object Federation {
   /** Credential/Console lease times. Defaults are used when user doesn't
     * request specific time periods, max will limit how long can be requested.
     */
-  val maxShortTime: Duration = 3.hours
+  val maxShortTime: Duration = 8.hours
   val minShortTime: Duration = 15.minutes
   val defaultShortTime: Duration = 1.hour
   val maxLongTime: Duration = 10.hours

--- a/app/views/fragments/multiSelectHero.scala.html
+++ b/app/views/fragments/multiSelectHero.scala.html
@@ -55,6 +55,7 @@
                     <ul id='dropdown-time--short' class='dropdown-content'>
                         <li><a href="#!" data-length="short" data-duration="1800000" class="dropdown-time__link">30 mins</a></li>
                         <li><a href="#!" data-length="short" data-duration="@defaultShortTime.toMillis" class="dropdown-time__link dropdown-time__link--default">@formatDuration(defaultShortTime)</a></li>
+                        <li><a href="#!" data-length="short" data-duration="10800000" class="dropdown-time__link">3 hours</a></li>
                         <li><a href="#!" data-length="short" data-duration="@maxShortTime.toMillis" class="dropdown-time__link dropdown-time__link--max">@formatDuration(maxShortTime)</a></li>
                     </ul>
                 </div>


### PR DESCRIPTION

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Extends the maximum time for `shortTerm` permissions, and provides more flexibility for short term session length selection in the UI.

## What is the value of this change and how do we measure success?

This may be required as a temporary measure while if we mark more permissions as being short-term. Let's be driven by the need, if it arises.

See also: https://github.com/guardian/janus-app/pull/922, which makes it clearer to users of Janus which of their permissions should be considered "admin".

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->

The select still defaults to 1 hour:
<img width="471" height="70" alt="Screenshot 2026-07-20 at 17 50 40" src="https://github.com/user-attachments/assets/edba86ff-d1a6-4a78-909c-454d787f7bbb" />

But now includes more (and longer) options:
<img width="471" height="209" alt="Screenshot 2026-07-20 at 17 50 28" src="https://github.com/user-attachments/assets/1e83f2de-9b7b-4d79-9bc5-e1216cbd9450" />
