### PR TITLE
Use shared banner fragments on the superuser page

### DIFF
--- a/app/views/superuser.scala.html
+++ b/app/views/superuser.scala.html
@@ -1,11 +1,32 @@
 @import com.gu.googleauth.UserIdentity
 @import com.gu.janus.model.JanusData
+@import logic.ViewHelpers.BannerLevel
 @import models.{AwsAccountAccess, DeveloperPolicyCacheStatus}
 @import play.api.Mode
 
 @(accountAccesses: List[AwsAccountAccess], cacheStatus: DeveloperPolicyCacheStatus, user: UserIdentity, janusData: JanusData)(implicit req: RequestHeader, mode: Mode, assetsFinder: AssetsFinder)
 
 @main("Superuser", Some(user), janusData) {
+    @cacheStatus match {
+        case DeveloperPolicyCacheStatus.Failure => {
+            @fragments.bannerCta("Developer policy status", BannerLevel.Error) {
+                Developer policy failures detected - this may mean some permissions are not showing.
+            } {
+                <a href="@routes.AccountsController.accountDeveloperPolicies">status page</a>
+            }
+        }
+        case DeveloperPolicyCacheStatus.Empty => {
+            @fragments.banner("Developer policy status", BannerLevel.Warn) {
+                Developer policy cache is empty - this may mean some permissions are not showing. Try refreshing in a few moments.
+            }
+        }
+        case DeveloperPolicyCacheStatus.Disabled => {
+            @fragments.banner("Developer policy status", BannerLevel.Error) {
+                The developer policy service is disabled - this may mean some permissions are not showing. Please contact DevX Security for further information.
+            }
+        }
+        case DeveloperPolicyCacheStatus.Success => {}
+    }
     <div class="container">
         <div class="row">
             <div class="col s12">
@@ -20,27 +41,6 @@
                     </span>
                 </div>
             </div>
-        </div>
-
-        <div role="region" aria-label="Developer policy status">
-            @cacheStatus match {
-                case DeveloperPolicyCacheStatus.Failure => {
-                    <div class="cache-status card-panel red lighten-4" role="status" aria-atomic="true">
-                        Developer policy failures detected - this may mean some permissions are not showing. Visit the <a href="@routes.AccountsController.accountDeveloperPolicies">policies status page</a> for more information.
-                    </div>
-                }
-                case DeveloperPolicyCacheStatus.Empty => {
-                    <div class="cache-status card-panel yellow lighten-4" role="status" aria-atomic="true">
-                        Developer policy cache is empty - this may mean some permissions are not showing. Try refreshing in a few moments.
-                    </div>
-                }
-                case DeveloperPolicyCacheStatus.Disabled => {
-                    <div class="cache-status card-panel red lighten-4" role="status" aria-atomic="true">
-                        The developer policy service is disabled - this may mean some permissions are not showing. Please contact DevX Security for further information.
-                    </div>
-                }
-                case DeveloperPolicyCacheStatus.Success => {}
-            }
         </div>
 
         <div class="superuser-accounts-container">


### PR DESCRIPTION
## What is the purpose of this change?

The developer policy cache status messages on the superuser page used hand-written `card-panel` markup, so the same warnings looked different depending on whether you were on the index page or the superuser page.

This switches the superuser page over to the shared `banner` / `bannerCta` fragments, and moves the status block above the container so it renders full width at the top of the page, as it does on index.

All three states are converted:

| State | Before | After |
| --- | --- | --- |
| `Failure` | `card-panel red lighten-4` | `bannerCta(BannerLevel.Error)`, status page link moved into the CTA slot |
| `Empty` | `card-panel yellow lighten-4` | `banner(BannerLevel.Warn)` |
| `Disabled` | `card-panel red lighten-4` | `banner(BannerLevel.Error)` |

## What is the value of this change and how do we measure success?

The same message now looks the same wherever it appears, so the styling is one thing to maintain rather than two. The hand-written `role="region"` wrapper is also gone, since the fragment emits it along with `role="status"` and `aria-atomic`.

## Images

<!-- Screenshots to follow after manual verification. -->

## Any additional notes?

Only `superuser.scala.html` changes. No CSS was needed: the `main-banner` styles already exist, and the `cache-status` class had no rule of its own and now appears nowhere in the repo.

The superuser-specific wording ("some permissions" rather than "you have permissions") is kept. The `Failure` sentence loses its trailing "Visit the ... for more information" because the link becomes a CTA button.