### PR TITLE
Fetch Janus Data from local setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,6 +31,14 @@ else
   echo "janus-service-account-cert.json is present"
 fi
 
+if [[ ! -f ~/.gu/janus-app/janusData.conf ]]; then
+   aws --region eu-west-1 s3 cp s3://security-dist/security/DEV/janus/janusData.conf \
+       ~/.gu/janus-app \
+       --profile security
+else
+  echo "janusData.conf is present"
+fi
+
 # Need AWS profile 'janus' to test access to dev-playground account.
 # See Readme.md 'Janus AWS Profile' section.
 aws --profile security --region eu-west-1 ssm get-parameter \
@@ -46,11 +54,3 @@ sleep 2
 
 # Create tables - will fail if they exist, but can be run manually with "destroy" or "recreate"
 sbt "setup / run create"
-
-if [[ ! -f ~/.gu/janus-app/janusData.conf ]]; then
-   echo "!!! You need to copy in a janusData.conf file at ~/.gu/janus-app/janusData.conf"
-   exit 1
-else
-  echo "janusData.conf is present"
-fi
-


### PR DESCRIPTION
A DEV version of the janus data is now fetched by the setup script. This makes it easy for a new engineer to fetch a valid janus data file, and also allows us to more easily share changes if the data config format changes.

Uses the same pattern as the other configuration files and moves it aboe the DB code, which fails if the DB is already set up.

This DEV access file needs to be kept up to date, but the config format changes rarely so that's not a huge concern. There are other ways to fetch an up to date valid config file, and engineers can continue to use those as needed.

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->
