### PR TITLE
configTools: remove legacy admin key read support

### DIFF
--- a/configTools/src/main/scala/com/gu/janus/config/Loader.scala
+++ b/configTools/src/main/scala/com/gu/janus/config/Loader.scala
@@ -14,7 +14,6 @@ import scala.util.Try
   */
 object Loader {
   private val superuserPath = "janus.superuser"
-  private val legacySuperuserPath = "janus.admin"
 
   def fromConfig(config: Config): Either[String, JanusData] = {
     for {
@@ -117,26 +116,20 @@ object Loader {
     } yield ACL(acl.toMap, defaultAccess.toSet)
   }
 
-  /** Loads the estate-wide superuser ACL.
+  /** Loads the estate-wide superuser ACL from the `janus.superuser` key.
     *
-    * This access was previously called "admin", and config files using the
-    * legacy `janus.admin` key are still supported. `janus.superuser` is used
-    * when both keys are present.
+    * This access was previously called "admin".
     */
   private[config] def loadSuperuser(
       config: Config,
       permissions: Set[Permission]
   ): Either[String, ACL] = {
-    val path =
-      if (config.hasPath(superuserPath)) superuserPath
-      else if (config.hasPath(legacySuperuserPath)) legacySuperuserPath
-      else superuserPath
     for {
       configuredAccess <- config
-        .as[ConfiguredSuperuser](path)
+        .as[ConfiguredSuperuser](superuserPath)
         .left
         .map(err =>
-          s"Failed to load superuser config from path `$path`: ${err.getMessage}"
+          s"Failed to load superuser config from path `$superuserPath`: ${err.getMessage}"
         )
       acl <- parseAclEntries(configuredAccess.acl, permissions)
     } yield ACL(

--- a/configTools/src/test/resources/example-without-permissions-repo.conf
+++ b/configTools/src/test/resources/example-without-permissions-repo.conf
@@ -53,7 +53,7 @@ janus {
     }
   }
 
-  admin {
+  superuser {
     acl {
       employee1 = [
         { account = "website", label = "admin" }

--- a/configTools/src/test/resources/invalid.conf
+++ b/configTools/src/test/resources/invalid.conf
@@ -33,7 +33,7 @@ janus {
     }
   }
 
-  admin { }
+  superuser { }
 
   permissions = [ ]
 }

--- a/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
+++ b/configTools/src/test/scala/com/gu/janus/config/LoaderTest.scala
@@ -32,20 +32,6 @@ class LoaderTest
       // TODO: check the data here as well
       janusData.permissionsRepo shouldEqual None
     }
-
-    "parses an example that uses the legacy admin key" in {
-      val config = ConfigFactory
-        .parseString(
-          """janus.admin.acl {
-            |  employee2 = [
-            |    { account = "website", label = "s3-manager" }
-            |  ]
-            |}""".stripMargin
-        )
-        .withFallback(testConfig.withoutPath("janus.superuser"))
-      val janusData = Loader.fromConfig(config).value
-      janusData.superuser.userAccess.keySet shouldEqual Set("employee2")
-    }
   }
 
   "loadPermissionsRepo" - {
@@ -187,13 +173,6 @@ class LoaderTest
   }
 
   "loadSuperuser" - {
-    val legacyBlock = ConfigFactory.parseString(
-      """janus.admin.acl {
-        |  employee2 = [
-        |    { account = "website", label = "s3-manager" }
-        |  ]
-        |}""".stripMargin
-    )
     val withoutSuperuserKey = testConfig.withoutPath("janus.superuser")
 
     def superuserAclFor(config: Config) = {
@@ -212,23 +191,7 @@ class LoaderTest
       )
     }
 
-    "loads a legacy admin definition" in {
-      val config = legacyBlock.withFallback(withoutSuperuserKey)
-      superuserAclFor(config).userAccess
-        .get("employee2")
-        .value
-        .permissions
-        .map(_.id) shouldEqual Set(
-        "website-s3-manager"
-      )
-    }
-
-    "prefers the superuser key when both keys are present" in {
-      val config = legacyBlock.withFallback(testConfig)
-      superuserAclFor(config).userAccess.keySet shouldEqual Set("employee1")
-    }
-
-    "fails when neither key is present" in {
+    "fails when the superuser key is absent" in {
       val accounts = Loader.loadAccounts(withoutSuperuserKey).value
       val permissions =
         Loader.loadPermissions(withoutSuperuserKey, accounts).value


### PR DESCRIPTION
> [!NOTE]
> **Disclaimer**: AI was used to significantly generate all the stacked PRs associated with this change. I've manually reviewed all the work and taken time to edit and curate the AI's output (both code and text), but this work has primarily been done by Opus 5 via the GitHub Copilot CLI.

Removes the legacy `janus.admin` fallback, so the loader accepts only `janus.superuser`.

- The fallback is dropped from `Loader.loadSuperuser`
- The legacy-key tests are removed
- The remaining test resources move to the new key

> [!IMPORTANT]
> **Breaking change.** This removes support for the old config file format and needs a major release (14.0.0).

> [!WARNING]
> **Blocked on sequencing.** CI here is green and the change is fully tested locally, but it must not merge until:
> - the config repo is generating the new format in production, and it has been stable for a while
> - developers have refreshed their local `janus.local.conf` with the `superuser` key
>
> After this, an old local config will fail to load.


---

Part of #937, which tracks the whole migration including the releases,
deploys and verification steps between these PRs.

1. app: rename estate-wide concept to superuser (#930)
1. app: rename `AccessSource.Admin` to `Superuser` (#931)
1. configTools: read both `superuser` and legacy `admin` keys (#932)
1. guardian/janus and other consumers: bump to 12.0.0
1. configTools: write `superuser`, rename `JanusData.admin` (#933)
1. example project pinned to 13.0.0 (#934) — CI red until 13.0.0 ships
1. guardian/janus and other consumers: bump to 13.0.0
1. configTools: remove legacy `admin` read support (#935)  ← **you are here**
1. guardian/janus and other consumers: bump to 14.0.0
