### PR TITLE
Close modal before destroying, to make sure page is interactable afterwards

### DIFF
--- a/frontend/utils/modalUtils.js
+++ b/frontend/utils/modalUtils.js
@@ -388,8 +388,8 @@ export function showConfirmationModal(
     const cleanup = () => {
       confirmButton.removeEventListener("click", handleConfirm);
       cancelButton.removeEventListener("click", handleCancel);
+      modalInstance.close();
       modalInstance.destroy();
-      modalElement.remove();
     };
 
     // Initialize modal


### PR DESCRIPTION


<!-- 
Hello and thank you for contributing! 
Please note that it may not be possible for us to accept all pull requests. Janus has been developed to meet the security and workflow requirements of Guardian Digital, therefore we may be hesitant to significantly expand or alter the remit of this application.
-->

## What is the purpose of this change?

I noticed that after one of the passkey modals has opened, the page is no longer scrollable, even after the page closes. This seems to be because we `destroy()` the modal instance without `close()`ing the modal first, which seems to mean that it won't clean up any changes it had made to the DOM, including setting the body style to `overflow: hidden`. 

Fix by making sure to close the modal before destroying its instance. Bonus points: once we do this we appear not to need to explicitly remove the modal DOM element from the page.

## What is the value of this change and how do we measure success?


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
<!-- Remember to redact any secret or private information! -->


## Any additional notes?

