### PR TITLE
Prevent the dependency-review workflow from blocking PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,4 @@ jobs:
       
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          fail-on-severity: high
           comment-summary-in-pr: always


### PR DESCRIPTION


<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?
We've been seeing PRs that do not touch dependencies be blocked by security alerts. Let's make sure this status check isn't required, while keeping the information it provides to both the PR and dependency graph.


