### PR TITLE
Force a major version bump in the janus-config-tools library

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "13.0.2-SNAPSHOT"
+ThisBuild / version := "14.0.0-SNAPSHOT"


### PR DESCRIPTION
The automation in the previous release incorrectly issued that change as a "patch". It should have been a major version change.

This PR forces a major version bump of janus-config-tools by manually setting the snapshot to the next major version.

Thanks @rtyley for the pointer.

<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

