### PR TITLE
Add CSV export option to the account audit trail

### DIFF
--- a/app/aws/AuditTrailDB.scala
+++ b/app/aws/AuditTrailDB.scala
@@ -90,8 +90,8 @@ object AuditTrailDB {
       dynamoDB: DynamoDbClient,
       request: QueryRequest
   ): Seq[Either[String, AuditLog]] = {
-    val result = dynamoDB.query(request)
-    result
+    dynamoDB
+      .queryPaginator(request)
       .items()
       .asScala
       .map(attrs => auditLogFromAttrs(attrs.asScala.toMap))

--- a/app/controllers/Audit.scala
+++ b/app/controllers/Audit.scala
@@ -3,7 +3,7 @@ package controllers
 import aws.AuditTrailDB
 import com.gu.googleauth.AuthAction
 import com.gu.janus.model.JanusData
-import logic.Date
+import logic.{AuditTrail, Date}
 import play.api.mvc.{
   AbstractController,
   Action,
@@ -12,6 +12,8 @@ import play.api.mvc.{
 }
 import play.api.{Logging, Mode}
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+
+import java.time.{Duration, Instant}
 
 class Audit(
     janusData: JanusData,
@@ -40,6 +42,32 @@ class Audit(
           janusData
         )
       )
+  }
+
+  /** Export the last 6 months as a CSV file
+    *
+    * This supports use cases like figuring out who still needs account access.
+    */
+  def exportByAccount(account: String): Action[AnyContent] = authAction {
+    implicit request =>
+      val endDate = Instant.now()
+      val startDate = endDate.minus(Duration.ofDays(180))
+      logger.info(s"Exporting logs for $account from $startDate to $endDate")
+      val (failures, auditLogs) = AuditTrailDB
+        .getAccountLogs(account, startDate, endDate)
+        .partitionMap(identity)
+      if (failures.nonEmpty) {
+        logger.warn(
+          s"Omitting ${failures.size} unreadable log entries from the CSV export for $account"
+        )
+      }
+      val csvContent = AuditTrail.auditLogsAsCsv(auditLogs)
+      Ok(csvContent)
+        .as("text/csv")
+        .withHeaders(
+          CONTENT_DISPOSITION -> s"""attachment; filename="janus-audit-$account-${Date
+              .rawDate(endDate)}.csv""""
+        )
   }
 
   def byUser(username: String): Action[AnyContent] = authAction {

--- a/app/logic/AuditTrail.scala
+++ b/app/logic/AuditTrail.scala
@@ -111,6 +111,37 @@ object AuditTrail extends Logging {
       permissionType
     )
 
+  def auditLogsAsCsv(auditLogs: Seq[AuditLog]): String = {
+    auditLogs
+      .map(auditLogAsCsvRow)
+      .mkString(s"$auditLogCsvHeader\n", "\n", "\n")
+  }
+
+  private val auditLogCsvHeader: String =
+    "timestamp,username,account,access-level,access-type,duration-seconds,is-external,permission-type"
+
+  private def auditLogAsCsvRow(auditLog: AuditLog): String = {
+    Seq(
+      Date.isoDateString(auditLog.instant),
+      auditLog.username,
+      auditLog.account,
+      auditLog.accessLevel,
+      auditLog.accessType.toString,
+      auditLog.duration.toSeconds.toString,
+      auditLog.external.toString,
+      auditLog.permissionType.serialised
+    ).map(csvField).mkString(",")
+  }
+
+  /** Quotes a field if it contains a character that would otherwise break the
+    * row, doubling any quotes it already contains.
+    */
+  private def csvField(value: String): String = {
+    if (value.exists(c => c == ',' || c == '"' || c == '\n' || c == '\r'))
+      "\"" + value.replace("\"", "\"\"") + "\""
+    else value
+  }
+
   /** Extract nice error message from db conversion.
     */
   def errorStrings(

--- a/app/views/audit.scala.html
+++ b/app/views/audit.scala.html
@@ -15,6 +15,11 @@
             <h1 class="header orange-text">Audit trail</h1>
 
             <p>
+                @key.toOption.map { account =>
+                    <a href="@routes.Audit.exportByAccount(account)" class="right grey-text text-darken-1">
+                        <i class="material-icons tiny">file_download</i> Export last 6 months (CSV)
+                    </a>
+                }
                 For <b>@key.fold(s => s, s => s)</b>, week commencing Monday @formatDate(startDate).
             </p>
 

--- a/conf/routes
+++ b/conf/routes
@@ -23,6 +23,7 @@ GET           /audit/user/:username                     controllers.Audit.byUser
 POST          /audit/user/:username                     controllers.Audit.changeUserDate(username: String)
 GET           /audit/account/:account                   controllers.Audit.byAccount(account: String)
 POST          /audit/account/:account                   controllers.Audit.changeAccountDate(account: String)
+GET           /audit/account-export/:account            controllers.Audit.exportByAccount(account: String)
 
 GET           /revoke                                   controllers.RevokePermissions.revoke
 GET           /revoke-request                           controllers.RevokePermissions.revokeRequest(accountId: String)

--- a/test/logic/AuditTrailTest.scala
+++ b/test/logic/AuditTrailTest.scala
@@ -174,4 +174,62 @@ class AuditTrailTest
       }
     }
   }
