### PR TITLE
Update the example project for janus-config-tools 13.0.0

### DIFF
--- a/example/build.sbt
+++ b/example/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "example",
     libraryDependencies ++= Seq(
-      "com.gu" %% "janus-config-tools" % "11.0.0",
+      "com.gu" %% "janus-config-tools" % "13.0.0",
       "org.scalatest" %% "scalatest" % "3.2.20" % Test
     )
   )

--- a/example/src/main/scala/com/example/Data.scala
+++ b/example/src/main/scala/com/example/Data.scala
@@ -6,7 +6,7 @@ object Data {
   val janusData = JanusData(
     accounts = Accounts.allAccounts,
     access = Access.acl,
-    admin = Superuser.acl,
+    superuser = Superuser.acl,
     support = Support.acl,
     permissionsRepo = None
   )

--- a/example/src/test/scala/com/example/DataTest.scala
+++ b/example/src/test/scala/com/example/DataTest.scala
@@ -38,7 +38,7 @@ class DataTest extends AnyFreeSpec with Matchers {
     janusData.support.supportAccess shouldEqual reloadedJanusData.support.supportAccess
     janusData.support.rota shouldEqual reloadedJanusData.support.rota
 
-    janusData.admin shouldEqual reloadedJanusData.admin
+    janusData.superuser shouldEqual reloadedJanusData.superuser
 
     file.delete()
   }


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer**: AI was used to significantly generate all the stacked PRs associated with this change. I've manually reviewed all the work and taken time to edit and curate the AI's output (both code and text), but this work has primarily been done by Opus 5 via the GitHub Copilot CLI.

Updates the example project for `janus-config-tools` 13.0.0.

- Bumps the pinned dependency from 11.0.0 to 13.0.0
- `Data.scala` uses `superuser = Superuser.acl`
- `DataTest` round-trips `janusData.superuser`

> [!WARNING]
> **CI on this PR will fail, and that is expected.** The example project resolves the published artifact rather than the in-repo module, so it cannot compile against the renamed API until 13.0.0 is on Maven Central. The same applies locally, so the diff is the only thing to review for now.
>
> **Do not merge until 13.0.0 is published.** That means #933 merged and the Release workflow run. Once the artifact is available, re-run CI here and it should go green.

---

Part of #937, which tracks the whole migration including the releases,
deploys and verification steps between these PRs.

1. app: rename estate-wide concept to superuser (#930)
1. app: rename `AccessSource.Admin` to `Superuser` (#931)
1. configTools: read both `superuser` and legacy `admin` keys (#932)
1. guardian/janus and other consumers: bump to 12.0.0
1. configTools: write `superuser`, rename `JanusData.admin` (#933)
1. example project pinned to 13.0.0 (#934) — CI red until 13.0.0 ships  ← **you are here**
1. guardian/janus and other consumers: bump to 13.0.0
1. configTools: remove legacy `admin` read support (#935)
1. guardian/janus and other consumers: bump to 14.0.0
