### PR TITLE
Rename AccessSource.Admin to AccessSource.Superuser

### DIFF
--- a/app/logic/UserAccess.scala
+++ b/app/logic/UserAccess.scala
@@ -9,7 +9,7 @@ import com.gu.janus.model.PermissionType.{
 import logic.DeveloperPolicies.toPermission
 import logic.UserAccess.username
 import models.*
-import models.AccessSource.{Admin, Internal, Support}
+import models.AccessSource.{Internal, Superuser, Support}
 
 import java.time.Instant
 
@@ -115,7 +115,7 @@ object UserAccess {
         access: SourcedAccountAccess
     ): List[(AccountAccess, AccessSource)] = List(
       access.internal -> Internal,
-      access.superuser -> Admin,
+      access.superuser -> Superuser,
       access.support -> Support
     )
 
@@ -132,7 +132,7 @@ object UserAccess {
           val policyGrants = src match {
             case Internal =>
               policyGrantsForUser(user, acl = janusData.access)
-            case Admin =>
+            case Superuser =>
               policyGrantsForUser(user, acl = janusData.admin)
             case Support => Set.empty
           }

--- a/app/models/models.scala
+++ b/app/models/models.scala
@@ -38,7 +38,7 @@ enum AccessSource {
     /** Access given in the standard ACL, including default permissions */
     Internal,
     /** Access given in the superuser ACL */
-    Admin,
+    Superuser,
     /** Access given in the support ACL */
     Support
 }

--- a/test/logic/UserAccessTest.scala
+++ b/test/logic/UserAccessTest.scala
@@ -752,7 +752,7 @@ class UserAccessTest
         permission.shortTerm shouldEqual true
       }
 
-      "source is Admin ACL" in {
+      "source is Superuser ACL" in {
         val (_, source, _) = checkUserPermissionWithSource(
           toUser("superuser.user"),
           derivedPermission.id,
@@ -760,7 +760,7 @@ class UserAccessTest
           janusData,
           Set(policy)
         ).value
-        source shouldEqual AccessSource.Admin
+        source shouldEqual AccessSource.Superuser
       }
 
       "permission type is DeveloperPolicyPermission" in {
@@ -810,7 +810,7 @@ class UserAccessTest
         source shouldEqual AccessSource.Internal
       }
 
-      "is Admin when the permission was granted via superuser access only" in {
+      "is Superuser when the permission was granted via superuser access only" in {
         val (_, source, _) = checkUserPermissionWithSource(
           toUser("superuser"),
           fooDev.id,
@@ -818,7 +818,7 @@ class UserAccessTest
           janusData,
           Set.empty
         ).value
-        source shouldEqual AccessSource.Admin
+        source shouldEqual AccessSource.Superuser
       }
 
       "is Support when the permission was granted via support access only" in {

--- a/test/services/MetricsServiceTest.scala
+++ b/test/services/MetricsServiceTest.scala
@@ -26,7 +26,11 @@ class MetricsServiceTest
     with ScalaCheckPropertyChecks {
 
   private def accessSourceGen =
-    Gen.oneOf(AccessSource.Internal, AccessSource.Admin, AccessSource.Support)
+    Gen.oneOf(
+      AccessSource.Internal,
+      AccessSource.Superuser,
+      AccessSource.Support
+    )
 
   private def accessTypeGen = Gen.oneOf(JCredentials, JConsole)
 


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer**: AI was used to significantly generate all the stacked PRs associated with this change. I've manually reviewed all the work and taken time to edit and curate the AI's output (both code and text), but this work has primarily been done by Opus 5 via the GitHub Copilot CLI.

Renames `AccessSource.Admin` to `AccessSource.Superuser`, continuing the rename from #930.

> [!WARNING]
> **This changes an emitted CloudWatch metric dimension.** The `access-source` dimension will start emitting `Superuser` instead of `Admin`, which starts a new time series. Existing dashboards and alarms that filter on `access-source = Admin` will need updating.

The dimension value comes from the enum name, so it changes with the rename.


---

Part of #937, which tracks the whole migration including the releases,
deploys and verification steps between these PRs.

1. app: rename estate-wide concept to superuser (#930)
1. app: rename `AccessSource.Admin` to `Superuser` (#931)  ← **you are here**
1. configTools: read both `superuser` and legacy `admin` keys (#932)
1. guardian/janus and other consumers: bump to 11.1.0
1. configTools: write `superuser`, rename `JanusData.admin` (#933)
1. example project pinned to 12.0.0 (#934) — CI red until 12.0.0 ships
1. guardian/janus and other consumers: bump to 12.0.0
1. configTools: remove legacy `admin` read support (#935)
1. guardian/janus and other consumers: bump to 13.0.0
