### PR TITLE
configTools: read the superuser ACL from either config key

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/config/Loader.scala
+++ b/configTools/src/main/scala/com/gu/janus/config/Loader.scala
@@ -13,15 +13,18 @@ import scala.util.Try
   * fails, a description of the failure is made available.
   */
 object Loader {
+  private val superuserPath = "janus.superuser"
+  private val legacySuperuserPath = "janus.admin"
+
   def fromConfig(config: Config): Either[String, JanusData] = {
     for {
       permissionsRepo <- loadPermissionsRepo(config)
       accounts <- loadAccounts(config)
       permissions <- loadPermissions(config, accounts)
       access <- loadAccess(config, permissions)
-      admin <- loadAdmin(config, permissions)
+      superuser <- loadSuperuser(config, permissions)
       support <- loadSupport(config, permissions)
-    } yield JanusData(accounts, access, admin, support, permissionsRepo)
+    } yield JanusData(accounts, access, superuser, support, permissionsRepo)
   }
 
   private[config] def loadPermissionsRepo(
@@ -114,22 +117,32 @@ object Loader {
     } yield ACL(acl.toMap, defaultAccess.toSet)
   }
 
-  private[config] def loadAdmin(
+  /** Loads the estate-wide superuser ACL.
+    *
+    * This access was previously called "admin", and config files using the
+    * legacy `janus.admin` key are still supported. `janus.superuser` is used
+    * when both keys are present.
+    */
+  private[config] def loadSuperuser(
       config: Config,
       permissions: Set[Permission]
   ): Either[String, ACL] = {
+    val path =
+      if (config.hasPath(superuserPath)) superuserPath
+      else if (config.hasPath(legacySuperuserPath)) legacySuperuserPath
+      else superuserPath
     for {
       configuredAccess <- config
-        .as[ConfiguredAdmin]("janus.admin")
+        .as[ConfiguredSuperuser](path)
         .left
         .map(err =>
-          s"Failed to load admin config from path `janus.admin`: ${err.getMessage}"
+          s"Failed to load superuser config from path `$path`: ${err.getMessage}"
         )
       acl <- parseAclEntries(configuredAccess.acl, permissions)
     } yield ACL(
       acl.toMap,
       Set.empty
-    ) // TODO: these shouldn't share a representation since Admin doesn't need the default permissions
+    ) // TODO: these shouldn't share a representation since the superuser ACL doesn't need the default permissions
   }
 
   private[config] def parseAclEntries(

--- a/configTools/src/main/scala/com/gu/janus/model/configuredRepresentation.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/configuredRepresentation.scala
@@ -60,7 +60,7 @@ case class ConfiguredAccess(
 )
 
 // helps circe-config auto-extract data
-case class ConfiguredAdmin(
+case class ConfiguredSuperuser(
     acl: Map[String, List[
       ConfiguredAclEntry | ConfiguredDeveloperPolicyGrantAclEntry
     ]]

--- a/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
@@ -2,7 +2,7 @@ package com.gu.janus.config
 
 import com.gu.janus.model.*
 import com.gu.janus.testutils.HaveMatchers
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
@@ -31,6 +31,20 @@ class LoaderTest
       val janusData = Loader.fromConfig(testConfigWithoutPermissionsRepo).value
       // TODO: check the data here as well
       janusData.permissionsRepo shouldEqual None
+    }
+
+    "parses an example that uses the superuser key" in {
+      val config = ConfigFactory
+        .parseString(
+          """janus.superuser.acl {
+            |  employee2 = [
+            |    { account = "website", label = "s3-manager" }
+            |  ]
+            |}""".stripMargin
+        )
+        .withFallback(testConfig.withoutPath("janus.admin"))
+      val janusData = Loader.fromConfig(config).value
+      janusData.admin.userAccess.keySet shouldEqual Set("employee2")
     }
   }
 
@@ -172,18 +186,57 @@ class LoaderTest
     }
   }
 
-  "loadAdmin" - {
-    "loads the example file's admin definition" in {
-      val accounts = Loader.loadAccounts(testConfig).value
-      val permissions = Loader.loadPermissions(testConfig, accounts).value
-      val adminAcl = Loader.loadAdmin(testConfig, permissions).value
-      adminAcl.userAccess
+  "loadSuperuser" - {
+    val superuserBlock = ConfigFactory.parseString(
+      """janus.superuser.acl {
+        |  employee2 = [
+        |    { account = "website", label = "s3-manager" }
+        |  ]
+        |}""".stripMargin
+    )
+    val withoutLegacyKey = testConfig.withoutPath("janus.admin")
+
+    def superuserAclFor(config: Config) = {
+      val accounts = Loader.loadAccounts(config).value
+      val permissions = Loader.loadPermissions(config, accounts).value
+      Loader.loadSuperuser(config, permissions).value
+    }
+
+    "loads the example file's legacy admin definition" in {
+      superuserAclFor(testConfig).userAccess
         .get("employee1")
         .value
         .permissions
         .map(_.id) shouldEqual Set(
         "website-admin"
       )
+    }
+
+    "loads a superuser definition" in {
+      val config = superuserBlock.withFallback(withoutLegacyKey)
+      superuserAclFor(config).userAccess
+        .get("employee2")
+        .value
+        .permissions
+        .map(_.id) shouldEqual Set(
+        "website-s3-manager"
+      )
+    }
+
+    "prefers the superuser key when both keys are present" in {
+      val config = superuserBlock.withFallback(testConfig)
+      val userAccess = superuserAclFor(config).userAccess
+      userAccess.keySet shouldEqual Set("employee2")
+    }
+
+    "fails when neither key is present" in {
+      val accounts = Loader.loadAccounts(withoutLegacyKey).value
+      val permissions =
+        Loader.loadPermissions(withoutLegacyKey, accounts).value
+      Loader
+        .loadSuperuser(withoutLegacyKey, permissions)
+        .left
+        .value should include("janus.superuser")
     }
   }
 


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer**: AI was used to significantly generate all the stacked PRs associated with this change. I've manually reviewed all the work and taken time to edit and curate the AI's output (both code and text), but this work has primarily been done by Opus 5 via the GitHub Copilot CLI.

Teaches the config loader to read the superuser ACL from either `janus.superuser` or the legacy `janus.admin` key.

This is the first step of the config format migration, which is split up to allow us to roll back. This change means the Janus application understands both formats, so a config file in either shape is valid.

- `Loader.loadAdmin` becomes `loadSuperuser`, reading `janus.superuser` first and falling back to `janus.admin`
- `ConfiguredAdmin` becomes `ConfiguredSuperuser`
- If a config file contains both keys, `superuser` wins
- If neither key is present, loading fails and the error names the new key, `janus.superuser`

The writer, the Twirl template and `JanusData.admin` are unchanged, so this is not a breaking change and no release is required.


---

Part of #937, which tracks the whole migration including the releases,
deploys and verification steps between these PRs.

1. app: rename estate-wide concept to superuser (#930)
1. app: rename `AccessSource.Admin` to `Superuser` (#931)
1. configTools: read both `superuser` and legacy `admin` keys (#932)  ← **you are here**
1. guardian/janus and other consumers: bump to 11.1.0
1. configTools: write `superuser`, rename `JanusData.admin` (#933)
1. example project pinned to 12.0.0 (#934) — CI red until 12.0.0 ships
1. guardian/janus and other consumers: bump to 12.0.0
1. configTools: remove legacy `admin` read support (#935)
1. guardian/janus and other consumers: bump to 13.0.0