+
+  "auditLogsAsCsv" - {
+    def auditLog(
+        account: String = "account",
+        username: String = "username",
+        accessLevel: String = "accessLevel"
+    ) = AuditLog(
+      account,
+      username,
+      ZonedDateTime.of(2015, 11, 4, 15, 22, 0, 0, UTC).toInstant,
+      Duration.ofHours(1),
+      accessLevel,
+      JCredentials,
+      external = true,
+      AccountPermission
+    )
+
+    "starts with a header row" in {
+      val lines = AuditTrail.auditLogsAsCsv(Nil).linesIterator.toList
+      lines.head shouldEqual "timestamp,username,account,access-level,access-type,duration-seconds,is-external,permission-type"
+    }
+
+    "writes a row per audit log" in {
+      val csv =
+        AuditTrail.auditLogsAsCsv(Seq(auditLog(), auditLog(username = "other")))
+      csv.linesIterator.size shouldEqual 3
+    }
+
+    "gives each row the same number of fields as the header" in {
+      val lines =
+        AuditTrail.auditLogsAsCsv(Seq(auditLog())).linesIterator.toList
+      lines(1).split(",").length shouldEqual lines.head.split(",").length
+    }
+
+    "writes the fields in header order" in {
+      val lines =
+        AuditTrail.auditLogsAsCsv(Seq(auditLog())).linesIterator.toList
+      lines(
+        1
+      ) shouldEqual "2015-11-04T15:22:00Z,username,account,accessLevel,credentials,3600,true,account-permission"
+    }
+
+    "quotes a field containing a comma" in {
+      val lines = AuditTrail
+        .auditLogsAsCsv(Seq(auditLog(accessLevel = "dev,ops")))
+        .linesIterator
+        .toList
+      lines(1) should include("\"dev,ops\"")
+    }
+
+    "doubles quotes within a quoted field" in {
+      val lines = AuditTrail
+        .auditLogsAsCsv(Seq(auditLog(accessLevel = "the \"best\", really")))
+        .linesIterator
+        .toList
+      lines(1) should include("\"the \"\"best\"\", really\"")
+    }
+  }
 }


### PR DESCRIPTION
This allows teams to review historic access to see who still needs access.

Just a conversation starter, let's talk to the EMs as well. In particular, is 6 months right, would three months be better? Does this need to be configurable? I've assumed we don't need this for individuals, is that right?

Lots of questions, but this PR was easy to create as a starting point.

### How it looks
<img width="866" height="442" alt="Screenshot 2026-08-03 at 16 54 07" src="https://github.com/user-attachments/assets/9de9cecb-8a4b-4e87-bcad-c13754ac25ee" />

### How the export gets imported
<img width="1012" height="114" alt="Screenshot 2026-08-03 at 16 56 54" src="https://github.com/user-attachments/assets/936e51c9-2aa6-418a-a28c-740674797faa" />


