### PR TITLE
Upgrade AWS SDK to 2.52.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 ThisBuild / organization := "com.gu"
 ThisBuild / licenses := Seq(License.Apache2)
 
-val awsSdkVersion = "2.48.3"
+val awsSdkVersion = "2.52.0"
 val circeVersion = "0.14.16"
 val commonDependencies = Seq(
   "org.typelevel" %% "cats-core" % "2.13.0",


### PR DESCRIPTION
<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

Upgrade to AWS SDK so that only dependencies on Netty are version 4.1.137.Final, resolving several vulnerability warnings.


## What is the value of this change and how do we measure success?


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->


## Any additional notes?

