### PR TITLE
configTools: write the superuser key and rename JanusData.admin

### DIFF
--- a/app/controllers/Janus.scala
+++ b/app/controllers/Janus.scala
@@ -131,7 +131,7 @@ class Janus(
         )
         userPolicyGrants = policyGrantsForUser(
           request.user,
-          janusData.admin
+          janusData.superuser
         )
         uiAccountAccess = orderedAccountAccess(accountsAccess, userPolicyGrants)
         cacheStatus = DeveloperPolicies.lookupDeveloperPolicyCacheStatus(

--- a/app/controllers/PasskeyController.scala
+++ b/app/controllers/PasskeyController.scala
@@ -273,7 +273,7 @@ class PasskeyController(
       user: UserIdentity
   ): Try[Unit] = {
     if hasAccess(user, janusData.access) ||
-      hasAccess(user, janusData.admin)
+      hasAccess(user, janusData.superuser)
     then Success(())
     else Failure(JanusException.noAccessFailure(user))
   }

--- a/app/logic/UserAccess.scala
+++ b/app/logic/UserAccess.scala
@@ -65,7 +65,7 @@ object UserAccess {
     val access = totalUserAccess(
       user,
       internalAcl = None,
-      superuserAcl = Some(janusData.admin),
+      superuserAcl = Some(janusData.superuser),
       supportData = None,
       developerPolicies
     )
@@ -122,7 +122,7 @@ object UserAccess {
     totalUserAccess(
       user,
       Some(janusData.access),
-      Some(janusData.admin),
+      Some(janusData.superuser),
       Some((janusData.support, date)),
       developerPolicies
     ).valuesIterator
@@ -133,7 +133,7 @@ object UserAccess {
             case Internal =>
               policyGrantsForUser(user, acl = janusData.access)
             case Superuser =>
-              policyGrantsForUser(user, acl = janusData.admin)
+              policyGrantsForUser(user, acl = janusData.superuser)
             case Support => Set.empty
           }
           aa.permissions

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -38,7 +38,7 @@
                         <ul class="right hide-on-med-and-down">
                             <li><a href="/accounts">Accounts</a></li>
                             <li><a href="/support">Support</a></li>
-                            @if(hasAccess(user, janusData.admin)) { <li><a href="/superuser">Superuser</a></li> }
+                            @if(hasAccess(user, janusData.superuser)) { <li><a href="/superuser">Superuser</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/user-account">@user.firstName @user.lastName</a></li>
                         </ul>
@@ -47,7 +47,7 @@
                             <li><a href="/">Home</a></li>
                             <li><a href="/accounts">Accounts</a></li>
                             @if(isSupportUser(user, Instant.now(), janusData.support)) { <li><a href="/support">Support</a></li> }
-                            @if(hasAccess(user, janusData.admin)) { <li><a href="/superuser">Superuser</a></li> }
+                            @if(hasAccess(user, janusData.superuser)) { <li><a href="/superuser">Superuser</a></li> }
                             <li><a href="/revoke">Revoke</a></li>
                             <li><a href="/user-account">@user.firstName @user.lastName <i class="material-icons right">perm_identity</i></a></li>
                         </ul>

--- a/configTools/src/main/scala/com/gu/janus/model/models.scala
+++ b/configTools/src/main/scala/com/gu/janus/model/models.scala
@@ -8,7 +8,7 @@ import java.time.{Duration, Instant}
 case class JanusData(
     accounts: Set[AwsAccount],
     access: ACL,
-    admin: ACL,
+    superuser: ACL,
     support: SupportACL,
     permissionsRepo: Option[String]
 )
@@ -160,7 +160,7 @@ object Permission {
 
     janusData.access.defaultPermissions ++
       perms(janusData.access.userAccess) ++
-      perms(janusData.admin.userAccess) ++
+      perms(janusData.superuser.userAccess) ++
       janusData.support.supportAccess
   }
 }

--- a/configTools/src/main/twirl/com/gu/janus/config/templates/janusData.scala.txt
+++ b/configTools/src/main/twirl/com/gu/janus/config/templates/janusData.scala.txt
@@ -51,9 +51,9 @@ janus {
         }
     }
 
-    admin {
+    superuser {
         acl {
-            @for((user, aclEntry) <- janusData.admin.userAccess){
+            @for((user, aclEntry) <- janusData.superuser.userAccess){
                 "@user" = [
                     @for(permission <- aclEntry.permissions) {
                         @permissionReference(permission)

--- a/configTools/src/test/resources/example.conf
+++ b/configTools/src/test/resources/example.conf
@@ -57,7 +57,7 @@ janus {
     }
   }
 
-  admin {
+  superuser {
     acl {
       employee1 = [
         { account = "website", label = "admin" }

--- a/configTools/src/test/scala/com/gu/janus/ValidationTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/ValidationTest.scala
@@ -94,12 +94,12 @@ class ValidationTest extends AnyFreeSpec with Matchers {
         }
       }
 
-      "in the admin ACL" - {
+      "in the superuser ACL" - {
         "for a large inline policy" in {
           val janusData = JanusData(
             Set(account1),
             emptyAcl,
-            admin =
+            superuser =
               ACL(Map("user1" -> ACLEntry(Set(largePermission), Set.empty))),
             emptySupportAcl,
             None
@@ -111,7 +111,7 @@ class ValidationTest extends AnyFreeSpec with Matchers {
           val janusData = JanusData(
             Set(account1),
             emptyAcl,
-            admin = ACL(
+            superuser = ACL(
               Map(
                 "user1" -> ACLEntry(
                   Set(smallPermissionWithLargeManagedPolicyArns),

--- a/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/ConfigIntegrationTests.scala
@@ -32,7 +32,7 @@ class ConfigIntegrationTests
 
       janusData.accounts shouldEqual reloadedJanusData.accounts
       janusData.access shouldEqual reloadedJanusData.access
-      janusData.admin shouldEqual reloadedJanusData.admin
+      janusData.superuser shouldEqual reloadedJanusData.superuser
       janusData.support shouldEqual reloadedJanusData.support
       janusData.permissionsRepo shouldEqual reloadedJanusData.permissionsRepo
 
@@ -61,7 +61,7 @@ class ConfigIntegrationTests
 
       janusData.accounts shouldEqual reloadedJanusData.accounts
       janusData.access shouldEqual reloadedJanusData.access
-      janusData.admin shouldEqual reloadedJanusData.admin
+      janusData.superuser shouldEqual reloadedJanusData.superuser
       janusData.support shouldEqual reloadedJanusData.support
       janusData.permissionsRepo shouldEqual reloadedJanusData.permissionsRepo
 

--- a/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
@@ -33,18 +33,18 @@ class LoaderTest
       janusData.permissionsRepo shouldEqual None
     }
 
-    "parses an example that uses the superuser key" in {
+    "parses an example that uses the legacy admin key" in {
       val config = ConfigFactory
         .parseString(
-          """janus.superuser.acl {
+          """janus.admin.acl {
             |  employee2 = [
             |    { account = "website", label = "s3-manager" }
             |  ]
             |}""".stripMargin
         )
-        .withFallback(testConfig.withoutPath("janus.admin"))
+        .withFallback(testConfig.withoutPath("janus.superuser"))
       val janusData = Loader.fromConfig(config).value
-      janusData.admin.userAccess.keySet shouldEqual Set("employee2")
+      janusData.superuser.userAccess.keySet shouldEqual Set("employee2")
     }
   }
 
@@ -187,14 +187,14 @@ class LoaderTest
   }
 
   "loadSuperuser" - {
-    val superuserBlock = ConfigFactory.parseString(
-      """janus.superuser.acl {
+    val legacyBlock = ConfigFactory.parseString(
+      """janus.admin.acl {
         |  employee2 = [
         |    { account = "website", label = "s3-manager" }
         |  ]
         |}""".stripMargin
     )
-    val withoutLegacyKey = testConfig.withoutPath("janus.admin")
+    val withoutSuperuserKey = testConfig.withoutPath("janus.superuser")
 
     def superuserAclFor(config: Config) = {
       val accounts = Loader.loadAccounts(config).value
@@ -202,7 +202,7 @@ class LoaderTest
       Loader.loadSuperuser(config, permissions).value
     }
 
-    "loads the example file's legacy admin definition" in {
+    "loads the example file's superuser definition" in {
       superuserAclFor(testConfig).userAccess
         .get("employee1")
         .value
@@ -212,8 +212,8 @@ class LoaderTest
       )
     }
 
-    "loads a superuser definition" in {
-      val config = superuserBlock.withFallback(withoutLegacyKey)
+    "loads a legacy admin definition" in {
+      val config = legacyBlock.withFallback(withoutSuperuserKey)
       superuserAclFor(config).userAccess
         .get("employee2")
         .value
@@ -224,17 +224,16 @@ class LoaderTest
     }
 
     "prefers the superuser key when both keys are present" in {
-      val config = superuserBlock.withFallback(testConfig)
-      val userAccess = superuserAclFor(config).userAccess
-      userAccess.keySet shouldEqual Set("employee2")
+      val config = legacyBlock.withFallback(testConfig)
+      superuserAclFor(config).userAccess.keySet shouldEqual Set("employee1")
     }
 
     "fails when neither key is present" in {
-      val accounts = Loader.loadAccounts(withoutLegacyKey).value
+      val accounts = Loader.loadAccounts(withoutSuperuserKey).value
       val permissions =
-        Loader.loadPermissions(withoutLegacyKey, accounts).value
+        Loader.loadPermissions(withoutSuperuserKey, accounts).value
       Loader
-        .loadSuperuser(withoutLegacyKey, permissions)
+        .loadSuperuser(withoutSuperuserKey, permissions)
         .left
         .value should include("janus.superuser")
     }

--- a/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/WriterTest.scala
@@ -21,7 +21,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         Some("https://example.com/")
       )
@@ -34,7 +34,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -53,7 +53,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
         Set(account1),
         access =
           ACL(Map("user1" -> ACLEntry(Set(permission), Set.empty)), Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -74,7 +74,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
         Set(account1),
         access =
           ACL(Map("user1" -> ACLEntry(Set(permission), Set.empty)), Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -105,7 +105,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
             Map("testuser" -> ACLEntry(Set(permission), Set.empty)),
             Set.empty
           ),
-          admin = ACL(Map.empty, Set.empty),
+          superuser = ACL(Map.empty, Set.empty),
           SupportACL.create(Map.empty, Set.empty),
           None
         )
@@ -119,7 +119,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
             Map("testuser" -> ACLEntry(Set.empty, Set(grant))),
             Set.empty
           ),
-          admin = ACL(Map.empty, Set.empty),
+          superuser = ACL(Map.empty, Set.empty),
           SupportACL.create(Map.empty, Set.empty),
           None
         )
@@ -135,7 +135,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
             Map("testuser" -> ACLEntry(Set.empty, Set(grant))),
             Set.empty
           ),
-          admin = ACL(Map.empty, Set.empty),
+          superuser = ACL(Map.empty, Set.empty),
           SupportACL.create(Map.empty, Set.empty),
           None
         )
@@ -155,7 +155,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
             Map("testuser" -> ACLEntry(Set.empty, Set(grant1, grant2))),
             Set.empty
           ),
-          admin = ACL(Map.empty, Set.empty),
+          superuser = ACL(Map.empty, Set.empty),
           SupportACL.create(Map.empty, Set.empty),
           None
         )
@@ -190,7 +190,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
             Map("testuser" -> ACLEntry(Set(perm1, perm2), Set(grant1, grant2))),
             Set.empty
           ),
-          admin = ACL(Map.empty, Set.empty),
+          superuser = ACL(Map.empty, Set.empty),
           SupportACL.create(Map.empty, Set.empty),
           None
         )
@@ -221,7 +221,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
       }
     }
 
-    "admin section" - {
+    "superuser section" - {
       val permission = Permission(
         account1,
         "adminPerm",
@@ -232,11 +232,11 @@ class WriterTest extends AnyFreeSpec with Matchers {
       val grant =
         DeveloperPolicyGrant("AdminGrant", "admin-grant-id", shortTerm = false)
 
-      "includes user in admin ACL" in {
+      "includes user in superuser ACL" in {
         val janusData = JanusData(
           Set(account1),
           access = ACL(Map.empty, Set.empty),
-          admin = ACL(
+          superuser = ACL(
             Map("adminuser" -> ACLEntry(Set(permission), Set.empty)),
             Set.empty
           ),
@@ -246,11 +246,25 @@ class WriterTest extends AnyFreeSpec with Matchers {
         Writer.toConfig(janusData) should include(""""adminuser"""")
       }
 
-      "includes DeveloperPolicyGrant in admin ACL entry" in {
+      "writes the ACL under the superuser key" in {
         val janusData = JanusData(
           Set(account1),
           access = ACL(Map.empty, Set.empty),
-          admin = ACL(
+          superuser = ACL(
+            Map("adminuser" -> ACLEntry(Set(permission), Set.empty)),
+            Set.empty
+          ),
+          SupportACL.create(Map.empty, Set.empty),
+          None
+        )
+        Writer.toConfig(janusData) should include("superuser {")
+      }
+
+      "includes DeveloperPolicyGrant in superuser ACL entry" in {
+        val janusData = JanusData(
+          Set(account1),
+          access = ACL(Map.empty, Set.empty),
+          superuser = ACL(
             Map("adminuser" -> ACLEntry(Set.empty, Set(grant))),
             Set.empty
           ),
@@ -262,11 +276,11 @@ class WriterTest extends AnyFreeSpec with Matchers {
         )
       }
 
-      "includes DeveloperPolicyGrant id in admin ACL entry" in {
+      "includes DeveloperPolicyGrant id in superuser ACL entry" in {
         val janusData = JanusData(
           Set(account1),
           access = ACL(Map.empty, Set.empty),
-          admin = ACL(
+          superuser = ACL(
             Map("adminuser" -> ACLEntry(Set.empty, Set(grant))),
             Set.empty
           ),
@@ -294,7 +308,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
         val janusData = JanusData(
           Set(account1),
           access = ACL(Map.empty, Set.empty),
-          admin = ACL(
+          superuser = ACL(
             Map("adminuser" -> ACLEntry(Set.empty, Set(grant1, grant2))),
             Set.empty
           ),
@@ -347,7 +361,7 @@ class WriterTest extends AnyFreeSpec with Matchers {
         val janusData = JanusData(
           Set(account1),
           access = ACL(Map.empty, Set.empty),
-          admin = ACL(
+          superuser = ACL(
             Map(
               "adminuser" -> ACLEntry(Set(perm1, perm2), Set(grant1, grant2))
             ),

--- a/configTools/src/test/scala/com/gu/janus/model/PermissionTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/model/PermissionTest.scala
@@ -19,7 +19,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -32,7 +32,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set(permission)),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -46,7 +46,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
         Set.empty,
         access =
           ACL(Map("user1" -> ACLEntry(Set(permission), Set.empty)), Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -67,7 +67,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
           ),
           Set.empty
         ),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         SupportACL.create(Map.empty, Set.empty),
         None
       )
@@ -85,7 +85,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set.empty),
-        admin = ACL(
+        superuser = ACL(
           Map(
             "admin1" -> ACLEntry(Set(permission1), Set.empty),
             "admin2" -> ACLEntry(Set(permission2), Set.empty)
@@ -107,7 +107,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
       val janusData = JanusData(
         Set.empty,
         access = ACL(Map.empty, Set.empty),
-        admin = ACL(Map.empty, Set.empty),
+        superuser = ACL(Map.empty, Set.empty),
         support = SupportACL
           .create(Map.empty, Set(permission)),
         None
@@ -135,7 +135,7 @@ class PermissionTest extends AnyFreeSpec with Matchers {
           ),
           Set.empty
         ),
-        admin = ACL(
+        superuser = ACL(
           Map(
             "admin1" -> ACLEntry(Set(permission3), Set.empty),
             "admin2" -> ACLEntry(Set(permission4), Set.empty)

--- a/test/logic/UserAccessTest.scala
+++ b/test/logic/UserAccessTest.scala
@@ -338,7 +338,8 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = ACL(Map.empty),
-        admin = ACL(Map(superuserOnlyUser -> ACLEntry(Set(fooDev), Set.empty))),
+        superuser =
+          ACL(Map(superuserOnlyUser -> ACLEntry(Set(fooDev), Set.empty))),
         support = SupportACL.create(Map.empty, Set.empty),
         permissionsRepo = None
       )
@@ -526,7 +527,8 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = ACL(Map(internalOnlyUser -> ACLEntry(Set(fooDev), Set.empty))),
-        admin = ACL(Map("superuser.user" -> ACLEntry(Set(barDev), Set.empty))),
+        superuser =
+          ACL(Map("superuser.user" -> ACLEntry(Set(barDev), Set.empty))),
         support = SupportACL.create(Map.empty, Set.empty),
         permissionsRepo = None
       )
@@ -611,7 +613,7 @@ class UserAccessTest
     val janusData = JanusData(
       accounts = Set.empty,
       access = acl,
-      admin = superuserAcl,
+      superuser = superuserAcl,
       support = supportAcl,
       permissionsRepo = None
     )
@@ -680,7 +682,7 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = ACL(Map("internal.user" -> ACLEntry(Set.empty, Set(grant)))),
-        admin = ACL(Map.empty),
+        superuser = ACL(Map.empty),
         support = SupportACL.create(Map.empty, Set.empty),
         permissionsRepo = None
       )
@@ -736,7 +738,8 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = ACL(Map.empty),
-        admin = ACL(Map("superuser.user" -> ACLEntry(Set.empty, Set(grant)))),
+        superuser =
+          ACL(Map("superuser.user" -> ACLEntry(Set.empty, Set(grant)))),
         support = SupportACL.create(Map.empty, Set.empty),
         permissionsRepo = None
       )
@@ -794,7 +797,7 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = internalAcl,
-        admin = superuserAcl,
+        superuser = superuserAcl,
         support = supportAcl,
         permissionsRepo = None
       )
@@ -841,7 +844,7 @@ class UserAccessTest
       val janusData = JanusData(
         accounts = Set.empty,
         access = internalAcl,
-        admin = ACL(Map.empty),
+        superuser = ACL(Map.empty),
         support = SupportACL.create(Map.empty, Set.empty),
         permissionsRepo = None
       )


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer**: AI was used to significantly generate all the stacked PRs associated with this change. I've manually reviewed all the work and taken time to edit and curate the AI's output (both code and text), but this work has primarily been done by Opus 5 via the GitHub Copilot CLI.

Switches the writer to the new key and renames the field.

- `JanusData.admin` becomes `JanusData.superuser`
- The Twirl template emits a `superuser { ... }` block
- App usages and `configTools` tests are updated
- `example.conf` uses the new key; the legacy-key tests from #932 now inject the old key programmatically

> [!IMPORTANT]
> **Breaking change.** This changes both the `configTools` API and the generated config file format, and needs a major release (13.0.0) before the config repo can adopt it.

Reading is unaffected: #932 is already merged by this point, so the loader accepts both keys.

Note: This repo's `example/` project stays pinned to 11.0.0 here. It will be updated in a subsequent PR, once 13.0.0 is published.


---

Part of #937, which tracks the whole migration including the releases,
deploys and verification steps between these PRs.

1. app: rename estate-wide concept to superuser (#930)
1. app: rename `AccessSource.Admin` to `Superuser` (#931)
1. configTools: read both `superuser` and legacy `admin` keys (#932)
1. guardian/janus and other consumers: bump to 12.0.0
1. configTools: write `superuser`, rename `JanusData.admin` (#933)  ← **you are here**
1. example project pinned to 13.0.0 (#934) — CI red until 13.0.0 ships
1. guardian/janus and other consumers: bump to 13.0.0
1. configTools: remove legacy `admin` read support (#935)
1. guardian/janus and other consumers: bump to 14.0.0
